### PR TITLE
feat(scanner): pHash-based deduplication scanner engine

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,6 @@ pywin32>=306; platform_system == "Windows"
 Pillow>=10.0
 pillow-heif>=0.15
 rawpy>=0.19 ; platform_system != "Windows" or python_version >= "3.9"
+# Deduplication scanner
+imagehash>=4.3
+tqdm>=4.66

--- a/scan.py
+++ b/scan.py
@@ -1,0 +1,136 @@
+"""scan.py — Deduplication scanner CLI.
+
+Walks 3 source directories, computes SHA-256 + pHash for every media file,
+detects exact duplicates, cross-format duplicates, and near-duplicates, then
+writes a non-destructive migration_manifest.sqlite for human review.
+
+Usage examples:
+  # Full scan
+  python scan.py \\
+    --source iphone="\\\\LinXiaoYun\\home\\Photos\\MobileBackup\\iPhone" \\
+    --source takeout="D:\\Downloads\\Takeout\\Google 相簿" \\
+    --source jdrive="J:\\圖片" \\
+    --output migration_manifest.sqlite
+
+  # Summary only, no DB written
+  python scan.py --source ... --dry-run
+
+  # Tighter near-duplicate threshold
+  python scan.py --source ... --similarity-threshold 6
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+try:
+    from tqdm import tqdm
+    _TQDM = True
+except ImportError:
+    _TQDM = False
+
+
+def _parse_source(value: str) -> tuple[str, Path]:
+    """Parse 'label=path' into (label, Path)."""
+    if "=" not in value:
+        raise argparse.ArgumentTypeError(
+            f"--source must be in 'label=path' format, got: {value!r}"
+        )
+    label, _, raw_path = value.partition("=")
+    return label.strip(), Path(raw_path.strip())
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Non-destructive deduplication scan → migration_manifest.sqlite"
+    )
+    parser.add_argument(
+        "--source",
+        action="append",
+        metavar="LABEL=PATH",
+        required=True,
+        help="Source to scan, e.g. iphone='\\\\NAS\\Photos\\MobileBackup\\iPhone' (repeatable)",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("migration_manifest.sqlite"),
+        help="Output SQLite path (default: migration_manifest.sqlite)",
+    )
+    parser.add_argument(
+        "--similarity-threshold",
+        type=int,
+        default=10,
+        dest="threshold",
+        help="pHash hamming distance for REVIEW_DUPLICATE (default: 10)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print summary only; do not write the manifest file",
+    )
+    args = parser.parse_args()
+
+    sources: dict[str, Path] = {}
+    for raw in args.source:
+        label, path = _parse_source(raw)
+        sources[label] = path
+
+    # --- Import scanner modules (deferred so --help works without dependencies) ---
+    from scanner.walker import scan_sources
+    from scanner.hasher import compute_sha256, compute_phash
+    from scanner.exif import ExiftoolProcess, batch_read_dates
+    from scanner.dedup import HashResult, classify
+    from scanner.manifest import write_manifest, print_summary
+
+    print(f"Scanning {len(sources)} source(s)…")
+    records = scan_sources(sources)
+    print(f"  Found {len(records):,} media files")
+
+    print("Computing hashes…")
+    hash_results: list[HashResult] = []
+
+    # Batch EXIF date extraction via exiftool
+    print("Reading EXIF dates (exiftool)…")
+    all_paths = [r.path for r in records]
+    try:
+        with ExiftoolProcess() as et:
+            dates = batch_read_dates(all_paths, et)
+    except FileNotFoundError:
+        print(
+            "WARNING: exiftool not found on PATH — EXIF dates unavailable.\n"
+            "Install from https://exiftool.org/ and ensure it is in your PATH.",
+            file=sys.stderr,
+        )
+        dates = {p: None for p in all_paths}
+
+    # Compute SHA-256 + pHash
+    iterable = tqdm(records, desc="Hashing", unit="file") if _TQDM else records
+    for record in iterable:
+        sha256 = compute_sha256(record.path)
+        phash = compute_phash(record.path, record.file_type)
+        hash_results.append(HashResult(
+            record=record,
+            sha256=sha256,
+            phash=phash,
+            exif_date=dates.get(record.path),
+        ))
+
+    print("Classifying…")
+    rows = classify(hash_results, threshold=args.threshold)
+
+    print_summary(rows)
+
+    if args.dry_run:
+        print("--dry-run: manifest not written.")
+        return 0
+
+    write_manifest(rows, args.output)
+    print(f"Manifest written to: {args.output}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scanner/__init__.py
+++ b/scanner/__init__.py
@@ -1,0 +1,1 @@
+"""Standalone deduplication scanner — no Qt dependency."""

--- a/scanner/dedup.py
+++ b/scanner/dedup.py
@@ -1,0 +1,279 @@
+"""Classify files as KEEP/MOVE/SKIP/REVIEW_DUPLICATE/UNDATED.
+
+Classification rules:
+  SHA-256 match                          → SKIP (EXACT_DUPLICATE)
+  pHash hamming == 0, both lossy         → SKIP lower priority (FORMAT_DUPLICATE)
+  pHash hamming == 0, one RAW + lossy    → MOVE both (complementary)
+  pHash hamming 1–threshold              → REVIEW_DUPLICATE
+  no EXIF date                           → UNDATED
+  otherwise                              → MOVE (or KEEP for iphone source)
+
+Source priority: iphone > takeout > jdrive
+Format priority (lossy only): heic > jpeg > png > others
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+try:
+    import imagehash
+    _IMAGEHASH_AVAILABLE = True
+except ImportError:
+    _IMAGEHASH_AVAILABLE = False
+
+from scanner.media import RAW_EXTENSIONS
+from scanner.walker import FileRecord
+
+# ---------------------------------------------------------------------------
+# Priority tables
+# ---------------------------------------------------------------------------
+
+SOURCE_PRIORITY = {"iphone": 0, "takeout": 1, "jdrive": 2}
+
+FORMAT_PRIORITY = {"heic": 0, "jpeg": 1, "png": 2, "gif": 3, "webp": 4, "raw": -1}
+# raw is intentionally -1 (not comparable with lossy — RAW+lossy always co-exist)
+
+LOSSY_TYPES = {"jpeg", "heic", "png", "gif", "webp"}
+
+# ---------------------------------------------------------------------------
+# Data structures
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class HashResult:
+    """A FileRecord augmented with computed hashes and EXIF date."""
+
+    record: FileRecord
+    sha256: str
+    phash: Optional[str]       # None for video or hash failure
+    exif_date: Optional[datetime]
+
+
+@dataclass
+class ManifestRow:
+    """One row destined for migration_manifest.sqlite."""
+
+    source_path: str
+    source_label: str
+    dest_path: Optional[str]   # relative path under dest root; None if SKIP/UNDATED
+    action: str                # KEEP | MOVE | SKIP | REVIEW_DUPLICATE | UNDATED
+    source_hash: str
+    phash: Optional[str]
+    hamming_distance: Optional[int]
+    duplicate_of: Optional[str]
+    reason: str
+
+
+# ---------------------------------------------------------------------------
+# Classification
+# ---------------------------------------------------------------------------
+
+
+def classify(records: list[HashResult], threshold: int = 10) -> list[ManifestRow]:
+    """Assign an action to every record and return ManifestRows.
+
+    iPhone files always receive KEEP (already in place; used as dedup reference).
+    """
+    rows: dict[Path, ManifestRow] = {}
+
+    # Pass 1: exact SHA-256 duplicates
+    _classify_exact(records, rows)
+
+    # Pass 2: pHash-based (cross-format + near-duplicate)
+    _classify_phash(records, rows, threshold)
+
+    # Pass 3: remaining unclassified files
+    for hr in records:
+        if hr.record.path in rows:
+            continue
+        if hr.record.source_label == "iphone":
+            rows[hr.record.path] = _make_row(hr, "KEEP", reason="iphone source — stays in place")
+        elif hr.exif_date is None:
+            rows[hr.record.path] = _make_row(hr, "UNDATED", reason="no EXIF DateTimeOriginal")
+        else:
+            rows[hr.record.path] = _make_row(
+                hr, "MOVE", reason="unique", dest=_dest_path(hr)
+            )
+
+    # Pass 4: propagate SKIP/KEEP to Live Photo MOV partners
+    _propagate_pairs(records, rows)
+
+    return list(rows.values())
+
+
+def _classify_exact(records: list[HashResult], rows: dict[Path, ManifestRow]) -> None:
+    """Group by SHA-256; mark lower-priority copies as SKIP."""
+    by_hash: dict[str, list[HashResult]] = {}
+    for hr in records:
+        by_hash.setdefault(hr.sha256, []).append(hr)
+
+    for group in by_hash.values():
+        if len(group) < 2:
+            continue
+        group.sort(key=lambda h: (SOURCE_PRIORITY.get(h.record.source_label, 99),))
+        keeper = group[0]
+        for duplicate in group[1:]:
+            rows[duplicate.record.path] = _make_row(
+                duplicate,
+                "SKIP",
+                duplicate_of=str(keeper.record.path),
+                reason=f"EXACT_DUPLICATE of {keeper.record.path.name}",
+            )
+
+
+def _classify_phash(
+    records: list[HashResult], rows: dict[Path, ManifestRow], threshold: int
+) -> None:
+    """Group by pHash; classify FORMAT_DUPLICATE and REVIEW_DUPLICATE."""
+    # Only consider records not already classified and with a valid pHash
+    candidates = [hr for hr in records if hr.phash and hr.record.path not in rows]
+
+    # Build pHash → records map (exact matches first)
+    by_phash: dict[str, list[HashResult]] = {}
+    for hr in candidates:
+        by_phash.setdefault(hr.phash, []).append(hr)
+
+    # Exact pHash match (hamming == 0) → FORMAT_DUPLICATE or complementary RAW+lossy
+    for group in by_phash.values():
+        if len(group) < 2:
+            continue
+        _classify_format_group(group, rows)
+
+    # Near-duplicate scan: compare all pairs with hamming distance ≤ threshold
+    # Use bucket approach: compare within pHash prefix buckets to limit O(n²)
+    _classify_near_duplicates(candidates, rows, threshold)
+
+
+def _classify_format_group(group: list[HashResult], rows: dict[Path, ManifestRow]) -> None:
+    """Within a pHash==0 group, apply RAW+lossy exception and format priority."""
+    has_raw = any(hr.record.file_type == "raw" for hr in group)
+    lossy = [hr for hr in group if hr.record.file_type in LOSSY_TYPES]
+
+    if has_raw and lossy:
+        # RAW + lossy: complementary — all MOVE, don't skip anything
+        return
+
+    if len(lossy) < 2:
+        return
+
+    # All lossy FORMAT_DUPLICATE: keep highest-format × highest-source-priority
+    lossy.sort(key=lambda h: (
+        FORMAT_PRIORITY.get(h.record.file_type, 99),
+        SOURCE_PRIORITY.get(h.record.source_label, 99),
+    ))
+    keeper = lossy[0]
+    for duplicate in lossy[1:]:
+        if duplicate.record.path in rows:
+            continue
+        rows[duplicate.record.path] = _make_row(
+            duplicate,
+            "SKIP",
+            duplicate_of=str(keeper.record.path),
+            hamming=0,
+            reason=f"FORMAT_DUPLICATE of {keeper.record.path.name} "
+                   f"({duplicate.record.file_type} vs {keeper.record.file_type})",
+        )
+
+
+def _classify_near_duplicates(
+    candidates: list[HashResult], rows: dict[Path, ManifestRow], threshold: int
+) -> None:
+    """Flag pHash pairs with hamming distance 1–threshold as REVIEW_DUPLICATE."""
+    if not _IMAGEHASH_AVAILABLE:
+        return
+
+    unclassified = [hr for hr in candidates if hr.record.path not in rows]
+    hashes = [(hr, imagehash.hex_to_hash(hr.phash)) for hr in unclassified if hr.phash]
+
+    for i, (hr_a, hash_a) in enumerate(hashes):
+        if hr_a.record.path in rows:
+            continue
+        for hr_b, hash_b in hashes[i + 1:]:
+            if hr_b.record.path in rows:
+                continue
+            distance = hash_a - hash_b
+            if 0 < distance <= threshold:
+                # Flag the lower-priority file as REVIEW_DUPLICATE
+                ordered = sorted(
+                    [hr_a, hr_b],
+                    key=lambda h: SOURCE_PRIORITY.get(h.record.source_label, 99),
+                )
+                flagged = ordered[1]
+                if flagged.record.path not in rows:
+                    rows[flagged.record.path] = _make_row(
+                        flagged,
+                        "REVIEW_DUPLICATE",
+                        duplicate_of=str(ordered[0].record.path),
+                        hamming=distance,
+                        reason=f"near-duplicate (hamming={distance}) of "
+                               f"{ordered[0].record.path.name}",
+                    )
+
+
+def _propagate_pairs(records: list[HashResult], rows: dict[Path, ManifestRow]) -> None:
+    """Propagate SKIP/KEEP actions to Live Photo MOV partners.
+
+    Always overrides the partner's existing action — the image file is authoritative
+    for the pair. If the image is SKIP, the MOV must also be SKIP even if it was
+    independently classified as MOVE.
+    """
+    path_to_hr = {hr.record.path: hr for hr in records}
+
+    for hr in records:
+        partner_path = hr.record.pair_partner
+        if partner_path is None:
+            continue
+        own_row = rows.get(hr.record.path)
+        if own_row is None:
+            continue
+        if own_row.action in ("SKIP", "KEEP"):
+            partner_hr = path_to_hr.get(partner_path)
+            if partner_hr:
+                rows[partner_path] = _make_row(
+                    partner_hr,
+                    own_row.action,
+                    duplicate_of=own_row.duplicate_of or str(hr.record.path),
+                    reason=f"Live Photo pair partner of {hr.record.path.name}",
+                )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_row(
+    hr: HashResult,
+    action: str,
+    reason: str = "",
+    duplicate_of: Optional[str] = None,
+    hamming: Optional[int] = None,
+    dest: Optional[str] = None,
+) -> ManifestRow:
+    return ManifestRow(
+        source_path=str(hr.record.path),
+        source_label=hr.record.source_label,
+        dest_path=dest,
+        action=action,
+        source_hash=hr.sha256,
+        phash=hr.phash,
+        hamming_distance=hamming,
+        duplicate_of=duplicate_of,
+        reason=reason,
+    )
+
+
+def _dest_path(hr: HashResult) -> Optional[str]:
+    """Compute relative destination path for a MOVE action."""
+    if hr.exif_date is None:
+        return None
+    year = hr.exif_date.strftime("%Y")
+    date_prefix = hr.exif_date.strftime("%Y%m%d")
+    label = hr.record.source_label
+    filename = hr.record.path.name
+    return f"{year}/{date_prefix}_{label}/{filename}"

--- a/scanner/exif.py
+++ b/scanner/exif.py
@@ -1,0 +1,102 @@
+"""Batch EXIF date extraction via exiftool's -stay_open mode."""
+
+from __future__ import annotations
+
+import subprocess
+from contextlib import contextmanager
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+
+class ExiftoolProcess:
+    """Persistent exiftool process for batch EXIF reads.
+
+    Uses -stay_open True for performance — avoids subprocess overhead per file.
+    Pattern from sync_takeout.py.
+    """
+
+    def __init__(self) -> None:
+        self.proc = subprocess.Popen(
+            ["exiftool", "-stay_open", "True", "-@", "-"],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            encoding="utf-8",
+            errors="replace",
+        )
+
+    def execute(self, args: list) -> str:
+        """Send args to exiftool, return output up to {ready} sentinel."""
+        cmd = "\n".join(str(a) for a in args) + "\n-execute\n"
+        self.proc.stdin.write(cmd)
+        self.proc.stdin.flush()
+        lines = []
+        while True:
+            line = self.proc.stdout.readline()
+            if not line:
+                break
+            stripped = line.rstrip("\n")
+            if stripped == "{ready}":
+                break
+            lines.append(stripped)
+        return "\n".join(lines)
+
+    def close(self) -> None:
+        try:
+            self.proc.stdin.write("-stay_open\nFalse\n")
+            self.proc.stdin.flush()
+            self.proc.wait(timeout=10)
+        except Exception:  # pylint: disable=broad-exception-caught
+            self.proc.kill()
+
+    def __enter__(self) -> "ExiftoolProcess":
+        return self
+
+    def __exit__(self, *_) -> None:
+        self.close()
+
+
+_EXIF_DATE_FMT = "%Y:%m:%d %H:%M:%S"
+_VALID_SENTINEL = "-"
+_ZERO_DATE = "0000:00:00 00:00:00"
+
+
+def _parse_exif_date(raw: str) -> Optional[datetime]:
+    raw = raw.strip()
+    if not raw or raw == _VALID_SENTINEL or raw.startswith(_ZERO_DATE[:4] + ":"):
+        return None
+    # Strip timezone suffix if present ("2024:06:01 12:00:00+09:00" → drop "+09:00")
+    raw = raw[:19]
+    try:
+        return datetime.strptime(raw, _EXIF_DATE_FMT)
+    except ValueError:
+        return None
+
+
+def batch_read_dates(paths: list[Path], et: ExiftoolProcess) -> dict[Path, Optional[datetime]]:
+    """Return {path: DateTimeOriginal} for all paths in one exiftool call.
+
+    Falls back to CreateDate / QuickTime:CreateDate when DateTimeOriginal is absent.
+    """
+    if not paths:
+        return {}
+
+    args = ["-DateTimeOriginal", "-CreateDate", "-QuickTime:CreateDate", "-s3", "-f"]
+    args += [str(p) for p in paths]
+    output = et.execute(args)
+
+    result: dict[Path, Optional[datetime]] = {}
+    lines = output.splitlines()
+    # exiftool -s3 outputs 3 lines per file (one per tag, in order)
+    for i, path in enumerate(paths):
+        base = i * 3
+        if base + 2 >= len(lines):
+            result[path] = None
+            continue
+        dt_orig = _parse_exif_date(lines[base])
+        create = _parse_exif_date(lines[base + 1])
+        qt_create = _parse_exif_date(lines[base + 2])
+        result[path] = dt_orig or create or qt_create
+
+    return result

--- a/scanner/hasher.py
+++ b/scanner/hasher.py
@@ -1,0 +1,93 @@
+"""SHA-256 and perceptual hash computation for all media formats."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+from pathlib import Path
+from typing import Optional
+
+try:
+    from PIL import Image
+    import imagehash
+    _HASH_AVAILABLE = True
+except ImportError:
+    _HASH_AVAILABLE = False
+
+try:
+    import rawpy
+    _RAWPY_AVAILABLE = True
+except ImportError:
+    _RAWPY_AVAILABLE = False
+
+try:
+    from pillow_heif import register_heif_opener
+    register_heif_opener()
+    _HEIF_AVAILABLE = True
+except ImportError:
+    _HEIF_AVAILABLE = False
+
+
+def compute_sha256(path: Path) -> str:
+    """Stream-compute SHA-256 of a file in 64 KB chunks."""
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(65536), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def compute_phash(path: Path, file_type: str) -> Optional[str]:
+    """Compute a 64-bit perceptual hash for image files.
+
+    Returns None for videos and on any loading failure.
+
+    RAW files: try embedded JPEG preview first (fast), fall back to full decode.
+    HEIC: requires pillow-heif registered (done at module import).
+    """
+    if not _HASH_AVAILABLE:
+        return None
+    if file_type in ("mp4", "mov", "gif", "skip"):
+        return None
+
+    img: Optional[Image.Image] = None
+    if file_type == "raw":
+        img = _load_raw_preview(path)
+    else:
+        try:
+            with Image.open(path) as pil_img:
+                img = pil_img.convert("RGB")
+                img.load()
+        except (OSError, ValueError):
+            return None
+
+    if img is None:
+        return None
+    try:
+        return str(imagehash.phash(img))
+    except (ValueError, TypeError):
+        return None
+
+
+def _load_raw_preview(path: Path) -> Optional[Image.Image]:
+    """Load a PIL Image from a RAW file's embedded JPEG thumbnail.
+
+    Falls back to full rawpy decode if no thumbnail is present.
+    """
+    if not _RAWPY_AVAILABLE:
+        return None
+    try:
+        with rawpy.imread(str(path)) as raw:
+            try:
+                thumb = raw.extract_thumb()
+                if thumb.format == rawpy.ThumbFormat.JPEG:
+                    img = Image.open(io.BytesIO(thumb.data)).convert("RGB")
+                    img.load()
+                    return img
+            except rawpy.LibRawNoThumbnailError:
+                pass
+            # Full decode fallback — slower but always works
+            rgb = raw.postprocess(use_auto_wb=True, output_bps=8)
+            return Image.fromarray(rgb).convert("RGB")
+    except (OSError, ValueError):
+        return None

--- a/scanner/manifest.py
+++ b/scanner/manifest.py
@@ -1,0 +1,80 @@
+"""Write and summarise the migration manifest SQLite database."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+from scanner.dedup import ManifestRow
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS migration_manifest (
+    id               INTEGER PRIMARY KEY,
+    source_path      TEXT    NOT NULL,
+    source_label     TEXT    NOT NULL,
+    dest_path        TEXT,
+    action           TEXT    NOT NULL,
+    source_hash      TEXT,
+    phash            TEXT,
+    hamming_distance INTEGER,
+    duplicate_of     TEXT,
+    reason           TEXT,
+    executed         INTEGER NOT NULL DEFAULT 0
+);
+CREATE INDEX IF NOT EXISTS idx_source_hash ON migration_manifest(source_hash);
+CREATE INDEX IF NOT EXISTS idx_phash       ON migration_manifest(phash);
+CREATE INDEX IF NOT EXISTS idx_action      ON migration_manifest(action);
+"""
+
+_INSERT = """
+INSERT INTO migration_manifest
+    (source_path, source_label, dest_path, action, source_hash,
+     phash, hamming_distance, duplicate_of, reason)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+"""
+
+
+def write_manifest(rows: list[ManifestRow], output: Path) -> None:
+    """Create (or overwrite) the SQLite manifest at output."""
+    output.parent.mkdir(parents=True, exist_ok=True)
+    if output.exists():
+        output.unlink()
+
+    with sqlite3.connect(output) as conn:
+        conn.executescript(_DDL)
+        conn.executemany(
+            _INSERT,
+            [
+                (
+                    r.source_path,
+                    r.source_label,
+                    r.dest_path,
+                    r.action,
+                    r.source_hash,
+                    r.phash,
+                    r.hamming_distance,
+                    r.duplicate_of,
+                    r.reason,
+                )
+                for r in rows
+            ],
+        )
+        conn.commit()
+
+
+def print_summary(rows: list[ManifestRow]) -> None:
+    """Print an action-count summary table to stdout."""
+    from collections import Counter
+    counts: Counter = Counter(r.action for r in rows)
+    total = len(rows)
+
+    print("\n── Migration Manifest Summary ──────────────────────")
+    print(f"  Total files scanned : {total:>7,}")
+    for action in ("KEEP", "MOVE", "SKIP", "REVIEW_DUPLICATE", "UNDATED"):
+        n = counts.get(action, 0)
+        pct = 100 * n / total if total else 0
+        print(f"  {action:<20}: {n:>7,}  ({pct:.1f}%)")
+    other = total - sum(counts[a] for a in ("KEEP", "MOVE", "SKIP", "REVIEW_DUPLICATE", "UNDATED"))
+    if other:
+        print(f"  {'other':<20}: {other:>7,}")
+    print("────────────────────────────────────────────────────\n")

--- a/scanner/media.py
+++ b/scanner/media.py
@@ -1,0 +1,150 @@
+"""Media type detection, filename parsing, and file-set constants.
+
+Ported from sync_takeout.py with extensions for additional RAW formats.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+MEDIA_EXTENSIONS = {
+    ".jpg", ".jpeg", ".heic", ".heif", ".png", ".gif", ".webp",
+    ".tif", ".tiff",
+    ".dng", ".cr2", ".cr3", ".nef", ".arw", ".raf", ".rw2",
+    ".mp4", ".mov", ".m4v", ".avi",
+}
+
+PHOTO_EXTENSIONS = MEDIA_EXTENSIONS - {".mp4", ".mov", ".m4v", ".avi"}
+VIDEO_EXTENSIONS = {".mp4", ".mov", ".m4v", ".avi"}
+RAW_EXTENSIONS = {".dng", ".cr2", ".cr3", ".nef", ".arw", ".raf", ".rw2"}
+LOSSY_EXTENSIONS = {".jpg", ".jpeg", ".heic", ".heif", ".png", ".gif", ".webp", ".tif", ".tiff"}
+
+SKIP_FILENAMES = {"thumbs.db", "desktop.ini", "failed_inserting_exif.txt", ".ds_store"}
+
+# Google Takeout: "IMG_9556(1).HEIC" → base="IMG_9556", number=1
+DUPE_RE = re.compile(r"^(.*)\((\d+)\)$")
+
+# Edited-photo suffixes to strip when matching Live Photo pairs
+EDITED_SUFFIXES = ["-已編輯", "(已編輯)", "-edited", "-Edit", "_edited", " edited"]
+
+# Order to try when finding a video's companion image JSON (Live Photo)
+COMPANION_PHOTO_EXTS = [".HEIC", ".heic", ".JPG", ".jpg", ".JPEG", ".jpeg", ".PNG", ".png"]
+
+
+# ---------------------------------------------------------------------------
+# File type detection
+# ---------------------------------------------------------------------------
+
+def _magic_type(path: Path) -> Optional[str]:
+    """Detect actual file type from magic bytes (first 12 bytes)."""
+    try:
+        header = path.read_bytes()[:12]
+    except OSError:
+        return None
+    if header[:2] == b"\xff\xd8":
+        return "jpeg"
+    if header[:8] == b"\x89PNG\r\n\x1a\n":
+        return "png"
+    if header[:6] in (b"GIF87a", b"GIF89a"):
+        return "gif"
+    if len(header) >= 12 and header[:4] == b"RIFF" and header[8:12] == b"WEBP":
+        return "webp"
+    if len(header) >= 12 and header[4:8] == b"ftyp":
+        brand = header[8:12].lower()
+        if brand in (b"heic", b"heix", b"mif1", b"msf1", b"heim", b"heis", b"hevc"):
+            return "heic"
+        if brand in (b"mp41", b"mp42", b"isom", b"iso2", b"avc1", b"f4v ", b"m4v "):
+            return "mp4"
+        if brand in (b"qt  ",):
+            return "mov"
+    return None
+
+
+def get_file_type(path: Path) -> tuple[str, bool]:
+    """Return (file_type, needs_magic_check) for a media file.
+
+    file_type is one of: 'jpeg' | 'heic' | 'raw' | 'png' | 'gif' | 'webp'
+                         | 'mp4' | 'mov' | 'skip'
+    needs_magic_check is True when the extension was ambiguous and magic bytes
+    revealed a different type (caller should be aware the path might be misnamed).
+    """
+    ext = path.suffix.lower()
+    ext_type_map = {
+        ".jpg": "jpeg", ".jpeg": "jpeg",
+        ".heic": "heic", ".heif": "heic",
+        ".dng": "raw", ".cr2": "raw", ".cr3": "raw",
+        ".nef": "raw", ".arw": "raw", ".raf": "raw", ".rw2": "raw",
+        ".tif": "raw", ".tiff": "raw",
+        ".png": "png",
+        ".gif": "gif",
+        ".webp": "webp",
+        ".mp4": "mp4", ".m4v": "mp4",
+        ".mov": "mov",
+    }
+    declared = ext_type_map.get(ext, "skip")
+
+    # Verify magic bytes for formats that can be misnamed
+    if declared in ("heic", "raw", "png", "gif", "webp"):
+        actual = _magic_type(path)
+        if actual and actual != declared:
+            return actual, True
+
+    return declared, False
+
+
+# ---------------------------------------------------------------------------
+# Filename parsing
+# ---------------------------------------------------------------------------
+
+@dataclass
+class MediaFile:
+    """Decomposed media filename for JSON/pair matching."""
+
+    path: Path
+    base_stem: str       # stem with (N) stripped
+    number: Optional[int]  # N from (N), or None
+    suffix: str          # ".HEIC" (preserves original case)
+    is_edited: bool
+    clean_stem: str      # base_stem with edited suffix stripped
+
+
+def parse_media_filename(path: Path) -> MediaFile:
+    """Decompose a media filename into its parts.
+
+    Handles Google Takeout duplicate numbering (IMG_9556(1).HEIC)
+    and edited suffixes (-已編輯, -edited, …).
+    """
+    stem = path.stem
+    suffix = path.suffix
+
+    m = DUPE_RE.match(stem)
+    if m:
+        base_stem = m.group(1)
+        number: Optional[int] = int(m.group(2))
+    else:
+        base_stem = stem
+        number = None
+
+    is_edited = False
+    clean_stem = base_stem
+    for es in EDITED_SUFFIXES:
+        if base_stem.endswith(es):
+            clean_stem = base_stem[: -len(es)]
+            is_edited = True
+            break
+
+    return MediaFile(
+        path=path,
+        base_stem=base_stem,
+        number=number,
+        suffix=suffix,
+        is_edited=is_edited,
+        clean_stem=clean_stem,
+    )

--- a/scanner/walker.py
+++ b/scanner/walker.py
@@ -1,0 +1,131 @@
+"""Walk source directories and build FileRecord lists with Live Photo pairing."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from scanner.media import (
+    COMPANION_PHOTO_EXTS,
+    EDITED_SUFFIXES,
+    MEDIA_EXTENSIONS,
+    SKIP_FILENAMES,
+    get_file_type,
+    parse_media_filename,
+)
+
+
+@dataclass
+class FileRecord:
+    """A single media file discovered during a source scan."""
+
+    path: Path
+    source_label: str        # 'iphone' | 'takeout' | 'jdrive'
+    file_type: str           # 'jpeg' | 'heic' | 'raw' | 'png' | 'mp4' | 'mov' | …
+    pair_partner: Optional[Path] = None  # MOV partner for Live Photo HEIC, or vice versa
+    misnamed: bool = False   # True if magic bytes differ from file extension
+
+
+def scan_sources(sources: dict[str, Path]) -> list[FileRecord]:
+    """Walk each source directory and return all discovered FileRecords.
+
+    Args:
+        sources: Mapping of label → root path, e.g.
+                 {'iphone': Path('\\\\LinXiaoYun\\home\\Photos\\MobileBackup\\iPhone'),
+                  'takeout': Path('D:\\Downloads\\Takeout\\Google 相簿'),
+                  'jdrive': Path('J:\\圖片')}
+    """
+    records: list[FileRecord] = []
+    for label, root in sources.items():
+        if not root.exists():
+            raise FileNotFoundError(f"Source directory not found: {root}")
+        records.extend(_scan_dir(root, label))
+    return records
+
+
+def _scan_dir(root: Path, label: str) -> list[FileRecord]:
+    """Recursively walk root and return FileRecords with Live Photo pairs resolved."""
+    # Collect all media files grouped by directory for efficient pairing
+    by_dir: dict[Path, list[Path]] = {}
+    for path in root.rglob("*"):
+        if not path.is_file():
+            continue
+        if path.name.lower() in SKIP_FILENAMES:
+            continue
+        if path.suffix.lower() not in MEDIA_EXTENSIONS:
+            continue
+        by_dir.setdefault(path.parent, []).append(path)
+
+    records: list[FileRecord] = []
+    for directory, files in by_dir.items():
+        records.extend(_process_directory(files, label))
+    return records
+
+
+def _process_directory(files: list[Path], label: str) -> list[FileRecord]:
+    """Build FileRecords for one directory, pairing Live Photos by stem."""
+    # Build stem → files map using clean stems (strip Takeout numbering + edited suffixes)
+    stem_map: dict[str, list[Path]] = {}
+    for path in files:
+        mf = parse_media_filename(path)
+        stem_map.setdefault(mf.clean_stem, []).append(path)
+
+    records: list[FileRecord] = []
+    paired: set[Path] = set()
+
+    for path in files:
+        if path in paired:
+            continue
+
+        file_type, misnamed = get_file_type(path)
+        if file_type == "skip":
+            continue
+
+        partner = _find_live_photo_partner(path, stem_map)
+        if partner is not None:
+            paired.add(partner)
+
+        records.append(FileRecord(
+            path=path,
+            source_label=label,
+            file_type=file_type,
+            pair_partner=partner,
+            misnamed=misnamed,
+        ))
+
+    return records
+
+
+def _find_live_photo_partner(path: Path, stem_map: dict[str, list[Path]]) -> Optional[Path]:
+    """Return the paired Live Photo partner for a HEIC/JPG or MOV file, or None.
+
+    HEIC/JPG → look for same-stem MOV
+    MOV → look for same-stem HEIC/JPG (using COMPANION_PHOTO_EXTS order)
+    Edited copies are excluded from pairing.
+    """
+    mf = parse_media_filename(path)
+    if mf.is_edited:
+        return None
+
+    ext = path.suffix.lower()
+    candidates = stem_map.get(mf.clean_stem, [])
+
+    if ext in (".heic", ".heif", ".jpg", ".jpeg"):
+        # Look for a same-stem MOV
+        for candidate in candidates:
+            if candidate.suffix.lower() in (".mov", ".mp4") and candidate != path:
+                c_mf = parse_media_filename(candidate)
+                if not c_mf.is_edited and c_mf.clean_stem == mf.clean_stem:
+                    return candidate
+
+    elif ext in (".mov", ".mp4"):
+        # Look for a same-stem image (HEIC preferred)
+        for photo_ext in COMPANION_PHOTO_EXTS:
+            for candidate in candidates:
+                if (candidate.suffix == photo_ext and candidate != path):
+                    c_mf = parse_media_filename(candidate)
+                    if not c_mf.is_edited and c_mf.clean_stem == mf.clean_stem:
+                        return candidate
+
+    return None

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -1,0 +1,208 @@
+"""Tests for scanner/dedup.py — duplicate classification logic."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+from scanner.dedup import HashResult, ManifestRow, classify
+from scanner.walker import FileRecord
+
+
+def _dt(year: int = 2024, month: int = 6, day: int = 1) -> datetime:
+    return datetime(year, month, day, 12, 0, 0)
+
+
+def _rows(result: list) -> dict:
+    """Index ManifestRows by posix source_path (Windows-safe)."""
+    return {Path(r.source_path).as_posix(): r for r in result}
+
+
+def _record(
+    path: str,
+    source_label: str = "jdrive",
+    file_type: str = "jpeg",
+    pair_partner: Path | None = None,
+) -> FileRecord:
+    return FileRecord(
+        path=Path(path),
+        source_label=source_label,
+        file_type=file_type,
+        pair_partner=pair_partner,
+    )
+
+
+def _hr(
+    path: str,
+    sha256: str = "aaa",
+    phash: str | None = "0000000000000000",
+    exif_date: datetime | None = None,
+    source_label: str = "jdrive",
+    file_type: str = "jpeg",
+    pair_partner: Path | None = None,
+) -> HashResult:
+    return HashResult(
+        record=_record(path, source_label=source_label, file_type=file_type,
+                       pair_partner=pair_partner),
+        sha256=sha256,
+        phash=phash,
+        exif_date=exif_date,
+    )
+
+
+# ---------------------------------------------------------------------------
+# KEEP for iPhone source
+# ---------------------------------------------------------------------------
+
+class TestIphoneKeep:
+    def test_iphone_always_keep(self):
+        hr = _hr("/iphone/IMG_001.HEIC", source_label="iphone", exif_date=_dt())
+        rows = classify([hr])
+        assert rows[0].action == "KEEP"
+
+    def test_iphone_keep_even_when_duplicate_elsewhere(self):
+        iphone = _hr("/iphone/IMG_001.HEIC", sha256="abc", source_label="iphone",
+                     exif_date=_dt())
+        jdrive = _hr("/jdrive/IMG_001.jpg", sha256="abc", source_label="jdrive",
+                     exif_date=_dt())
+        rows = _rows(classify([iphone, jdrive]))
+        assert rows["/iphone/IMG_001.HEIC"].action == "KEEP"
+        assert rows["/jdrive/IMG_001.jpg"].action == "SKIP"
+
+
+# ---------------------------------------------------------------------------
+# EXACT_DUPLICATE
+# ---------------------------------------------------------------------------
+
+class TestExactDuplicate:
+    def test_lower_priority_source_skipped(self):
+        iphone = _hr("/iphone/a.jpg", sha256="same", source_label="iphone", exif_date=_dt())
+        takeout = _hr("/takeout/a.jpg", sha256="same", source_label="takeout", exif_date=_dt())
+        jdrive = _hr("/jdrive/a.jpg", sha256="same", source_label="jdrive", exif_date=_dt())
+        rows = _rows(classify([iphone, takeout, jdrive]))
+        assert rows["/iphone/a.jpg"].action == "KEEP"
+        assert rows["/takeout/a.jpg"].action == "SKIP"
+        assert rows["/jdrive/a.jpg"].action == "SKIP"
+
+    def test_skip_points_to_kept_file(self):
+        a = _hr("/jdrive/a.jpg", sha256="x", source_label="jdrive", exif_date=_dt())
+        b = _hr("/takeout/b.jpg", sha256="x", source_label="takeout", exif_date=_dt())
+        rows = _rows(classify([a, b]))
+        kept = "/takeout/b.jpg"  # takeout > jdrive
+        assert Path(rows["/jdrive/a.jpg"].duplicate_of).as_posix() == kept
+
+
+# ---------------------------------------------------------------------------
+# FORMAT_DUPLICATE
+# ---------------------------------------------------------------------------
+
+class TestFormatDuplicate:
+    def test_heic_kept_over_jpeg_same_phash(self):
+        heic = _hr("/a.heic", sha256="h1", phash="0" * 16, file_type="heic",
+                   source_label="jdrive", exif_date=_dt())
+        jpeg = _hr("/a.jpg", sha256="h2", phash="0" * 16, file_type="jpeg",
+                   source_label="jdrive", exif_date=_dt())
+        rows = _rows(classify([heic, jpeg]))
+        assert rows["/a.heic"].action in ("MOVE", "KEEP")
+        assert rows["/a.jpg"].action == "SKIP"
+
+    def test_raw_and_jpeg_both_move(self):
+        """RAW + JPEG of same shot must both be kept (complementary rule)."""
+        raw = _hr("/a.arw", sha256="r1", phash="0" * 16, file_type="raw",
+                  source_label="jdrive", exif_date=_dt())
+        jpeg = _hr("/a.jpg", sha256="j1", phash="0" * 16, file_type="jpeg",
+                   source_label="jdrive", exif_date=_dt())
+        rows = _rows(classify([raw, jpeg]))
+        assert rows["/a.arw"].action == "MOVE"
+        assert rows["/a.jpg"].action == "MOVE"
+
+
+# ---------------------------------------------------------------------------
+# REVIEW_DUPLICATE (near-duplicate)
+# ---------------------------------------------------------------------------
+
+class TestNearDuplicate:
+    def test_near_duplicate_flagged(self):
+        import imagehash
+        base = imagehash.hex_to_hash("0" * 16)
+        # Flip 5 bits → hamming distance 5 (within default threshold 10)
+        near = imagehash.hex_to_hash("f" + "0" * 15)
+        a = _hr("/a.jpg", sha256="s1", phash=str(base), source_label="takeout",
+                exif_date=_dt())
+        b = _hr("/b.jpg", sha256="s2", phash=str(near), source_label="jdrive",
+                exif_date=_dt())
+        rows = _rows(classify([a, b], threshold=10))
+        assert rows["/b.jpg"].action == "REVIEW_DUPLICATE"
+
+    def test_beyond_threshold_not_flagged(self):
+        import imagehash
+        # 16-bit difference: hamming distance = 4 (0x000f vs 0x0000)
+        h1 = imagehash.hex_to_hash("0" * 16)
+        h2 = imagehash.hex_to_hash("000000000000000f")
+        a = _hr("/a.jpg", sha256="s1", phash=str(h1), exif_date=_dt())
+        b = _hr("/b.jpg", sha256="s2", phash=str(h2), exif_date=_dt())
+        # threshold=3 → distance 4 is beyond threshold
+        rows = _rows(classify([a, b], threshold=3))
+        assert rows["/b.jpg"].action != "REVIEW_DUPLICATE"
+
+
+# ---------------------------------------------------------------------------
+# UNDATED
+# ---------------------------------------------------------------------------
+
+class TestUndated:
+    def test_no_exif_becomes_undated(self):
+        hr = _hr("/jdrive/mystery.jpg", exif_date=None)
+        rows = classify([hr])
+        assert rows[0].action == "UNDATED"
+
+    def test_iphone_undated_still_keep(self):
+        hr = _hr("/iphone/IMG.HEIC", source_label="iphone", exif_date=None)
+        rows = classify([hr])
+        assert rows[0].action == "KEEP"
+
+
+# ---------------------------------------------------------------------------
+# Live Photo pair propagation
+# ---------------------------------------------------------------------------
+
+class TestLivePhotoPair:
+    def test_mov_skipped_when_heic_skipped(self):
+        heic_path = Path("/iphone/IMG_1234.HEIC")
+        mov_path = Path("/iphone/IMG_1234.MOV")
+        orig_heic_path = Path("/jdrive/IMG_1234.HEIC")
+
+        heic = _hr(str(heic_path), sha256="x", source_label="jdrive",
+                   file_type="heic", exif_date=_dt(),
+                   pair_partner=mov_path)
+        mov = _hr(str(mov_path), sha256="y", phash=None,
+                  source_label="jdrive", file_type="mov", exif_date=_dt(),
+                  pair_partner=heic_path)
+        orig = _hr(str(orig_heic_path), sha256="x", source_label="iphone",
+                   file_type="heic", exif_date=_dt())
+
+        rows = _rows(classify([heic, mov, orig]))
+        assert rows[heic_path.as_posix()].action == "SKIP"
+        assert rows[mov_path.as_posix()].action == "SKIP"
+
+
+# ---------------------------------------------------------------------------
+# dest_path
+# ---------------------------------------------------------------------------
+
+class TestDestPath:
+    def test_move_has_dest_path(self):
+        hr = _hr("/jdrive/IMG.jpg", sha256="u", phash=None,
+                 source_label="jdrive", exif_date=_dt(2024, 6, 1))
+        rows = classify([hr])
+        assert rows[0].action == "MOVE"
+        assert rows[0].dest_path == "2024/20240601_jdrive/IMG.jpg"
+
+    def test_skip_has_no_dest_path(self):
+        a = _hr("/a.jpg", sha256="dup", source_label="takeout", exif_date=_dt())
+        b = _hr("/b.jpg", sha256="dup", source_label="jdrive", exif_date=_dt())
+        rows = _rows(classify([a, b]))
+        assert rows["/b.jpg"].dest_path is None

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -1,0 +1,152 @@
+"""Tests for scanner/hasher.py — SHA-256 and pHash computation."""
+
+from __future__ import annotations
+
+import hashlib
+import io
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from PIL import Image
+
+
+def _make_image(color: tuple = (128, 64, 32), size: tuple = (64, 64)) -> Image.Image:
+    img = Image.new("RGB", size, color)
+    return img
+
+
+def _write_jpeg(path: Path, color=(128, 64, 32)) -> None:
+    _make_image(color).save(path, "JPEG")
+
+
+def _write_png(path: Path, color=(0, 128, 255)) -> None:
+    _make_image(color).save(path, "PNG")
+
+
+# ---------------------------------------------------------------------------
+# compute_sha256
+# ---------------------------------------------------------------------------
+
+class TestComputeSha256:
+    def test_stable_across_calls(self, tmp_path):
+        from scanner.hasher import compute_sha256
+        f = tmp_path / "file.bin"
+        f.write_bytes(b"hello world")
+        assert compute_sha256(f) == compute_sha256(f)
+
+    def test_matches_hashlib(self, tmp_path):
+        from scanner.hasher import compute_sha256
+        data = b"test content " * 1000
+        f = tmp_path / "data.bin"
+        f.write_bytes(data)
+        expected = hashlib.sha256(data).hexdigest()
+        assert compute_sha256(f) == expected
+
+    def test_different_files_differ(self, tmp_path):
+        from scanner.hasher import compute_sha256
+        a = tmp_path / "a.bin"
+        b = tmp_path / "b.bin"
+        a.write_bytes(b"aaa")
+        b.write_bytes(b"bbb")
+        assert compute_sha256(a) != compute_sha256(b)
+
+
+# ---------------------------------------------------------------------------
+# compute_phash
+# ---------------------------------------------------------------------------
+
+class TestComputePhash:
+    def test_returns_string_for_jpeg(self, tmp_path):
+        from scanner.hasher import compute_phash
+        f = tmp_path / "img.jpg"
+        _write_jpeg(f)
+        result = compute_phash(f, "jpeg")
+        assert isinstance(result, str)
+        assert len(result) == 16  # 64-bit hash = 16 hex chars
+
+    def test_returns_string_for_png(self, tmp_path):
+        from scanner.hasher import compute_phash
+        f = tmp_path / "img.png"
+        _write_png(f)
+        result = compute_phash(f, "png")
+        assert isinstance(result, str)
+
+    def test_returns_none_for_video(self, tmp_path):
+        from scanner.hasher import compute_phash
+        f = tmp_path / "clip.mov"
+        f.write_bytes(b"\x00" * 16)
+        assert compute_phash(f, "mov") is None
+        assert compute_phash(f, "mp4") is None
+
+    def test_returns_none_for_gif(self, tmp_path):
+        from scanner.hasher import compute_phash
+        f = tmp_path / "anim.gif"
+        _make_image().save(f, "GIF")
+        assert compute_phash(f, "gif") is None
+
+    def test_same_image_same_hash(self, tmp_path):
+        from scanner.hasher import compute_phash
+        f1 = tmp_path / "a.jpg"
+        f2 = tmp_path / "b.jpg"
+        _write_jpeg(f1, color=(200, 100, 50))
+        _write_jpeg(f2, color=(200, 100, 50))
+        assert compute_phash(f1, "jpeg") == compute_phash(f2, "jpeg")
+
+    def test_different_images_differ(self, tmp_path):
+        from scanner.hasher import compute_phash
+        f1 = tmp_path / "a.jpg"
+        f2 = tmp_path / "b.jpg"
+        # Use distinct gradient patterns — solid colors can produce identical pHash
+        img1 = Image.new("RGB", (64, 64))
+        img2 = Image.new("RGB", (64, 64))
+        img1.putdata([(x * 4, 0, 0) for x in range(64 * 64)])          # red gradient
+        img2.putdata([(0, 0, x * 4) for x in range(64 * 64)])          # blue gradient
+        img1.save(f1, "JPEG", quality=95)
+        img2.save(f2, "JPEG", quality=95)
+        assert compute_phash(f1, "jpeg") != compute_phash(f2, "jpeg")
+
+    def test_jpeg_png_same_content_same_hash(self, tmp_path):
+        """Cross-format: JPEG and PNG of same image should produce same pHash."""
+        from scanner.hasher import compute_phash
+        img = _make_image(color=(100, 150, 200), size=(128, 128))
+        jpg = tmp_path / "img.jpg"
+        png = tmp_path / "img.png"
+        # Save as JPEG with high quality to minimise compression artefacts
+        img.save(jpg, "JPEG", quality=95)
+        img.save(png, "PNG")
+        h_jpg = compute_phash(jpg, "jpeg")
+        h_png = compute_phash(png, "png")
+        assert h_jpg is not None and h_png is not None
+        # pHash may have small hamming distance due to JPEG artefacts; allow ≤ 4
+        import imagehash
+        dist = imagehash.hex_to_hash(h_jpg) - imagehash.hex_to_hash(h_png)
+        assert dist <= 4, f"Expected cross-format pHash distance ≤ 4, got {dist}"
+
+    def test_raw_embedded_preview(self, tmp_path):
+        """RAW with embedded JPEG thumbnail → pHash extracted from thumbnail."""
+        from scanner.hasher import compute_phash
+
+        # Mock rawpy so we don't need a real RAW file
+        thumb_mock = MagicMock()
+        thumb_mock.format = MagicMock()
+
+        buf = io.BytesIO()
+        _make_image(color=(80, 160, 40), size=(64, 64)).save(buf, "JPEG")
+        thumb_mock.data = buf.getvalue()
+
+        import rawpy as _rawpy  # noqa: F401 (may not be installed)
+
+        with patch("scanner.hasher.rawpy") as mock_rawpy, \
+             patch("scanner.hasher._RAWPY_AVAILABLE", True):
+            mock_rawpy.ThumbFormat.JPEG = thumb_mock.format
+            mock_raw = MagicMock()
+            mock_raw.extract_thumb.return_value = thumb_mock
+            mock_rawpy.imread.return_value.__enter__ = lambda s: mock_raw
+            mock_rawpy.imread.return_value.__exit__ = MagicMock(return_value=False)
+
+            f = tmp_path / "photo.arw"
+            f.write_bytes(b"\x00" * 16)
+            result = compute_phash(f, "raw")
+
+        assert result is not None

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -1,0 +1,112 @@
+"""Tests for scanner/walker.py — directory walking and Live Photo pairing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+
+def _write_jpeg(path: Path) -> None:
+    Image.new("RGB", (16, 16), (128, 128, 128)).save(path, "JPEG")
+
+
+def _write_mov(path: Path) -> None:
+    # Minimal ftyp box that looks like a QuickTime MOV
+    path.write_bytes(b"\x00\x00\x00\x08ftyp" + b"qt  ")
+
+
+class TestScanSources:
+    def test_missing_source_raises(self, tmp_path):
+        from scanner.walker import scan_sources
+        with pytest.raises(FileNotFoundError, match="Source directory not found"):
+            scan_sources({"label": tmp_path / "nonexistent"})
+
+    def test_finds_jpeg_files(self, tmp_path):
+        from scanner.walker import scan_sources
+        _write_jpeg(tmp_path / "photo.jpg")
+        records = scan_sources({"test": tmp_path})
+        paths = [r.path for r in records]
+        assert tmp_path / "photo.jpg" in paths
+
+    def test_skips_thumbs_db(self, tmp_path):
+        from scanner.walker import scan_sources
+        (tmp_path / "Thumbs.db").write_bytes(b"db")
+        (tmp_path / "thumbs.db").write_bytes(b"db")
+        records = scan_sources({"test": tmp_path})
+        assert not records
+
+    def test_skips_json_sidecars(self, tmp_path):
+        from scanner.walker import scan_sources
+        (tmp_path / "photo.jpg.json").write_text("{}", encoding="utf-8")
+        records = scan_sources({"test": tmp_path})
+        assert not records
+
+    def test_source_label_assigned(self, tmp_path):
+        from scanner.walker import scan_sources
+        _write_jpeg(tmp_path / "a.jpg")
+        records = scan_sources({"mylabel": tmp_path})
+        assert all(r.source_label == "mylabel" for r in records)
+
+    def test_recursive_walk(self, tmp_path):
+        from scanner.walker import scan_sources
+        subdir = tmp_path / "2024" / "event"
+        subdir.mkdir(parents=True)
+        _write_jpeg(subdir / "photo.jpg")
+        records = scan_sources({"test": tmp_path})
+        assert len(records) == 1
+
+    def test_multiple_sources(self, tmp_path):
+        from scanner.walker import scan_sources
+        src_a = tmp_path / "a"
+        src_b = tmp_path / "b"
+        src_a.mkdir()
+        src_b.mkdir()
+        _write_jpeg(src_a / "x.jpg")
+        _write_jpeg(src_b / "y.jpg")
+        records = scan_sources({"alpha": src_a, "beta": src_b})
+        labels = {r.source_label for r in records}
+        assert labels == {"alpha", "beta"}
+
+
+class TestLivePhotoPairing:
+    def test_heic_paired_with_mov(self, tmp_path):
+        from scanner.walker import scan_sources
+        _write_jpeg(tmp_path / "IMG_1234.HEIC")
+        _write_mov(tmp_path / "IMG_1234.MOV")
+        records = scan_sources({"test": tmp_path})
+        heic = next(r for r in records if r.path.suffix.upper() == ".HEIC")
+        assert heic.pair_partner is not None
+        assert heic.pair_partner.name == "IMG_1234.MOV"
+
+    def test_jpg_paired_with_mov(self, tmp_path):
+        from scanner.walker import scan_sources
+        _write_jpeg(tmp_path / "IMG_5678.JPG")
+        _write_mov(tmp_path / "IMG_5678.MOV")
+        records = scan_sources({"test": tmp_path})
+        jpg = next(r for r in records if r.path.suffix.upper() == ".JPG")
+        assert jpg.pair_partner is not None
+
+    def test_no_pairing_without_partner(self, tmp_path):
+        from scanner.walker import scan_sources
+        _write_jpeg(tmp_path / "IMG_9999.HEIC")
+        records = scan_sources({"test": tmp_path})
+        assert records[0].pair_partner is None
+
+    def test_edited_not_paired(self, tmp_path):
+        from scanner.walker import scan_sources
+        _write_jpeg(tmp_path / "IMG_1234-已編輯.HEIC")
+        _write_mov(tmp_path / "IMG_1234.MOV")
+        records = scan_sources({"test": tmp_path})
+        heic = next(r for r in records if "編輯" in r.path.name)
+        assert heic.pair_partner is None
+
+    def test_takeout_numbered_pair(self, tmp_path):
+        """IMG_9556(1).HEIC + IMG_9556(1).MOV should pair via clean_stem."""
+        from scanner.walker import scan_sources
+        _write_jpeg(tmp_path / "IMG_9556(1).HEIC")
+        _write_mov(tmp_path / "IMG_9556(1).MOV")
+        records = scan_sources({"test": tmp_path})
+        heic = next(r for r in records if r.path.suffix.upper() == ".HEIC")
+        assert heic.pair_partner is not None


### PR DESCRIPTION
## Summary

- Adds `scanner/` package implementing a standalone, non-destructive deduplication scan across three photo sources (iphone, takeout, jdrive)
- Classifies every file into KEEP / MOVE / SKIP / REVIEW_DUPLICATE / UNDATED and writes `migration_manifest.sqlite` for downstream migration
- Replaces the Cisdem Duplicate Finder dependency with internal pHash + SHA-256 logic

## What's included

| File | Purpose |
|------|---------|
| `scanner/media.py` | Extension sets, magic-byte detection, Takeout filename parsing |
| `scanner/walker.py` | Directory walk, Live Photo HEIC+MOV pairing |
| `scanner/hasher.py` | SHA-256 + pHash (Pillow / pillow-heif / rawpy embedded preview) |
| `scanner/exif.py` | Persistent exiftool `-stay_open` for batch EXIF date reads |
| `scanner/dedup.py` | Classification: exact → format → near-duplicate → UNDATED |
| `scanner/manifest.py` | SQLite writer + summary table |
| `scan.py` | CLI entry point (`--source LABEL=PATH`, `--dry-run`) |

## Key classification rules

- SHA-256 match → SKIP (EXACT_DUPLICATE)
- pHash hamming == 0, both lossy → SKIP lower format priority (FORMAT_DUPLICATE)
- pHash hamming == 0, RAW + lossy → MOVE both (complementary)
- pHash hamming 1–10 → REVIEW_DUPLICATE (human review)
- No EXIF DateTimeOriginal → UNDATED
- iPhone source → always KEEP
- Live Photo pair: SKIP/KEEP propagates from HEIC to MOV partner

## Test plan

- [x] 36/36 tests passing (`test_dedup.py`, `test_hasher.py`, `test_walker.py`)
- [x] Windows path separator handling verified (`Path.as_posix()` in test helpers)
- [ ] Dry-run against real sources (iphone MobileBackup + Takeout + jdrive)
- [ ] Spot-check 10 SKIP rows and 10 REVIEW_DUPLICATE rows in produced SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)