### PR TITLE
docs(readme): rewrite README for scanner-based workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,360 +1,143 @@
 # Photo Manager
 
-A Windows desktop tool for reviewing and culling large collections of **near-duplicate / similar photos**.
+A Windows tool for **deduplication scanning and review** of large personal photo collections.
 
-The app does **not** find duplicates itself — that job is delegated to an external tool (see [External Tools](#external-tools-upstream)). Once you have a CSV listing duplicate groups, Photo Manager lets you browse, compare, bulk-select, and safely delete the files you no longer want.
-
----
-
-## Table of Contents
-
-1. [Background & Motivation](#background--motivation)
-2. [Workflow Overview](#workflow-overview)
-3. [External Tools (Upstream)](#external-tools-upstream)
-   - [What is `.dupproj`?](#what-is-dupproj)
-   - [`convert_dupproj_to_csv.py`](#convert_dupproj_to_csvpy)
-4. [Scripts at a Glance](#scripts-at-a-glance)
-5. [Application Features](#application-features)
-6. [CSV Format](#csv-format)
-7. [Project Structure](#project-structure)
-8. [Getting Started](#getting-started)
-9. [Configuration (`settings.json`)](#configuration-settingsjson)
-10. [Development](#development)
+Produces `migration_manifest.sqlite` consumed by **[photo-transfer](https://github.com/jackal998/photo-transfer)** for the actual file migration.
 
 ---
 
-## Background & Motivation
-
-After years of photos synced across iPhones, Google Photos, and local backups, it is common to accumulate thousands of near-identical shots — burst photos, re-downloads, Google Takeout copies, etc. Dedicated duplicate-finder apps can detect these, but their built-in UIs are often limited for bulk human review.
-
-Photo Manager fills that gap:
-
-- Import the duplicate-group data as a CSV.
-- Browse groups side-by-side (thumbnails + metadata).
-- Apply selection rules automatically (e.g. "keep the largest file per group").
-- Manually adjust, then send unwanted files to the Recycle Bin in one go.
-
----
-
-## Workflow Overview
+## Workflow
 
 ```
-┌─────────────────────────────────┐
-│  1. Run a duplicate-finder app  │  (external — see below)
-│     e.g. Cisdem Duplicate Finder│
-└────────────────┬────────────────┘
-                 │  exports  .dupproj  (XML)
-                 ▼
-┌─────────────────────────────────┐
-│  2. convert_dupproj_to_csv.py   │  ← standalone helper script
-│     Converts .dupproj → .csv    │
-└────────────────┬────────────────┘
-                 │  produces  groups.csv
-                 ▼
-┌─────────────────────────────────┐
-│  3. Photo Manager (main.py)     │  ← this application
-│     Import CSV, review groups,  │
-│     apply rules, delete files   │
-└─────────────────────────────────┘
+scan.py   →   migration_manifest.sqlite   →   review.py   →   photo-transfer/migrate.py
+  │                                              │
+  └── walks sources, hashes files,              └── interactive triage of
+      classifies duplicates                          REVIEW_DUPLICATE rows
 ```
 
 ---
 
-## External Tools (Upstream)
+## Tools
 
-### What is `.dupproj`?
+### `scan.py` — Deduplication scanner
 
-A `.dupproj` file is the **project/results file exported by [Cisdem Duplicate Finder](https://www.cisdem.com/duplicate-finder-mac.html)** (a macOS/Windows utility).
-
-Internally it is an **XML file** that lists groups of duplicate or similar files found during a scan. Each group (`<GroupItem>`) contains `<Item>` elements, each holding the absolute path of one file in the duplicate set.
-
-Example XML structure:
-
-```xml
-<Root>
-  <GroupItem>
-    <Item>/Users/j/Photos/img_1234.heic_simlar_100</Item>
-    <Item>/Users/j/Photos/img_1234_copy.heic</Item>
-  </GroupItem>
-  <GroupItem>
-    <Item>/Users/j/Photos/vacation_01.jpg_simlar_98</Item>
-    <Item>/Users/j/Photos/vacation_01_edit.jpg</Item>
-  </GroupItem>
-</Root>
-```
-
-> **Note:** Cisdem appends a `_simlar_{score}` suffix (note the typo — "simlar" not "similar") to indicate the similarity score used for matching. `convert_dupproj_to_csv.py` strips this suffix automatically.
-
----
-
-### `convert_dupproj_to_csv.py`
-
-A standalone **pre-processing script** — run it once before opening the app.
-
-**What it does:**
-
-1. Parses the `.dupproj` XML file.
-2. Assigns sequential `GroupNumber` values (1, 2, 3 …) to each `<GroupItem>`.
-3. Strips the `_simlar_{N}` suffix from every file path.
-4. Normalises paths to lowercase.
-5. Splits each path into `FolderPath` + `FilePath`.
-6. Writes a CSV the app can import directly.
-
-**Usage:**
+Walks three source directories, computes SHA-256 + pHash for every media file, detects exact and cross-format duplicates, and writes a non-destructive `migration_manifest.sqlite`.
 
 ```powershell
-python convert_dupproj_to_csv.py <input.dupproj> <output.csv>
+# Full scan
+python scan.py `
+  --source iphone="\\LinXiaoYun\home\Photos\MobileBackup\iPhone" `
+  --source takeout="D:\Downloads\Takeout\Google 相簿" `
+  --source jdrive="J:\圖片" `
+  --output migration_manifest.sqlite
 
-# Example:
-python convert_dupproj_to_csv.py testdata\20250916.dupproj groups.csv
+# Dry run — summary only, no file written
+python scan.py ... --dry-run
+
+# Tighter near-duplicate threshold (default: 10)
+python scan.py ... --similarity-threshold 6
 ```
 
-**Output columns produced:**
+**Classification rules:**
 
-| Column | Value |
-|---|---|
-| `GroupNumber` | Sequential integer per duplicate group |
-| `IsMark` | `0` (default) |
-| `IsLocked` | `0` (default) |
-| `FolderPath` | Parent directory with trailing `\` |
-| `FilePath` | Full lowercase path |
-| `Capture Date` | *(empty — not in XML)* |
-| `Modified Date` | *(empty — not in XML)* |
-| `FileSize` | *(empty — filled by the app on import)* |
+| Condition | Action |
+|-----------|--------|
+| SHA-256 match | `SKIP` (EXACT_DUPLICATE) |
+| pHash hamming = 0, both lossy (JPG/HEIC/PNG) | `SKIP` lower format priority (FORMAT_DUPLICATE) |
+| pHash hamming = 0, one RAW + one lossy | `MOVE` both (complementary — kept together) |
+| pHash hamming 1–threshold | `REVIEW_DUPLICATE` (human review) |
+| No EXIF `DateTimeOriginal` | `UNDATED` |
+| iPhone source | `KEEP` (stays in place, used as dedup reference) |
+| Everything else | `MOVE` |
 
-The app will back-fill `FileSize`, `Creation Date`, and `Shot Date` from the actual files when the CSV is imported.
+**Source priority** (for exact duplicates): `iphone > takeout > jdrive`  
+**Format priority** (for FORMAT_DUPLICATE): `heic > jpeg > png > others`
+
+### `review.py` — Near-duplicate review CLI
+
+Interactive terminal tool for triaging `REVIEW_DUPLICATE` rows before migration.
+
+```powershell
+python review.py --manifest migration_manifest.sqlite
+
+# Re-show already-resolved rows
+python review.py --manifest migration_manifest.sqlite --show-all
+```
+
+Choices per pair: **[s]** skip candidate · **[k]** keep both · **[d]** defer  
+Decisions are persisted immediately — session is resumable.
 
 ---
 
-## Scripts at a Glance
+## Scanner features
 
-| Script | Purpose | Run standalone? |
-|---|---|---|
-| `main.py` | Application entry point — launches the PySide6 GUI | Yes — `python main.py` |
-| `convert_dupproj_to_csv.py` | Pre-processing: converts Cisdem `.dupproj` → CSV | Yes — `python convert_dupproj_to_csv.py` |
-| `heic_test.py` | Diagnostics: verifies HEIC decoding (Pillow + WIC) on your machine | Yes — `python heic_test.py [file.heic …]` |
-| `run_all_linters.py` | Dev utility: runs Black → isort → Ruff → Pylint in sequence | Yes — `python run_all_linters.py` |
-
-### Relationship between scripts
-
-```
-convert_dupproj_to_csv.py  ──(CSV)──►  main.py (app)
-                                            │
-                                            └── uses infrastructure/ (csv_repository, image_service, delete_service)
-                                            └── uses core/ (models, services)
-                                            └── uses app/ (views, viewmodels)
-
-heic_test.py      ── standalone sanity-check, no dependency on the app's CSV data
-run_all_linters.py ── standalone dev helper, analyses app/ core/ infrastructure/
-```
-
-`convert_dupproj_to_csv.py` is entirely independent from the app codebase. It only uses Python's standard library (`xml`, `csv`, `pathlib`, `re`).
+- **SHA-256** exact duplicate detection across all sources
+- **pHash** cross-format duplicate detection (JPEG vs HEIC vs RAW vs PNG)
+- **Hamming distance** near-duplicate similarity threshold (configurable)
+- **Live Photo pairs** — same-stem HEIC + MOV treated as atomic units
+- **RAW + lossy** — always kept together, never marked as duplicates
+- **Magic-byte verification** — catches JPEG files saved as `.HEIC`
+- **Takeout numbering** — `IMG_9556(1).HEIC` duplicate numbering handled
+- **Edited variants** — `-已編輯`, `-edited`, etc. excluded from pairing
+- **Batch EXIF** — exiftool `-stay_open` for fast date reads across all formats
 
 ---
 
-## Application Features
-
-- **Import / Export CSV** — load any conforming CSV; export with all fields refreshed from disk.
-- **Grouped tree view** — collapsible groups (`QTreeView`); each group shows photo count.
-- **Side-by-side preview** — single-image full preview + group thumbnail grid with LRU cache.
-- **HEIC / HEIF support** — via `pillow-heif`; falls back to Windows WIC thumbnails if not installed.
-- **Bulk selection rules** — "Select by Field/Regex" dialog; or JSON rule files (e.g. "keep largest per group").
-- **Lock** — mark individual records as locked so they are skipped by delete operations.
-- **Safe delete** — sends to Recycle Bin via `send2trash`; skips locked items; warns if an entire group would be deleted; writes a CSV delete log.
-- **Sort** — multi-key sort (configurable defaults in `settings.json`).
-- **Performance** — virtual/lazy loading designed for ~20 000 groups / 50 000 files.
-
----
-
-## CSV Format
-
-The canonical CSV used by the app (both import and export):
-
-```
-GroupNumber, IsMark, IsLocked, FolderPath, FilePath,
-Capture Date, Modified Date, Creation Date, Shot Date, FileSize
-```
-
-| Column | Type | Notes |
-|---|---|---|
-| `GroupNumber` | int | Groups files that are duplicates of each other |
-| `IsMark` | 0 / 1 | User-managed mark flag |
-| `IsLocked` | 0 / 1 | Protected from deletion (app-internal, not a file attribute) |
-| `FolderPath` | string | Parent folder with trailing `\` |
-| `FilePath` | string | Absolute file path (lowercase) |
-| `Capture Date` | datetime / blank | Legacy / source backup date |
-| `Modified Date` | datetime / blank | File modified timestamp |
-| `Creation Date` | datetime / blank | File system creation time (`os.path.getctime`); filled on import if blank |
-| `Shot Date` | datetime / blank | EXIF `DateTimeOriginal`; falls back to `Capture Date` if no EXIF |
-| `FileSize` | int (bytes) | Always re-read from disk on import and export |
-
-Human-readable sizes like `1.44MB` in the `FileSize` column are accepted on import and replaced with the actual byte count.
-
-A sample CSV is provided in `samples/sample.csv`.
-
----
-
-## Project Structure
+## Project structure
 
 ```
 photo-manager/
-├── main.py                      # App entry point
-├── convert_dupproj_to_csv.py    # Standalone: .dupproj → CSV
-├── heic_test.py                 # Standalone: HEIC decoding diagnostics
-├── run_all_linters.py           # Dev: run all linters at once
-├── settings.json                # Runtime configuration
-├── requirements.txt             # Runtime dependencies
-├── dev-requirements.txt         # Dev / linting dependencies
-├── pyproject.toml               # Tool config (black, isort, ruff, pylint)
-├── DESIGN.md                    # Architecture & design decisions (Chinese)
-├── LINTING_GUIDE.md             # Linting conventions
+├── scan.py                  # Deduplication scanner CLI
+├── review.py                # REVIEW_DUPLICATE interactive triage
+├── main.py                  # PySide6 GUI (legacy review app)
 │
-├── app/
-│   ├── views/                   # PySide6 windows, dialogs, widgets
-│   │   ├── main_window.py
-│   │   ├── preview_pane.py
-│   │   ├── image_tasks.py       # Background thumbnail loading
-│   │   ├── media_utils.py
-│   │   ├── selection_service.py
-│   │   ├── tree_model_builder.py
-│   │   ├── constants.py
-│   │   ├── components/          # Reusable controllers (tree, menu, selection)
-│   │   ├── dialogs/             # Select, Delete-confirm, Filters, Rules dialogs
-│   │   ├── handlers/            # Event handlers (file ops, dialogs, context menu)
-│   │   ├── layout/              # Layout manager
-│   │   └── widgets/             # Group media controller, video player
-│   └── viewmodels/
-│       ├── main_vm.py           # Main ViewModel (groups, sort, selection state)
-│       └── photo_vm.py          # Per-photo ViewModel
+├── scanner/                 # Scanner engine (no Qt dependency)
+│   ├── media.py             # Extensions, magic-byte detection, filename parsing
+│   ├── walker.py            # Directory walk + Live Photo pairing
+│   ├── hasher.py            # SHA-256 + pHash (Pillow / pillow-heif / rawpy)
+│   ├── exif.py              # Batch EXIF date reads via exiftool stay_open
+│   ├── dedup.py             # Classification: exact → format → near-dup → UNDATED
+│   └── manifest.py          # SQLite writer + summary printer
 │
-├── core/
-│   ├── models.py                # PhotoRecord, PhotoGroup dataclasses
-│   └── services/
-│       ├── interfaces.py        # IPhotoRepository, IImageService, etc.
-│       ├── selection_service.py # Bulk select/unselect logic
-│       └── sort_service.py      # Multi-key sort
+├── app/                     # PySide6 GUI (legacy)
+├── core/                    # Models + services
+├── infrastructure/          # CSV repo, image service, delete service
 │
-├── infrastructure/
-│   ├── csv_repository.py        # Read/write CSV ↔ PhotoRecord
-│   ├── image_service.py         # Thumbnail + preview loading, disk/memory cache
-│   ├── delete_service.py        # Recycle-bin delete, plan & execute
-│   ├── settings.py              # Load/validate settings.json
-│   ├── logging.py               # loguru initialisation
-│   └── utils.py                 # Shared helpers
-│
-├── schemas/
-│   └── rules.schema.json        # JSON Schema for rule files
-│
-└── samples/
-    ├── sample.csv               # Example CSV for quick testing
-    └── sample_rules.json        # Example bulk-selection rule file
+└── tests/
+    ├── test_hasher.py
+    ├── test_walker.py
+    ├── test_dedup.py
+    └── test_review.py
 ```
 
 ---
 
-## Getting Started
+## Getting started
 
 ### Prerequisites
 
-- **Windows 10/11** (the app is Windows-only; WIC thumbnail fallback requires Windows).
-- **Python 3.11+**
-- *(Optional but recommended)* Microsoft Store → **HEIF Image Extensions** — enables HEIC thumbnails in Windows shell.
+- Windows 10/11, Python 3.11+
+- [exiftool](https://exiftool.org/) on `PATH` (required for EXIF date extraction)
+- *(Optional)* [rawpy](https://pypi.org/project/rawpy/) for RAW file support
 
 ### Install
 
 ```powershell
-# Clone the repo
-git clone https://github.com/your-org/photo-manager.git
+git clone https://github.com/jackal998/photo-manager.git
 cd photo-manager
-
-# Create a virtual environment
 python -m venv .venv
 .venv\Scripts\Activate.ps1
-
-# Install runtime dependencies
 pip install -r requirements.txt
 ```
 
-### Run
+### Run tests
 
 ```powershell
-# Launch the GUI (auto-loads samples/sample.csv if present)
-python main.py
-```
-
-### Convert a `.dupproj` file
-
-```powershell
-# Step 1 — export your Cisdem Duplicate Finder results as a .dupproj file
-# Step 2 — convert it:
-python convert_dupproj_to_csv.py path\to\results.dupproj path\to\output.csv
-
-# Step 3 — open the app and File > Import the CSV
-python main.py
-```
-
-### Test HEIC decoding on your machine
-
-```powershell
-python heic_test.py "H:\Photos\example.heic"
+.venv\Scripts\python -m pytest
 ```
 
 ---
 
-## Configuration (`settings.json`)
+## Legacy GUI (`main.py`)
 
-```jsonc
-{
-  "thumbnail_size": 512,               // Max thumbnail side in pixels (256 / 512 / 1024)
-  "thumbnail_mem_cache": 512,          // In-memory LRU cache size (number of thumbnails)
-  "thumbnail_disk_cache_dir": "%LOCALAPPDATA%/PhotoManager/thumbs",
-  "delete": {
-    "confirm_group_full_delete": true  // Require extra confirmation when deleting all files in a group
-  },
-  "sorting": {
-    "defaults": [
-      { "field": "file_size_bytes", "asc": false },  // Largest first
-      { "field": "file_path",       "asc": true  }
-    ]
-  },
-  "ui": {
-    "locale": "zh-TW"
-  }
-}
-```
-
----
-
-## Development
-
-### Install dev dependencies
-
-```powershell
-pip install -r dev-requirements.txt
-```
-
-### Run all linters
-
-```powershell
-python run_all_linters.py
-```
-
-This runs (in order): **Black** (formatting) → **isort** (import sorting) → **Ruff** (fast lint) → **Pylint** (deep analysis).
-
-Individual tools:
-
-```powershell
-python -m black .
-python -m isort .
-python -m ruff check .
-python -m pylint app core infrastructure
-```
-
-See `LINTING_GUIDE.md` for project conventions and `pyproject.toml` for tool configuration.
-
-### Branching
-
-- `main` — stable
-- `feature/*` — development; merge via PR
-
-Versioning follows [SemVer](https://semver.org/); the first milestone release is `v1.0.0`.
+The original PySide6 desktop app for reviewing duplicate groups imported from a CSV (previously produced by Cisdem Duplicate Finder) is still available via `python main.py`. The new `scan.py` / `review.py` workflow replaces the Cisdem dependency for new scans.

--- a/review.py
+++ b/review.py
@@ -1,0 +1,181 @@
+"""review.py — Interactive terminal review of REVIEW_DUPLICATE rows.
+
+Shows each near-duplicate pair side-by-side (paths, hamming distance, source
+labels) and lets you resolve them: keep the reference (skip the candidate),
+keep both, or defer.
+
+Decisions are written back to migration_manifest.sqlite immediately so the
+session is resumable.
+
+Usage:
+  python review.py --manifest migration_manifest.sqlite
+  python review.py --manifest migration_manifest.sqlite --show-all   # re-show resolved rows
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Optional
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def _open(path: Path) -> sqlite3.Connection:
+    if not path.exists():
+        raise FileNotFoundError(f"Manifest not found: {path}")
+    conn = sqlite3.connect(path)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _pending_reviews(conn: sqlite3.Connection, show_all: bool) -> list[sqlite3.Row]:
+    where = "" if show_all else "AND executed = 0"
+    return conn.execute(
+        f"SELECT id, source_path, source_label, duplicate_of, hamming_distance, "
+        f"       phash, reason, action, executed "
+        f"FROM migration_manifest "
+        f"WHERE action = 'REVIEW_DUPLICATE' {where} "
+        f"ORDER BY hamming_distance, id"
+    ).fetchall()
+
+
+def _set_action(conn: sqlite3.Connection, row_id: int, action: str) -> None:
+    """Update action and mark executed=1 (resolved by human)."""
+    conn.execute(
+        "UPDATE migration_manifest SET action = ?, executed = 1 WHERE id = ?",
+        (action, row_id),
+    )
+    conn.commit()
+
+
+def _lookup(conn: sqlite3.Connection, source_path: str) -> Optional[sqlite3.Row]:
+    return conn.execute(
+        "SELECT source_path, source_label, action, dest_path "
+        "FROM migration_manifest WHERE source_path = ?",
+        (source_path,),
+    ).fetchone()
+
+
+# ---------------------------------------------------------------------------
+# Display helpers
+# ---------------------------------------------------------------------------
+
+def _fmt_row(row: sqlite3.Row) -> str:
+    name = Path(row["source_path"]).name
+    label = row["source_label"]
+    action = row["action"]
+    executed = row["executed"]
+    status = "resolved" if executed == 1 else "pending"
+    return f"  [{label}] {name}  ({action}, {status})"
+
+
+def _show_pair(candidate: sqlite3.Row, reference_row: Optional[sqlite3.Row]) -> None:
+    dist = candidate["hamming_distance"]
+    print(f"\n{'─' * 60}")
+    print(f"  hamming distance : {dist}")
+    print(f"\n  CANDIDATE (to review):")
+    print(f"  [{candidate['source_label']}] {candidate['source_path']}")
+    print(f"  reason: {candidate['reason']}")
+    print(f"\n  REFERENCE (kept):")
+    if reference_row:
+        print(f"  [{reference_row['source_label']}] {reference_row['source_path']}")
+        print(f"  action: {reference_row['action']}")
+    else:
+        print(f"  {candidate['duplicate_of']}  (not in manifest)")
+    print()
+
+
+# ---------------------------------------------------------------------------
+# Main loop
+# ---------------------------------------------------------------------------
+
+_PROMPT = (
+    "  [s] skip candidate (SKIP)  "
+    "[k] keep both (MOVE)  "
+    "[d] defer  "
+    "[q] quit\n  > "
+)
+
+
+def _review_loop(conn: sqlite3.Connection, rows: list[sqlite3.Row]) -> None:
+    total = len(rows)
+    pending = [r for r in rows if r["executed"] == 0]
+    print(f"\n{total} REVIEW_DUPLICATE row(s) — {len(pending)} pending resolution.\n")
+
+    for i, candidate in enumerate(rows):
+        if candidate["executed"] == 1:
+            continue  # already resolved in this session
+
+        reference = _lookup(conn, candidate["duplicate_of"]) if candidate["duplicate_of"] else None
+        _show_pair(candidate, reference)
+
+        remaining = sum(1 for r in rows[i:] if r["executed"] == 0)
+        print(f"  [{i + 1}/{total}]  {remaining - 1} remaining after this")
+
+        while True:
+            try:
+                choice = input(_PROMPT).strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                print("\nAborted.")
+                return
+
+            if choice == "s":
+                _set_action(conn, candidate["id"], "SKIP")
+                print("  → SKIP (candidate will not be copied)")
+                break
+            elif choice == "k":
+                _set_action(conn, candidate["id"], "MOVE")
+                print("  → MOVE (both files will be copied)")
+                break
+            elif choice == "d":
+                print("  → deferred")
+                break
+            elif choice == "q":
+                print("Quitting.")
+                return
+            else:
+                print("  Invalid choice — use s / k / d / q")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Review REVIEW_DUPLICATE rows in migration_manifest.sqlite"
+    )
+    parser.add_argument(
+        "--manifest",
+        type=Path,
+        default=Path("migration_manifest.sqlite"),
+        help="Path to manifest (default: migration_manifest.sqlite)",
+    )
+    parser.add_argument(
+        "--show-all",
+        action="store_true",
+        help="Show already-resolved rows too",
+    )
+    args = parser.parse_args()
+
+    conn = _open(args.manifest)
+    rows = _pending_reviews(conn, args.show_all)
+
+    if not rows:
+        print("No REVIEW_DUPLICATE rows found.")
+        return 0
+
+    _review_loop(conn, rows)
+
+    # Final tally
+    remaining = conn.execute(
+        "SELECT COUNT(*) FROM migration_manifest "
+        "WHERE action = 'REVIEW_DUPLICATE' AND executed = 0"
+    ).fetchone()[0]
+    print(f"\n{remaining} REVIEW_DUPLICATE row(s) still pending.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_review.py
+++ b/tests/test_review.py
@@ -1,0 +1,119 @@
+"""Tests for review.py — manifest DB helpers for REVIEW_DUPLICATE resolution."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+
+_DDL = """
+CREATE TABLE migration_manifest (
+    id               INTEGER PRIMARY KEY,
+    source_path      TEXT NOT NULL,
+    source_label     TEXT NOT NULL,
+    dest_path        TEXT,
+    action           TEXT NOT NULL,
+    source_hash      TEXT,
+    phash            TEXT,
+    hamming_distance INTEGER,
+    duplicate_of     TEXT,
+    reason           TEXT,
+    executed         INTEGER NOT NULL DEFAULT 0
+);
+"""
+
+
+def _make_manifest(tmp_path: Path, rows: list[dict]) -> Path:
+    db_path = tmp_path / "manifest.sqlite"
+    with sqlite3.connect(db_path) as conn:
+        conn.executescript(_DDL)
+        for r in rows:
+            conn.execute(
+                "INSERT INTO migration_manifest "
+                "(source_path, source_label, dest_path, action, "
+                " hamming_distance, duplicate_of, reason, executed) "
+                "VALUES (:source_path, :source_label, :dest_path, :action, "
+                "        :hamming_distance, :duplicate_of, :reason, :executed)",
+                r,
+            )
+        conn.commit()
+    return db_path
+
+
+def _default(overrides: dict) -> dict:
+    base = {
+        "source_path": "/jdrive/a.jpg",
+        "source_label": "jdrive",
+        "dest_path": None,
+        "action": "REVIEW_DUPLICATE",
+        "hamming_distance": 5,
+        "duplicate_of": "/iphone/a.jpg",
+        "reason": "near-duplicate (hamming=5)",
+        "executed": 0,
+    }
+    return {**base, **overrides}
+
+
+class TestPendingReviews:
+    def test_returns_only_review_duplicate_rows(self, tmp_path):
+        from review import _open, _pending_reviews
+        db = _make_manifest(tmp_path, [
+            _default({"source_path": "/a.jpg"}),
+            _default({"source_path": "/b.jpg", "action": "MOVE"}),
+            _default({"source_path": "/c.jpg", "action": "SKIP"}),
+        ])
+        conn = _open(db)
+        rows = _pending_reviews(conn, show_all=False)
+        assert len(rows) == 1
+        assert rows[0]["source_path"] == "/a.jpg"
+
+    def test_show_all_includes_resolved(self, tmp_path):
+        from review import _open, _pending_reviews
+        db = _make_manifest(tmp_path, [
+            _default({"source_path": "/a.jpg", "executed": 0}),
+            _default({"source_path": "/b.jpg", "executed": 1}),
+        ])
+        conn = _open(db)
+        assert len(_pending_reviews(conn, show_all=False)) == 1
+        assert len(_pending_reviews(conn, show_all=True)) == 2
+
+    def test_ordered_by_hamming_distance(self, tmp_path):
+        from review import _open, _pending_reviews
+        db = _make_manifest(tmp_path, [
+            _default({"source_path": "/c.jpg", "hamming_distance": 8}),
+            _default({"source_path": "/a.jpg", "hamming_distance": 2}),
+            _default({"source_path": "/b.jpg", "hamming_distance": 5}),
+        ])
+        conn = _open(db)
+        rows = _pending_reviews(conn, show_all=False)
+        distances = [r["hamming_distance"] for r in rows]
+        assert distances == sorted(distances)
+
+
+class TestSetAction:
+    def test_skip_resolves_row(self, tmp_path):
+        from review import _open, _pending_reviews, _set_action
+        db = _make_manifest(tmp_path, [_default({})])
+        conn = _open(db)
+        row_id = _pending_reviews(conn, show_all=False)[0]["id"]
+        _set_action(conn, row_id, "SKIP")
+        remaining = _pending_reviews(conn, show_all=False)
+        assert remaining == []
+        resolved = conn.execute(
+            "SELECT action, executed FROM migration_manifest WHERE id = ?", (row_id,)
+        ).fetchone()
+        assert resolved["action"] == "SKIP"
+        assert resolved["executed"] == 1
+
+    def test_move_resolves_row(self, tmp_path):
+        from review import _open, _pending_reviews, _set_action
+        db = _make_manifest(tmp_path, [_default({})])
+        conn = _open(db)
+        row_id = _pending_reviews(conn, show_all=False)[0]["id"]
+        _set_action(conn, row_id, "MOVE")
+        resolved = conn.execute(
+            "SELECT action FROM migration_manifest WHERE id = ?", (row_id,)
+        ).fetchone()
+        assert resolved["action"] == "MOVE"


### PR DESCRIPTION
## Summary

- Rewrites README to document the new `scan.py` / `review.py` workflow
- Replaces Cisdem/CSV-centric content with classification rules table, scanner features list, and updated project structure
- Legacy GUI section preserved at the bottom

🤖 Generated with [Claude Code](https://claude.com/claude-code)