### PR TITLE
fix(scanner): chunk exiftool, early-exit walker, --limit for debug dry-runs

### DIFF
--- a/scan.py
+++ b/scan.py
@@ -15,6 +15,9 @@ Usage examples:
   # Summary only, no DB written
   python scan.py --source ... --dry-run
 
+  # Debug: cap to 100 files per source (avoids full network read)
+  python scan.py --source ... --dry-run --limit 100
+
   # Tighter near-duplicate threshold
   python scan.py --source ... --similarity-threshold 6
 """
@@ -71,6 +74,13 @@ def main() -> int:
         action="store_true",
         help="Print summary only; do not write the manifest file",
     )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        default=None,
+        metavar="N",
+        help="Cap to N files per source — for debugging without reading the full network share",
+    )
     args = parser.parse_args()
 
     sources: dict[str, Path] = {}
@@ -85,28 +95,42 @@ def main() -> int:
     from scanner.dedup import HashResult, classify
     from scanner.manifest import write_manifest, print_summary
 
-    print(f"Scanning {len(sources)} source(s)…")
-    records = scan_sources(sources)
-    print(f"  Found {len(records):,} media files")
+    # --- Walk sources (print per-source progress) ---
+    limit_note = f" (capped at {args.limit} per source)" if args.limit else ""
+    print(f"Scanning {len(sources)} source(s){limit_note}…", flush=True)
+    records = []
+    for label, root in sources.items():
+        print(f"  Walking {label}: {root} …", end=" ", flush=True)
+        partial = scan_sources({label: root}, limit=args.limit)
+        print(f"{len(partial):,} files", flush=True)
+        records.extend(partial)
+    print(f"  Total: {len(records):,} media files", flush=True)
 
-    print("Computing hashes…")
-    hash_results: list[HashResult] = []
-
-    # Batch EXIF date extraction via exiftool
-    print("Reading EXIF dates (exiftool)…")
+    # --- Batch EXIF date extraction via exiftool (chunked) ---
     all_paths = [r.path for r in records]
+    chunk_size = 500
+    n_chunks = (len(all_paths) + chunk_size - 1) // chunk_size
+    print(f"Reading EXIF dates ({len(all_paths):,} files, {n_chunks} chunk(s))…", flush=True)
     try:
         with ExiftoolProcess() as et:
-            dates = batch_read_dates(all_paths, et)
+            dates = {}
+            for i in range(0, len(all_paths), chunk_size):
+                chunk = all_paths[i: i + chunk_size]
+                dates.update(batch_read_dates(chunk, et, chunk_size=chunk_size))
+                done = min(i + chunk_size, len(all_paths))
+                print(f"  EXIF {done:,}/{len(all_paths):,}", end="\r", flush=True)
+            print(f"  EXIF done — {sum(1 for v in dates.values() if v):,} dates found", flush=True)
     except FileNotFoundError:
         print(
-            "WARNING: exiftool not found on PATH — EXIF dates unavailable.\n"
+            "\nWARNING: exiftool not found on PATH — EXIF dates unavailable.\n"
             "Install from https://exiftool.org/ and ensure it is in your PATH.",
             file=sys.stderr,
         )
         dates = {p: None for p in all_paths}
 
-    # Compute SHA-256 + pHash
+    # --- Compute SHA-256 + pHash ---
+    print(f"Hashing {len(records):,} files…", flush=True)
+    hash_results: list[HashResult] = []
     iterable = tqdm(records, desc="Hashing", unit="file") if _TQDM else records
     for record in iterable:
         sha256 = compute_sha256(record.path)
@@ -117,18 +141,20 @@ def main() -> int:
             phash=phash,
             exif_date=dates.get(record.path),
         ))
+    if not _TQDM:
+        print("  Hashing done.", flush=True)
 
-    print("Classifying…")
+    print("Classifying…", flush=True)
     rows = classify(hash_results, threshold=args.threshold)
 
     print_summary(rows)
 
     if args.dry_run:
-        print("--dry-run: manifest not written.")
+        print("--dry-run: manifest not written.", flush=True)
         return 0
 
     write_manifest(rows, args.output)
-    print(f"Manifest written to: {args.output}")
+    print(f"Manifest written to: {args.output}", flush=True)
     return 0
 
 

--- a/scanner/exif.py
+++ b/scanner/exif.py
@@ -74,14 +74,30 @@ def _parse_exif_date(raw: str) -> Optional[datetime]:
         return None
 
 
-def batch_read_dates(paths: list[Path], et: ExiftoolProcess) -> dict[Path, Optional[datetime]]:
-    """Return {path: DateTimeOriginal} for all paths in one exiftool call.
+_EXIF_CHUNK = 500  # files per exiftool call — avoids memory/command-line limits
+
+
+def batch_read_dates(
+    paths: list[Path],
+    et: ExiftoolProcess,
+    chunk_size: int = _EXIF_CHUNK,
+) -> dict[Path, Optional[datetime]]:
+    """Return {path: DateTimeOriginal} for all paths, chunked to avoid limits.
 
     Falls back to CreateDate / QuickTime:CreateDate when DateTimeOriginal is absent.
+    Processes paths in chunks of chunk_size to keep each exiftool call manageable.
     """
     if not paths:
         return {}
 
+    result: dict[Path, Optional[datetime]] = {}
+    for offset in range(0, len(paths), chunk_size):
+        chunk = paths[offset: offset + chunk_size]
+        result.update(_read_chunk(chunk, et))
+    return result
+
+
+def _read_chunk(paths: list[Path], et: ExiftoolProcess) -> dict[Path, Optional[datetime]]:
     args = ["-DateTimeOriginal", "-CreateDate", "-QuickTime:CreateDate", "-s3", "-f"]
     args += [str(p) for p in paths]
     output = et.execute(args)

--- a/scanner/walker.py
+++ b/scanner/walker.py
@@ -27,27 +27,29 @@ class FileRecord:
     misnamed: bool = False   # True if magic bytes differ from file extension
 
 
-def scan_sources(sources: dict[str, Path]) -> list[FileRecord]:
+def scan_sources(
+    sources: dict[str, Path],
+    limit: int | None = None,
+) -> list[FileRecord]:
     """Walk each source directory and return all discovered FileRecords.
 
     Args:
-        sources: Mapping of label → root path, e.g.
-                 {'iphone': Path('\\\\LinXiaoYun\\home\\Photos\\MobileBackup\\iPhone'),
-                  'takeout': Path('D:\\Downloads\\Takeout\\Google 相簿'),
-                  'jdrive': Path('J:\\圖片')}
+        sources: Mapping of label → root path.
+        limit: If set, stop after this many files per source (for debug/dry-run).
     """
     records: list[FileRecord] = []
     for label, root in sources.items():
         if not root.exists():
             raise FileNotFoundError(f"Source directory not found: {root}")
-        records.extend(_scan_dir(root, label))
+        records.extend(_scan_dir(root, label, limit=limit))
     return records
 
 
-def _scan_dir(root: Path, label: str) -> list[FileRecord]:
+def _scan_dir(root: Path, label: str, limit: int | None = None) -> list[FileRecord]:
     """Recursively walk root and return FileRecords with Live Photo pairs resolved."""
     # Collect all media files grouped by directory for efficient pairing
     by_dir: dict[Path, list[Path]] = {}
+    total = 0
     for path in root.rglob("*"):
         if not path.is_file():
             continue
@@ -56,6 +58,9 @@ def _scan_dir(root: Path, label: str) -> list[FileRecord]:
         if path.suffix.lower() not in MEDIA_EXTENSIONS:
             continue
         by_dir.setdefault(path.parent, []).append(path)
+        total += 1
+        if limit and total >= limit:
+            break
 
     records: list[FileRecord] = []
     for directory, files in by_dir.items():


### PR DESCRIPTION
## Problem

Three issues discovered during first real dry-run against ~60K files:

1. `batch_read_dates` sent all 60K paths in a single exiftool call — potential memory/command-line limit failure
2. `--limit N` sliced results *after* walking the full NAS tree — still listed 6K files over the network before stopping
3. `scan.py` stdout buffering meant no output appeared until completion

## Fixes

- **exif.py**: chunk 500 files per exiftool call; progress printed per chunk
- **walker.py**: `scan_sources`/`_scan_dir` accept `limit` — `rglob` stops early once limit hit
- **scan.py**: pass `limit` into walker; `flush=True` on all prints; per-source count printed as each walk completes

## Dry-run result (50 files/source, 132 total)

```
KEEP              :  35  (26.5%)   ← iPhone, expected
MOVE              :  76  (57.6%)
SKIP              :   0
REVIEW_DUPLICATE  :   1  (0.8%)
UNDATED           :  20  (15.2%)   ← old J:\圖片 files without EXIF
```

No errors. Scanner working correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)