### PR TITLE
feat(ui): connect migration_manifest.sqlite to existing review GUI

### DIFF
--- a/app/viewmodels/main_vm.py
+++ b/app/viewmodels/main_vm.py
@@ -37,8 +37,22 @@ class MainVM:
 
     def load_csv(self, path: str) -> None:
         """Load CSV `path`, group records, and apply `default_sort` if provided."""
+        self._manifest_path = None
         items: list[PhotoRecord] = list(self._repo.load(path))
         self._source_csv_path = path
+        self._group_records(items)
+
+    def load_from_repo(self, repo, path: str) -> None:
+        """Load from an arbitrary repository (e.g. ManifestRepository).
+
+        Use this when the source is not a CSV (e.g. migration_manifest.sqlite).
+        """
+        self._source_csv_path = None
+        self._manifest_path = path
+        items: list[PhotoRecord] = list(repo.load(path))
+        self._group_records(items)
+
+    def _group_records(self, items: list[PhotoRecord]) -> None:
         grouped: dict[int, list[PhotoRecord]] = defaultdict(list)
         for item in items:
             grouped[item.group_number].append(item)

--- a/app/views/components/menu_controller.py
+++ b/app/views/components/menu_controller.py
@@ -36,6 +36,10 @@ class MenuController:
 
         # File Menu
         file_menu = menubar.addMenu("File")
+        self.actions["open_manifest"] = file_menu.addAction("Open Manifest…")
+        self.actions["save_manifest"] = file_menu.addAction("Save Manifest Decisions…")
+        self.actions["save_manifest"].setEnabled(False)
+        file_menu.addSeparator()
         self.actions["import"] = file_menu.addAction("Import CSV…")
         self.actions["export"] = file_menu.addAction("Export CSV…")
         self.actions["delete"] = file_menu.addAction("Delete Selected…")
@@ -77,6 +81,12 @@ class MenuController:
             handlers: Dictionary mapping action names to handler callables
         """
         # File menu actions
+        if "open_manifest" in handlers:
+            self.actions["open_manifest"].triggered.connect(handlers["open_manifest"])
+
+        if "save_manifest" in handlers:
+            self.actions["save_manifest"].triggered.connect(handlers["save_manifest"])
+
         if "import" in handlers:
             self.actions["import"].triggered.connect(handlers["import"])
 

--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -75,6 +75,73 @@ class FileOperationsHandler:
         # Optional callable or object with gather_checked_paths() to pull UI state
         self.checked_paths_provider = checked_paths_provider
 
+    def import_manifest(self) -> None:
+        """Open a migration_manifest.sqlite and load REVIEW_DUPLICATE groups."""
+        path, _ = QFileDialog.getOpenFileName(
+            self.parent, "Open Manifest", "", "SQLite Files (*.sqlite *.db);;All Files (*)"
+        )
+        if not path:
+            return
+
+        try:
+            from infrastructure.manifest_repository import ManifestRepository
+            manifest_repo = ManifestRepository()
+            self.vm.load_from_repo(manifest_repo, path)
+            self.ui_updater.show_group_counts(self.vm.group_count)
+            self.ui_updater.show_groups_summary(self.vm.groups)
+            self.ui_updater.refresh_tree(self.vm.groups)
+
+            # Enable "Save Manifest Decisions" and remember the open manifest path
+            self._manifest_path = path
+            try:
+                self.parent.menu_controller.enable_action("save_manifest", True)
+            except AttributeError:
+                pass
+
+            n_groups = self.vm.group_count
+            n_items = sum(len(g.items) for g in self.vm.groups)
+            logger.info("Opened manifest: {} | groups={} items={}", path, n_groups, n_items)
+            self.status_reporter.show_status(
+                f"Opened manifest: {n_groups} pairs to review ({n_items} files)"
+            )
+
+        except Exception as ex:
+            logger.exception("Open manifest failed: {}", ex)
+            QMessageBox.critical(self.parent, "Open Manifest Error", str(ex))
+            self.status_reporter.show_status("Open manifest failed")
+
+    def save_manifest_decisions(self) -> None:
+        """Write current is_mark state back to the open manifest."""
+        manifest_path = getattr(self, "_manifest_path", None)
+        if not manifest_path:
+            QMessageBox.information(self.parent, "Save Manifest", "No manifest open.")
+            return
+
+        try:
+            # Sync marks from UI checkboxes before saving
+            checked_paths: list[str] = []
+            provider = self.checked_paths_provider
+            if provider is not None:
+                if callable(provider):
+                    checked_paths = provider()
+                elif hasattr(provider, "gather_checked_paths"):
+                    checked_paths = provider.gather_checked_paths()
+            if hasattr(self.vm, "update_marks_from_checked_paths"):
+                self.vm.update_marks_from_checked_paths(checked_paths)
+
+            from infrastructure.manifest_repository import ManifestRepository
+            updated = ManifestRepository().save(manifest_path, self.vm.groups)
+            logger.info("Manifest decisions saved: {} rows updated", updated)
+            QMessageBox.information(
+                self.parent, "Save Manifest", f"Saved decisions for {updated} file(s)."
+            )
+            self.status_reporter.show_status(f"Manifest saved ({updated} decisions written)")
+
+        except Exception as ex:
+            logger.exception("Save manifest failed: {}", ex)
+            QMessageBox.critical(self.parent, "Save Manifest Error", str(ex))
+            self.status_reporter.show_status("Save manifest failed")
+
     def import_csv(self) -> None:
         """Handle CSV import with file dialog and error handling."""
         path, _ = QFileDialog.getOpenFileName(self.parent, "Import CSV", "", "CSV Files (*.csv)")

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -207,6 +207,8 @@ class MainWindow(QMainWindow):
         """Connect all signal/slot relationships."""
         # Menu action handlers
         handlers = {
+            "open_manifest": self.on_open_manifest,
+            "save_manifest": self.on_save_manifest,
             "import": self.on_import_csv,
             "export": self.on_export_csv,
             "delete": self.on_delete_selected,
@@ -266,6 +268,14 @@ class MainWindow(QMainWindow):
         pass
 
     # PRESERVED: Menu action handlers
+
+    def on_open_manifest(self) -> None:
+        """Handle Open Manifest action."""
+        self.file_operations.import_manifest()
+
+    def on_save_manifest(self) -> None:
+        """Handle Save Manifest Decisions action."""
+        self.file_operations.save_manifest_decisions()
 
     def on_import_csv(self) -> None:
         """Handle CSV import action."""

--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -1,0 +1,164 @@
+"""ManifestRepository — loads REVIEW_DUPLICATE groups from migration_manifest.sqlite
+into PhotoRecord/PhotoGroup objects for the existing Qt review UI.
+
+Load flow:
+  Each REVIEW_DUPLICATE row + its duplicate_of reference → one PhotoGroup (2 items).
+  Reference is locked (is_locked=True) to prevent accidental marking.
+  Candidate is pre-marked (is_mark=True) since the scanner flagged it as likely duplicate.
+
+Save flow:
+  is_mark=True  → action=SKIP,  executed=1  (user confirms it's a duplicate)
+  is_mark=False → action=MOVE,  executed=1  (user decided to keep it)
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+from collections.abc import Iterable, Iterator
+from pathlib import Path
+
+from loguru import logger
+
+from core.models import PhotoGroup, PhotoRecord
+from infrastructure.utils import get_exif_datetime_original, get_filesystem_creation_datetime
+
+_LOAD_SQL = """
+SELECT id, source_path, source_label, duplicate_of, hamming_distance, reason, action, executed
+FROM   migration_manifest
+WHERE  action = 'REVIEW_DUPLICATE'
+ORDER  BY hamming_distance, id
+"""
+
+_REF_SQL = """
+SELECT source_path, source_label, action
+FROM   migration_manifest
+WHERE  source_path = ?
+LIMIT  1
+"""
+
+_SAVE_SQL = """
+UPDATE migration_manifest
+SET    action = ?, executed = 1
+WHERE  source_path = ? AND action IN ('REVIEW_DUPLICATE', 'MOVE', 'SKIP')
+"""
+
+
+def _photo_record(
+    source_path: str,
+    group_number: int,
+    is_mark: bool,
+    is_locked: bool,
+) -> PhotoRecord:
+    """Build a PhotoRecord from a source_path, reading metadata from disk.
+
+    Raises FileNotFoundError if the source file does not exist.
+    """
+    if not Path(source_path).exists():
+        raise FileNotFoundError(f"Source file not found: {source_path}")
+    folder = str(Path(source_path).parent) + os.sep
+    shot = get_exif_datetime_original(source_path)
+    creation = get_filesystem_creation_datetime(source_path)
+    try:
+        size = int(os.path.getsize(source_path))
+    except OSError:
+        size = 0
+    try:
+        mtime = os.path.getmtime(source_path)
+        from datetime import datetime
+        modified = datetime.fromtimestamp(mtime)
+    except OSError:
+        modified = None
+
+    return PhotoRecord(
+        group_number=group_number,
+        is_mark=is_mark,
+        is_locked=is_locked,
+        folder_path=folder,
+        file_path=source_path,
+        capture_date=None,
+        modified_date=modified,
+        file_size_bytes=size,
+        creation_date=creation,
+        shot_date=shot,
+    )
+
+
+class ManifestRepository:
+    """Read REVIEW_DUPLICATE pairs from manifest; write decisions back."""
+
+    # ------------------------------------------------------------------ load
+
+    def load(self, manifest_path: str) -> Iterator[PhotoRecord]:
+        """Yield PhotoRecords for every REVIEW_DUPLICATE pair.
+
+        Each pair uses the manifest row id as group_number so groups remain
+        stable if the manifest is re-opened.
+        """
+        path = Path(manifest_path)
+        if not path.exists():
+            raise FileNotFoundError(f"Manifest not found: {manifest_path}")
+
+        conn = sqlite3.connect(manifest_path)
+        conn.row_factory = sqlite3.Row
+        try:
+            candidates = conn.execute(_LOAD_SQL).fetchall()
+            for row in candidates:
+                group_number = row["id"]
+                already_resolved = row["executed"] == 1
+
+                # Candidate (the near-duplicate flagged by scanner)
+                candidate_marked = row["action"] == "SKIP" or (
+                    row["action"] == "REVIEW_DUPLICATE" and not already_resolved
+                )
+                try:
+                    yield _photo_record(
+                        source_path=row["source_path"],
+                        group_number=group_number,
+                        is_mark=candidate_marked,
+                        is_locked=False,
+                    )
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    logger.warning("Skipping candidate {}: {}", row["source_path"], exc)
+                    continue
+
+                # Reference (the file the scanner kept as authoritative)
+                ref_path = row["duplicate_of"]
+                if not ref_path:
+                    continue
+                try:
+                    yield _photo_record(
+                        source_path=ref_path,
+                        group_number=group_number,
+                        is_mark=False,
+                        is_locked=True,
+                    )
+                except Exception as exc:  # pylint: disable=broad-exception-caught
+                    logger.warning("Skipping reference {}: {}", ref_path, exc)
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------ save
+
+    def save(self, manifest_path: str, groups: Iterable[PhotoGroup]) -> None:
+        """Write user decisions from groups back to the manifest.
+
+        For each non-locked item in each group:
+          is_mark=True  → SKIP  (user confirmed duplicate)
+          is_mark=False → MOVE  (user wants to keep it)
+        """
+        conn = sqlite3.connect(manifest_path)
+        updated = 0
+        try:
+            for group in groups:
+                for rec in group.items:
+                    if rec.is_locked:
+                        continue  # reference file — never change its action
+                    new_action = "SKIP" if rec.is_mark else "MOVE"
+                    cursor = conn.execute(_SAVE_SQL, (new_action, rec.file_path))
+                    updated += cursor.rowcount
+            conn.commit()
+        finally:
+            conn.close()
+        logger.info("Manifest decisions saved: {} rows updated", updated)
+        return updated

--- a/tests/test_manifest_repository.py
+++ b/tests/test_manifest_repository.py
@@ -1,0 +1,217 @@
+"""Tests for infrastructure/manifest_repository.py."""
+
+from __future__ import annotations
+
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from infrastructure.manifest_repository import ManifestRepository
+from core.models import PhotoGroup, PhotoRecord
+
+
+_DDL = """
+CREATE TABLE migration_manifest (
+    id               INTEGER PRIMARY KEY,
+    source_path      TEXT NOT NULL,
+    source_label     TEXT NOT NULL,
+    dest_path        TEXT,
+    action           TEXT NOT NULL,
+    source_hash      TEXT,
+    phash            TEXT,
+    hamming_distance INTEGER,
+    duplicate_of     TEXT,
+    reason           TEXT,
+    executed         INTEGER NOT NULL DEFAULT 0
+);
+"""
+
+
+def _make_manifest(tmp_path: Path, rows: list[dict]) -> Path:
+    db = tmp_path / "manifest.sqlite"
+    with sqlite3.connect(db) as conn:
+        conn.executescript(_DDL)
+        for r in rows:
+            conn.execute(
+                "INSERT INTO migration_manifest "
+                "(source_path, source_label, dest_path, action, hamming_distance, "
+                " duplicate_of, reason, executed) "
+                "VALUES (:source_path, :source_label, :dest_path, :action, "
+                "        :hamming_distance, :duplicate_of, :reason, :executed)",
+                r,
+            )
+        conn.commit()
+    return db
+
+
+def _row(overrides: dict) -> dict:
+    base = {
+        "source_path": "/jdrive/a.jpg",
+        "source_label": "jdrive",
+        "dest_path": None,
+        "action": "REVIEW_DUPLICATE",
+        "hamming_distance": 5,
+        "duplicate_of": "/takeout/a.jpg",
+        "reason": "near-duplicate (hamming=5)",
+        "executed": 0,
+    }
+    return {**base, **overrides}
+
+
+def _ref_row(overrides: dict = {}) -> dict:
+    base = {
+        "source_path": "/takeout/a.jpg",
+        "source_label": "takeout",
+        "dest_path": "2024/20240601_takeout/a.jpg",
+        "action": "MOVE",
+        "hamming_distance": None,
+        "duplicate_of": None,
+        "reason": "unique",
+        "executed": 0,
+    }
+    return {**base, **overrides}
+
+
+def _make_jpeg(path: Path) -> None:
+    from PIL import Image
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (16, 16), (128, 64, 32)).save(path, "JPEG")
+
+
+class TestManifestRepositoryLoad:
+    def test_raises_on_missing_manifest(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            list(ManifestRepository().load(str(tmp_path / "missing.sqlite")))
+
+    def test_returns_two_records_per_pair(self, tmp_path):
+        cand = tmp_path / "jdrive" / "a.jpg"
+        ref = tmp_path / "takeout" / "a.jpg"
+        _make_jpeg(cand)
+        _make_jpeg(ref)
+
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": str(cand), "duplicate_of": str(ref)}),
+            _ref_row({"source_path": str(ref)}),
+        ])
+        records = list(ManifestRepository().load(str(db)))
+        assert len(records) == 2
+
+    def test_candidate_is_pre_marked(self, tmp_path):
+        cand = tmp_path / "jdrive" / "a.jpg"
+        ref = tmp_path / "takeout" / "a.jpg"
+        _make_jpeg(cand)
+        _make_jpeg(ref)
+
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": str(cand), "duplicate_of": str(ref)}),
+            _ref_row({"source_path": str(ref)}),
+        ])
+        records = {r.file_path: r for r in ManifestRepository().load(str(db))}
+        assert records[str(cand)].is_mark is True
+        assert records[str(cand)].is_locked is False
+
+    def test_reference_is_locked_not_marked(self, tmp_path):
+        cand = tmp_path / "jdrive" / "a.jpg"
+        ref = tmp_path / "takeout" / "a.jpg"
+        _make_jpeg(cand)
+        _make_jpeg(ref)
+
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": str(cand), "duplicate_of": str(ref)}),
+            _ref_row({"source_path": str(ref)}),
+        ])
+        records = {r.file_path: r for r in ManifestRepository().load(str(db))}
+        assert records[str(ref)].is_locked is True
+        assert records[str(ref)].is_mark is False
+
+    def test_same_group_number_for_pair(self, tmp_path):
+        cand = tmp_path / "jdrive" / "a.jpg"
+        ref = tmp_path / "takeout" / "a.jpg"
+        _make_jpeg(cand)
+        _make_jpeg(ref)
+
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": str(cand), "duplicate_of": str(ref)}),
+            _ref_row({"source_path": str(ref)}),
+        ])
+        records = list(ManifestRepository().load(str(db)))
+        group_numbers = {r.group_number for r in records}
+        assert len(group_numbers) == 1  # both in same group
+
+    def test_skips_row_with_missing_source_file(self, tmp_path):
+        ref = tmp_path / "takeout" / "a.jpg"
+        _make_jpeg(ref)
+
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": str(tmp_path / "missing.jpg"), "duplicate_of": str(ref)}),
+            _ref_row({"source_path": str(ref)}),
+        ])
+        # Should not raise; missing candidate is skipped gracefully
+        records = list(ManifestRepository().load(str(db)))
+        assert all(r.file_path != str(tmp_path / "missing.jpg") for r in records)
+
+    def test_empty_when_no_review_duplicate_rows(self, tmp_path):
+        db = _make_manifest(tmp_path, [
+            {**_row({}), "action": "MOVE"},
+        ])
+        assert list(ManifestRepository().load(str(db))) == []
+
+
+class TestManifestRepositorySave:
+    def _make_group(self, cand_path: str, ref_path: str, cand_mark: bool) -> PhotoGroup:
+        cand = PhotoRecord(
+            group_number=1, is_mark=cand_mark, is_locked=False,
+            folder_path="", file_path=cand_path,
+            capture_date=None, modified_date=None, file_size_bytes=0,
+        )
+        ref = PhotoRecord(
+            group_number=1, is_mark=False, is_locked=True,
+            folder_path="", file_path=ref_path,
+            capture_date=None, modified_date=None, file_size_bytes=0,
+        )
+        return PhotoGroup(group_number=1, items=[cand, ref])
+
+    def test_marked_candidate_becomes_skip(self, tmp_path):
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": "/jdrive/a.jpg", "duplicate_of": "/takeout/a.jpg"}),
+        ])
+        group = self._make_group("/jdrive/a.jpg", "/takeout/a.jpg", cand_mark=True)
+        ManifestRepository().save(str(db), [group])
+
+        conn = sqlite3.connect(db)
+        row = conn.execute(
+            "SELECT action, executed FROM migration_manifest WHERE source_path = '/jdrive/a.jpg'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "SKIP"
+        assert row[1] == 1
+
+    def test_unmarked_candidate_becomes_move(self, tmp_path):
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": "/jdrive/a.jpg", "duplicate_of": "/takeout/a.jpg"}),
+        ])
+        group = self._make_group("/jdrive/a.jpg", "/takeout/a.jpg", cand_mark=False)
+        ManifestRepository().save(str(db), [group])
+
+        conn = sqlite3.connect(db)
+        row = conn.execute(
+            "SELECT action FROM migration_manifest WHERE source_path = '/jdrive/a.jpg'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "MOVE"
+
+    def test_locked_reference_not_updated(self, tmp_path):
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": "/jdrive/a.jpg", "duplicate_of": "/takeout/a.jpg"}),
+            _ref_row({"source_path": "/takeout/a.jpg"}),
+        ])
+        group = self._make_group("/jdrive/a.jpg", "/takeout/a.jpg", cand_mark=True)
+        ManifestRepository().save(str(db), [group])
+
+        conn = sqlite3.connect(db)
+        row = conn.execute(
+            "SELECT action FROM migration_manifest WHERE source_path = '/takeout/a.jpg'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == "MOVE"  # unchanged


### PR DESCRIPTION
## Summary

- **`File > Open Manifest…`** — loads `REVIEW_DUPLICATE` pairs from `migration_manifest.sqlite` into the existing Qt tree/thumbnail UI
- **`File > Save Manifest Decisions…`** — writes checked/unchecked state back to manifest as `SKIP`/`MOVE`
- Existing preview, thumbnail, mark rules, bulk-select, and lock all work unchanged

## How it fits the workflow

```
scan.py → migration_manifest.sqlite → python main.py (Open Manifest…) → review pairs visually → Save Manifest Decisions → migrate.py
```

## Key design decisions

- `ManifestRepository.load()` yields each `REVIEW_DUPLICATE` row + its `duplicate_of` reference as a 2-item `PhotoGroup`
- Candidate: `is_mark=True` (pre-checked — scanner flagged it as duplicate), `is_locked=False`
- Reference: `is_mark=False`, `is_locked=True` (protected from accidental marking)
- `ManifestRepository.save()` only updates non-locked items (`SKIP` if marked, `MOVE` if cleared)
- `MainVM.load_from_repo(repo, path)` added — supports any repository, not just `CsvPhotoRepository`; existing `load_csv()` unchanged

## Test plan

- [x] 51/51 tests passing (10 new tests for `ManifestRepository`)
- [ ] Manual: run `python main.py`, File > Open Manifest, verify pairs appear with thumbnails
- [ ] Manual: check a candidate, File > Save Manifest Decisions, verify `action=SKIP` in SQLite

🤖 Generated with [Claude Code](https://claude.com/claude-code)