### PR TITLE
fix: UX bugs, dual Set Action entry points, sort aggregation, test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,6 +91,7 @@ logs/
 settings.local.json
 
 # Databases
+*.sqlite
 *.sqlite3
 *.db
 *.db-journal

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -11,7 +11,7 @@
 - **鎖定**: 僅 App 內部狀態，不改動檔案屬性
 - **匯出 FileSize**: 一律重新讀取實體檔案大小，以 Bytes（整數）輸出
 - **資料量級**: 約 20,000 組群、50,000 檔案（需虛擬化、懶載入與快取）
-- **分群來源**: 一律由 CSV 提供；本 App 不做相似/重複分析
+- **分群來源**: 由 migration_manifest.sqlite 提供；本 App 不做相似/重複分析
 - **Select/UnSelect**: 「Select by Field/Regex」對話框支援批次選擇/取消選擇
 - **群組全選刪除策略**: 允許，但跳出強烈警告並需二次確認
 
@@ -31,24 +31,7 @@
 
 ---
 
-## 2. CSV 規格與匯出規則
-
-- 欄位（順序固定）：
-  - `GroupNumber, IsMark, IsLocked, FolderPath, FilePath, Capture Date, Modified Date, Creation Date, Shot Date, FileSize`
-- 匯入：
-  - 標頭對應必須；缺欄/型別錯誤以容錯策略處理並記錄日誌；忽略其他欄位
-  - `FileSize` 欄位若為人類可讀字串（如 "1.44MB"），匯入後將在內部以檔案實際大小覆寫（Bytes），若已經是Bytes（整數），則直接使用
-  - `Capture Date`：沿用舊欄位，視為來源拍攝日期備援
-  - `Creation Date`：以檔案系統建立時間 `os.path.getctime` 取得（Windows 即建立時間）；匯入時若 CSV 無此欄位或空值，內部以檔案系統值覆寫
-  - `Shot Date`：以 EXIF `DateTimeOriginal` 為主；匯入時若 CSV 無此欄位或空值，先嘗試 EXIF；若無 EXIF，則以 `Capture Date` 值備援
-- 匯出：
-  - 欄位順序維持一致
-  - `FileSize` 一律輸出實際檔案大小 Bytes（整數）
-  - 日期欄位一律輸出格式：`YYYY-MM-DD HH:MM:SS`；無值輸出空字串
-
----
-
-## 3. 系統架構
+## 2. 系統架構
 
 - 分層：`App(UI) → Core(商業邏輯) → Infrastructure(IO/外部)`
 - 依賴注入：簡易 Service Locator 或 `dependency-injector`
@@ -57,7 +40,7 @@
 ```mermaid
 flowchart LR
   UI[PySide6 Views/ViewModels] --> Core[Core Services & Rule Engine]
-  Core --> Repo[CSV Repository]
+  Core --> Repo[ManifestRepository]
   Core --> Img[ImageService (Shell/WIC, Cache)]
   Core --> Del[DeleteService (Recycle Bin)]
   Core --> Cfg[Settings]
@@ -80,7 +63,7 @@ photo_manager/
     services/         # 介面與共用服務（I*）
     utils/            # 轉換、比較器、型別輔助
   infrastructure/
-    csv_repository.py # 讀寫 CSV
+    manifest_repository.py # 讀寫 migration_manifest.sqlite
     image_service.py  # 縮圖/原圖載入、快取、Shell/WIC
     delete_service.py # 回收桶刪除、檢查
     settings.py       # 設定載入/驗證
@@ -118,7 +101,7 @@ photo_manager/
 | 欄位 | 來源 | 用途 | 可變？ |
 |------|------|------|-------|
 | `action` | Scanner 寫入，manifest 載入 | 分類標籤（col 0 Match 顯示依據） | 否（唯讀）|
-| `user_decision` | 使用者透過 Set Action 設定 | 實際檔案操作（col 8 Action 顯示依據）| 是 |
+| `user_decision` | 使用者透過 Set Action 設定 | 實際檔案操作（col 2 Action 顯示依據）| 是 |
 
 ---
 
@@ -151,7 +134,7 @@ photo_manager/
 對話框提供簡化批次選擇/取消選擇能力（Rule v0 為「UI-based Selection Rules」）：
 
 - 元件：
-  - 下拉選單 `Field`：列出主清單顯示的所有欄位（如 Group、File Name、Folder、Size(Bytes) 等可匹配項）
+  - 下拉選單 `Field`：列出主清單顯示的所有欄位（如 Match、Action、File Name、Folder、Size(Bytes)、Group Count、Creation Date、Shot Date 等可匹配項）
   - 文字框 `Regex`：接受使用者輸入，支援標準正則（RE），即時校驗格式
   - 按鈕：`Select`、`Unselect`
 - 行為：
@@ -174,10 +157,10 @@ photo_manager/
   - 預覽捲動：若影像高度大於可見高度，使用垂直捲動條以完整檢視
 - 操作：
   - 勾選/取消勾選（Selected）
-  - 功能表：`File > Import/Export/ Delete Selected…`、`Select > Select by Field/Regex/…`
+  - 功能表：`File > Delete Selected…`、`File > Set Action to Activated Files > delete/keep`、`File > Set Action to Selected (Sel) Files > delete/keep`、`Select > Select by Field/Regex/…`
   - 刪除：
     - 摘要：顯示受影響群組/全部群組、將刪除檔案/總檔案；若包含全選群組，列出群組清單並需勾選同意
-    - 執行：送回收桶（略過 locked）；寫刪除 CSV；自清單移除成功刪除檔案；移除僅剩單檔之群組；詢問是否覆寫來源 CSV
+    - 執行：送回收桶（略過 locked）；自清單移除成功刪除檔案；移除僅剩單檔之群組
 - 虛擬化與懶載入：
   - 群組先載入索引，展開時才載入子項（可選）
   - 縮圖在可見範圍內懶載入，背景預取鄰近項
@@ -269,7 +252,7 @@ photo_manager/
 ## 16. 里程碑與 DoD
 
 - M1 最小可用版本（Week 1）
-  - 匯入/匯出 CSV、群組樹與列表（檔案列具 Selected 勾選）、單/群縮圖預覽（含快取）、基本排序（Qt 內建）、Select 對話框（Field/Regex 的 Select/Unselect）、刪除（摘要/強制確認/回收桶/自動 CSV Log/清單修剪/詢問覆寫 CSV）
+  - 載入 manifest、群組樹與列表（檔案列具 Selected 勾選）、單/群縮圖預覽（含快取）、基本排序（Qt 內建）、Select 對話框（Field/Regex 的 Select/Unselect）、Set Action via Activated Files 或 Selected (Sel) Files（delete/keep）、Save Manifest Decisions（另存新檔對話框）、Execute Action（回收桶/清單修剪）
   - DoD：50k 筆可順暢瀏覽與基本操作；文件與打包指引齊備
 - M2 穩定與優化（Week 2）
   - 進階篩選、更多聚合器、設定面板、操作日誌匯出、UI 優化
@@ -296,11 +279,12 @@ GroupNumber,IsMark,IsLocked,FolderPath,FilePath,Capture Date,Modified Date,FileS
 
 ## 19. 定義與術語
 
-- **Selected（Sel）**：UI Sel 勾選框狀態，用於批次操作目標選擇
+- **Activated Files（Highlighted）**：樹狀視圖中以點擊或多選反白的列（`QTreeView` selectionModel rows）；透過 `File > Set Action to Activated Files` 批次設定 user_decision
+- **Selected（Sel）**：UI Sel 勾選框狀態，用於批次操作目標選擇；透過 `File > Set Action to Selected (Sel) Files` 批次設定 user_decision
 - **Marked（IsMark）**：`is_mark == True`（CSV workflow 使用；manifest workflow 中由 Sel 取代）
 - **Locked（IsLocked）**：`is_locked == True`（僅 App 內狀態；Delete service 跳過 locked 項目；manifest workflow 中目前一律為 False）
 - **action**：Scanner 分類（`EXACT` / `REVIEW_DUPLICATE` / `MOVE` / `KEEP` / `UNDATED`）；唯讀，col 0 "Match" 顯示
-- **user_decision**：使用者決定（`"delete"` / `"keep"` / `""`）；col 8 "Action" 顯示；透過 Set Action 設定
+- **user_decision**：使用者決定（`"delete"` / `"keep"` / `""` / `"removed"`）；col 2 "Action" 顯示；透過 Set Action 設定；`"removed"` 為系統內部哨兵值，表示已從審查清單移除
 
 ---
 
@@ -377,7 +361,7 @@ python scan.py ... --limit 200 --dry-run   # bounded debug run
 | `hamming_distance` | INTEGER | Distance to `duplicate_of`'s phash |
 | `duplicate_of` | TEXT | source_path of kept file |
 | `executed` | INTEGER | 0=pending 1=done |
-| `user_decision` | TEXT | User's planned file operation: `delete` / `keep` / `""` (undecided) |
+| `user_decision` | TEXT | User's planned file operation: `delete` / `keep` / `""` (undecided) / `"removed"` (hidden from review) |
 
 `user_decision` is added automatically to older manifests (pre-existing DBs
 lacking the column are migrated via `ALTER TABLE … ADD COLUMN` on first load).

--- a/README.md
+++ b/README.md
@@ -18,9 +18,10 @@ Produces `migration_manifest.sqlite` consumed by **[photo-transfer](https://gith
 │  2. REVIEW (photo-manager)                                                  │
 │     GUI: File > Open Manifest…                                              │
 │     Inspect every group — col 0 shows match type (exact / similar / empty) │
-│     Mark files with Sel checkboxes, then use                               │
-│       File > Set Action > delete / keep  to record your decision           │
-│     Right-click a single file → Set Action → delete / keep (per-file)     │
+│     Mark files with Sel checkboxes or highlight rows, then use            │
+│       File > Set Action to Selected (Sel) Files > delete / keep           │
+│       File > Set Action to Activated Files > delete / keep                │
+│     Right-click a single file → Set Action → delete / keep (per-file)    │
 │     File > Save Manifest Decisions… persists decisions to the manifest     │
 │                                                                             │
 │     CLI alternative: python review.py … for REVIEW_DUPLICATE triage       │
@@ -100,18 +101,21 @@ The tree shows all files loaded from the manifest.
 |--------|---------|
 | **Match** (col 0) | Scanner-assigned match type: `exact` / `similar` / *(empty for unmatched)* |
 | **Sel** | Checkbox — select files for batch actions |
-| **Action** (col 8) | Your decision: `delete` / `keep` / *(empty = undecided)* |
+| **Action** (col 2) | Your decision: `delete` / `keep` / *(empty = undecided)* |
 
 **Setting decisions:**
 
 - *Per file*: right-click a file → **Set Action → delete** or **keep**.
-- *Batch*: tick **Sel** on the files you want to act on, then
-  **File › Set Action › delete** (or **keep**) applies to all checked files.
+- *By Sel checkboxes*: tick **Sel** on the files you want, then
+  **File › Set Action to Selected (Sel) Files › delete** (or **keep**).
+- *By highlight*: click or multi-select rows in the tree, then
+  **File › Set Action to Activated Files › delete** (or **keep**).
 
 ### Step 3 — Save decisions
 
-**File › Save Manifest Decisions…** writes `delete` / `keep` decisions back
-to the SQLite manifest.  Decisions persist across sessions.
+**File › Save Manifest Decisions…** opens a file picker. Choose the same
+path to save in-place or a new path to export a copy. Decisions are written
+to the chosen file, and subsequent saves default to that location.
 
 ### Step 4 — Execute actions
 
@@ -229,7 +233,7 @@ photo-manager/
 │   │   └── workers/
 │   │       └── scan_worker.py         # Background QThread for scan pipeline
 │   └── viewmodels/
-│       └── main_vm.py       # Groups/marks logic; loads CSV or manifest
+│       └── main_vm.py       # Groups/marks logic; loads manifest
 │
 ├── core/                    # Models + service interfaces
 │   └── models.py            # PhotoRecord (action, user_decision), PhotoGroup
@@ -238,7 +242,7 @@ photo-manager/
 │
 ├── settings.json            # User configuration (source paths, thumbnail cache, …)
 │
-└── tests/                   # 190+ tests — scanner, infra, viewmodel, GUI handlers
+└── tests/                   # 200+ tests — scanner, infra, viewmodel, GUI handlers
     ├── conftest.py              # Shared fixtures (qapp)
     ├── test_dedup.py
     ├── test_hasher.py
@@ -247,12 +251,13 @@ photo-manager/
     ├── test_manifest_repository.py
     ├── test_settings.py
     ├── test_utils.py
-    ├── test_csv_repository.py
     ├── test_delete_service.py
     ├── test_scanner_exif.py
     ├── test_scanner_manifest.py
     ├── test_main_vm.py
-    ├── test_file_operations.py  # set_decision, batch_set_decision
+    ├── test_file_operations.py  # set_decision, batch_set_decision, set_decision_to_highlighted
+    ├── test_sort_service.py
+    ├── test_selection_service.py
     ├── test_execute_action_dialog.py
     └── test_context_menu.py
 ```

--- a/app/views/components/menu_controller.py
+++ b/app/views/components/menu_controller.py
@@ -43,11 +43,16 @@ class MenuController:
         self.actions["save_manifest"].setEnabled(False)
         file_menu.addSeparator()
         self.actions["delete"] = file_menu.addAction("Delete Selected…")
-        set_action_submenu = file_menu.addMenu("Set Action")
-        set_action_submenu.setEnabled(False)
-        self.actions["set_action_delete"] = set_action_submenu.addAction("delete")
-        self.actions["set_action_keep"] = set_action_submenu.addAction("keep")
-        self._set_action_submenu = set_action_submenu
+        hl_submenu = file_menu.addMenu("Set Action to Activated Files")
+        hl_submenu.setEnabled(False)
+        self.actions["set_action_hl_delete"] = hl_submenu.addAction("delete")
+        self.actions["set_action_hl_keep"] = hl_submenu.addAction("keep")
+        self._set_action_hl_submenu = hl_submenu
+        sel_submenu = file_menu.addMenu("Set Action to Selected (Sel) Files")
+        sel_submenu.setEnabled(False)
+        self.actions["set_action_sel_delete"] = sel_submenu.addAction("delete")
+        self.actions["set_action_sel_keep"] = sel_submenu.addAction("keep")
+        self._set_action_sel_submenu = sel_submenu
         self.actions["execute_action"] = file_menu.addAction("Execute Action…")
         self.actions["execute_action"].setEnabled(False)
         file_menu.addSeparator()
@@ -98,11 +103,17 @@ class MenuController:
         if "delete" in handlers:
             self.actions["delete"].triggered.connect(handlers["delete"])
 
-        if "set_action_delete" in handlers:
-            self.actions["set_action_delete"].triggered.connect(handlers["set_action_delete"])
+        if "set_action_hl_delete" in handlers:
+            self.actions["set_action_hl_delete"].triggered.connect(handlers["set_action_hl_delete"])
 
-        if "set_action_keep" in handlers:
-            self.actions["set_action_keep"].triggered.connect(handlers["set_action_keep"])
+        if "set_action_hl_keep" in handlers:
+            self.actions["set_action_hl_keep"].triggered.connect(handlers["set_action_hl_keep"])
+
+        if "set_action_sel_delete" in handlers:
+            self.actions["set_action_sel_delete"].triggered.connect(handlers["set_action_sel_delete"])
+
+        if "set_action_sel_keep" in handlers:
+            self.actions["set_action_sel_keep"].triggered.connect(handlers["set_action_sel_keep"])
 
         if "execute_action" in handlers:
             self.actions["execute_action"].triggered.connect(handlers["execute_action"])
@@ -159,9 +170,13 @@ class MenuController:
         action = self.actions.get(name)
         if action:
             action.setEnabled(enabled)
-        # Keep the Set Action submenu in sync with its children
-        if name in ("set_action_delete", "set_action_keep"):
-            submenu = getattr(self, "_set_action_submenu", None)
+        # Keep parent submenus in sync with their child actions
+        if name in ("set_action_hl_delete", "set_action_hl_keep"):
+            submenu = getattr(self, "_set_action_hl_submenu", None)
+            if submenu is not None:
+                submenu.setEnabled(enabled)
+        elif name in ("set_action_sel_delete", "set_action_sel_keep"):
+            submenu = getattr(self, "_set_action_sel_submenu", None)
             if submenu is not None:
                 submenu.setEnabled(enabled)
 

--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -52,6 +52,7 @@ class FileOperationsHandler:
         ui_updater: UIUpdateCallback,
         status_reporter: StatusReporter,
         checked_paths_provider: object | None = None,
+        highlighted_items_provider: object | None = None,
     ) -> None:
         self.vm = vm
         self.deleter = delete_service
@@ -61,6 +62,8 @@ class FileOperationsHandler:
         self.status_reporter = status_reporter
         # Optional callable or object with gather_checked_paths() to pull UI state
         self.checked_paths_provider = checked_paths_provider
+        # Optional callable returning list[dict] of highlighted (tree-selected) items
+        self.highlighted_items_provider = highlighted_items_provider
 
     def import_manifest(self) -> None:
         """Open a migration_manifest.sqlite and load REVIEW_DUPLICATE groups."""
@@ -78,12 +81,18 @@ class FileOperationsHandler:
             self.ui_updater.show_groups_summary(self.vm.groups)
             self.ui_updater.refresh_tree(self.vm.groups)
 
-            # Enable "Save Manifest Decisions" and remember the open manifest path
+            # Enable manifest-dependent menu actions
             self._manifest_path = path
-            try:
-                self.parent.menu_controller.enable_action("save_manifest", True)
-            except AttributeError:
-                pass
+            _manifest_actions = (
+                "save_manifest", "execute_action",
+                "set_action_hl_delete", "set_action_hl_keep",
+                "set_action_sel_delete", "set_action_sel_keep",
+            )
+            for _act in _manifest_actions:
+                try:
+                    self.parent.menu_controller.enable_action(_act, True)
+                except AttributeError:
+                    pass
 
             n_groups = self.vm.group_count
             n_items = sum(len(g.items) for g in self.vm.groups)
@@ -98,10 +107,22 @@ class FileOperationsHandler:
             self.status_reporter.show_status("Open manifest failed")
 
     def save_manifest_decisions(self) -> None:
-        """Write current is_mark state back to the open manifest."""
+        """Export current decisions to a (possibly new) manifest file."""
+        import os
+        import shutil
+
         manifest_path = getattr(self, "_manifest_path", None)
         if not manifest_path:
             QMessageBox.information(self.parent, "Save Manifest", "No manifest open.")
+            return
+
+        save_path, _ = QFileDialog.getSaveFileName(
+            self.parent,
+            "Save Manifest Decisions",
+            manifest_path,
+            "SQLite Files (*.sqlite *.db);;All Files (*)",
+        )
+        if not save_path:
             return
 
         try:
@@ -116,9 +137,16 @@ class FileOperationsHandler:
             if hasattr(self.vm, "update_marks_from_checked_paths"):
                 self.vm.update_marks_from_checked_paths(checked_paths)
 
+            # Copy manifest to new location if saving elsewhere
+            if os.path.normcase(os.path.normpath(save_path)) != os.path.normcase(
+                os.path.normpath(manifest_path)
+            ):
+                shutil.copy2(manifest_path, save_path)
+
             from infrastructure.manifest_repository import ManifestRepository
-            updated = ManifestRepository().save(manifest_path, self.vm.groups)
-            logger.info("Manifest decisions saved: {} rows updated", updated)
+            updated = ManifestRepository().save(save_path, self.vm.groups)
+            self._manifest_path = save_path
+            logger.info("Manifest decisions saved to {}: {} rows updated", save_path, updated)
             QMessageBox.information(
                 self.parent, "Save Manifest", f"Saved decisions for {updated} file(s)."
             )
@@ -385,6 +413,25 @@ class FileOperationsHandler:
                     count += 1
         self.ui_updater.refresh_tree(self.vm.groups)
         self.status_reporter.show_status(f"Set '{new_decision}' for {count} file(s)")
+
+    def set_decision_to_highlighted(self, new_decision: str) -> None:
+        """Set user_decision for tree-highlighted (activated) file rows."""
+        manifest_path = getattr(self, "_manifest_path", None)
+        if not manifest_path:
+            QMessageBox.information(self.parent, "Set Action", "No manifest loaded.")
+            return
+        items: list[dict] = []
+        provider = self.highlighted_items_provider
+        if provider is not None:
+            if callable(provider):
+                items = provider()
+            elif hasattr(provider, "get_selected_items"):
+                items = provider.get_selected_items()
+        file_items = [it for it in items if it.get("type") == "file"]
+        if not file_items:
+            QMessageBox.information(self.parent, "Set Action", "No activated files.")
+            return
+        self.set_decision(file_items, new_decision)
 
     def execute_action(self) -> None:
         """Open the Execute Action review dialog and run planned operations."""

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -111,6 +111,7 @@ class MainWindow(QMainWindow):
             ui_updater=self.ui_updater,
             status_reporter=self.status_reporter,
             checked_paths_provider=self.selection_controller,
+            highlighted_items_provider=self.tree_controller,
         )
 
         # Tree data provider for dialog handler
@@ -187,8 +188,10 @@ class MainWindow(QMainWindow):
             "open_manifest": self.on_open_manifest,
             "save_manifest": self.on_save_manifest,
             "delete": self.on_delete_selected,
-            "set_action_delete": lambda: self.file_operations.batch_set_decision("delete"),
-            "set_action_keep": lambda: self.file_operations.batch_set_decision("keep"),
+            "set_action_hl_delete": lambda: self.file_operations.set_decision_to_highlighted("delete"),
+            "set_action_hl_keep": lambda: self.file_operations.set_decision_to_highlighted("keep"),
+            "set_action_sel_delete": lambda: self.file_operations.batch_set_decision("delete"),
+            "set_action_sel_keep": lambda: self.file_operations.batch_set_decision("keep"),
             "execute_action": self.on_execute_action,
             "select_by": self.on_open_select_dialog,
             "remove_from_list": self._remove_from_list_toolbar,
@@ -270,7 +273,11 @@ class MainWindow(QMainWindow):
             except AttributeError:
                 pass
             n = self._vm.group_count
-            for _act in ("execute_action", "set_action_delete", "set_action_keep"):
+            for _act in (
+                "execute_action",
+                "set_action_hl_delete", "set_action_hl_keep",
+                "set_action_sel_delete", "set_action_sel_keep",
+            ):
                 try:
                     self.menu_controller.enable_action(_act, True)
                 except AttributeError:

--- a/app/views/tree_model_builder.py
+++ b/app/views/tree_model_builder.py
@@ -101,10 +101,14 @@ def build_model(
         for it in group_row:
             it.setEditable(False)
 
-        # Group-level SORT_ROLE: representative value from the first item
+        # Group-level SORT_ROLE: aggregate across all files so that sorting a column
+        # reorders groups by their "best" file's value (first file after in-group sort).
+        # Min-priority wins for ranked fields (delete=1 < keep=2 < ""=3); max wins for size.
         try:
             group_row[COL_GROUP].setData(
-                _ACTION_SORT.get(getattr(first, "action", ""), 6) if first else 6, SORT_ROLE
+                min((_ACTION_SORT.get(getattr(it, "action", ""), 6) for it in items_list),
+                    default=6),
+                SORT_ROLE,
             )
         except Exception:
             pass
@@ -115,24 +119,35 @@ def build_model(
             pass
         try:
             group_row[COL_ACTION].setData(
-                _DECISION_SORT.get(getattr(first, "user_decision", ""), 3) if first else 3,
+                min((_DECISION_SORT.get(getattr(it, "user_decision", ""), 3)
+                     for it in items_list),
+                    default=3),
                 SORT_ROLE,
             )
         except Exception:
             pass
         try:
-            first_name = Path(getattr(first, "file_path", "")).name.lower() if first else ""
-            group_row[COL_NAME].setData(first_name, SORT_ROLE)
+            group_row[COL_NAME].setData(
+                min((Path(getattr(it, "file_path", "")).name.lower() for it in items_list),
+                    default=""),
+                SORT_ROLE,
+            )
         except Exception:
             pass
         try:
-            first_folder = str(getattr(first, "folder_path", "")).lower() if first else ""
-            group_row[COL_FOLDER].setData(first_folder, SORT_ROLE)
+            group_row[COL_FOLDER].setData(
+                min((str(getattr(it, "folder_path", "")).lower() for it in items_list),
+                    default=""),
+                SORT_ROLE,
+            )
         except Exception:
             pass
         try:
-            first_size = int(getattr(first, "file_size_bytes", 0) or 0) if first else 0
-            group_row[COL_SIZE_BYTES].setData(first_size, SORT_ROLE)
+            group_row[COL_SIZE_BYTES].setData(
+                max((int(getattr(it, "file_size_bytes", 0) or 0) for it in items_list),
+                    default=0),
+                SORT_ROLE,
+            )
         except Exception:
             pass
         try:
@@ -140,17 +155,21 @@ def build_model(
         except Exception:
             pass
         try:
-            first_cd = getattr(first, "creation_date", None) if first else None
-            group_row[COL_CREATION_DATE].setData(
-                int(first_cd.timestamp()) if first_cd else 0, SORT_ROLE
-            )
+            cd_timestamps = [
+                int(cd.timestamp())
+                for it in items_list
+                if (cd := getattr(it, "creation_date", None)) is not None
+            ]
+            group_row[COL_CREATION_DATE].setData(min(cd_timestamps, default=0), SORT_ROLE)
         except Exception:
             pass
         try:
-            first_sd = getattr(first, "shot_date", None) if first else None
-            group_row[COL_SHOT_DATE].setData(
-                int(first_sd.timestamp()) if first_sd else 0, SORT_ROLE
-            )
+            sd_timestamps = [
+                int(sd.timestamp())
+                for it in items_list
+                if (sd := getattr(it, "shot_date", None)) is not None
+            ]
+            group_row[COL_SHOT_DATE].setData(min(sd_timestamps, default=0), SORT_ROLE)
         except Exception:
             pass
 

--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -251,5 +251,6 @@ class ManifestRepository:
         try:
             conn.executemany(_REMOVE_FROM_REVIEW_SQL, [(p,) for p in file_paths])
             conn.commit()
+            conn.execute("VACUUM")
         finally:
             conn.close()

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -61,7 +61,7 @@ def _rec(path: str, group: int = 1, decision: str = "") -> PhotoRecord:
     )
 
 
-def _make_handler(vm, manifest_path: str | None, checked_paths=None):
+def _make_handler(vm, manifest_path: str | None, checked_paths=None, highlighted_items=None):
     """Build a FileOperationsHandler with all Qt deps mocked."""
     from app.views.handlers.file_operations import FileOperationsHandler
 
@@ -78,6 +78,7 @@ def _make_handler(vm, manifest_path: str | None, checked_paths=None):
         ui_updater=ui_updater,
         status_reporter=status_reporter,
         checked_paths_provider=checked_paths,
+        highlighted_items_provider=highlighted_items,
     )
     if manifest_path:
         handler._manifest_path = manifest_path
@@ -364,3 +365,134 @@ class TestRemoveFromList:
         handler.batch_set_decision("delete")
 
         assert recs[0].user_decision == "delete"
+
+
+# ── set_decision_to_highlighted ───────────────────────────────────────────────
+
+class TestSetDecisionToHighlighted:
+    def test_sets_decision_for_highlighted_files(self, tmp_path):
+        recs = [_rec("/a.jpg"), _rec("/b.jpg")]
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=recs)])
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}, {"source_path": "/b.jpg"}])
+        hl_provider = lambda: [{"type": "file", "path": "/a.jpg"}]
+        handler, _, _ = _make_handler(vm, str(db), highlighted_items=hl_provider)
+
+        handler.set_decision_to_highlighted("keep")
+
+        assert recs[0].user_decision == "keep"
+        assert recs[1].user_decision == ""
+
+    def test_updates_sqlite_for_highlighted_files(self, tmp_path):
+        recs = [_rec("/a.jpg"), _rec("/b.jpg")]
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=recs)])
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}, {"source_path": "/b.jpg"}])
+        hl_provider = lambda: [{"type": "file", "path": "/a.jpg"}]
+        handler, _, _ = _make_handler(vm, str(db), highlighted_items=hl_provider)
+
+        handler.set_decision_to_highlighted("delete")
+
+        assert _read_decision(db, "/a.jpg") == "delete"
+        assert _read_decision(db, "/b.jpg") == ""
+
+    @patch("PySide6.QtWidgets.QMessageBox.information")
+    def test_skips_group_type_items(self, _mock, tmp_path):
+        recs = [_rec("/a.jpg")]
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=recs)])
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
+        hl_provider = lambda: [{"type": "group", "group_number": 1}]
+        handler, _, _ = _make_handler(vm, str(db), highlighted_items=hl_provider)
+
+        handler.set_decision_to_highlighted("delete")
+
+        assert recs[0].user_decision == ""
+
+    @patch("PySide6.QtWidgets.QMessageBox.information")
+    def test_no_manifest_noop(self, _mock, tmp_path):
+        recs = [_rec("/a.jpg")]
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=recs)])
+        hl_provider = lambda: [{"type": "file", "path": "/a.jpg"}]
+        handler, ui_updater, _ = _make_handler(vm, manifest_path=None, highlighted_items=hl_provider)
+
+        handler.set_decision_to_highlighted("delete")
+
+        assert recs[0].user_decision == ""
+        ui_updater.refresh_tree.assert_not_called()
+
+    def test_no_highlighted_files_shows_message(self, tmp_path):
+        recs = [_rec("/a.jpg")]
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=recs)])
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
+        hl_provider = lambda: []
+        handler, _, _ = _make_handler(vm, str(db), highlighted_items=hl_provider)
+
+        with patch("PySide6.QtWidgets.QMessageBox.information"):
+            handler.set_decision_to_highlighted("delete")
+
+        assert recs[0].user_decision == ""
+
+    def test_provider_with_get_selected_items_method(self, tmp_path):
+        """highlighted_items_provider can be an object with get_selected_items()."""
+        recs = [_rec("/a.jpg")]
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=recs)])
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
+        provider = SimpleNamespace(get_selected_items=lambda: [{"type": "file", "path": "/a.jpg"}])
+        handler, _, _ = _make_handler(vm, str(db), highlighted_items=provider)
+
+        handler.set_decision_to_highlighted("keep")
+
+        assert recs[0].user_decision == "keep"
+
+
+# ── save_manifest_decisions ───────────────────────────────────────────────────
+
+class TestSaveManifestDecisions:
+    @patch("PySide6.QtWidgets.QMessageBox.information")
+    def test_saves_to_same_path_in_place(self, _mock, tmp_path):
+        """Saving to the same file writes decisions without copying."""
+        recs = [_rec("/a.jpg", decision="keep")]
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=recs)])
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
+        handler, _, _ = _make_handler(vm, str(db))
+
+        with patch("PySide6.QtWidgets.QFileDialog.getSaveFileName", return_value=(str(db), "")):
+            handler.save_manifest_decisions()
+
+        assert _read_decision(db, "/a.jpg") == "keep"
+        assert handler._manifest_path == str(db)
+
+    @patch("PySide6.QtWidgets.QMessageBox.information")
+    def test_saves_to_different_path_copies_and_writes(self, _mock, tmp_path):
+        """Saving to a new path copies the source manifest and writes decisions."""
+        recs = [_rec("/a.jpg", decision="delete")]
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=recs)])
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
+        new_path = str(tmp_path / "exported.sqlite")
+        handler, _, _ = _make_handler(vm, str(db))
+
+        with patch("PySide6.QtWidgets.QFileDialog.getSaveFileName", return_value=(new_path, "")):
+            handler.save_manifest_decisions()
+
+        assert _read_decision(Path(new_path), "/a.jpg") == "delete"
+        assert handler._manifest_path == new_path
+
+    def test_dialog_cancel_is_noop(self, tmp_path):
+        """Cancelling the save dialog leaves the manifest unchanged."""
+        recs = [_rec("/a.jpg")]
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=recs)])
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
+        handler, _, _ = _make_handler(vm, str(db))
+
+        with patch("PySide6.QtWidgets.QFileDialog.getSaveFileName", return_value=("", "")):
+            handler.save_manifest_decisions()
+
+        assert _read_decision(db, "/a.jpg") == ""
+
+    def test_no_manifest_shows_message(self, tmp_path):
+        """With no manifest open, shows an info dialog and returns."""
+        vm = SimpleNamespace(groups=[])
+        handler, _, _ = _make_handler(vm, manifest_path=None)
+
+        with patch("PySide6.QtWidgets.QMessageBox.information") as mock_info:
+            handler.save_manifest_decisions()
+
+        mock_info.assert_called_once()

--- a/tests/test_manifest_repository.py
+++ b/tests/test_manifest_repository.py
@@ -543,3 +543,51 @@ class TestRemoveFromReview:
         paths = {r.file_path for r in records}
         assert str(cand) not in paths
         assert str(ref) in paths   # ref's own MOVE row now loads as standalone
+
+
+class TestMarkExecuted:
+    def _read_executed(self, db, path: str) -> int:
+        import sqlite3 as _sq
+        with _sq.connect(db) as conn:
+            row = conn.execute(
+                "SELECT executed FROM migration_manifest WHERE source_path = ?", (path,)
+            ).fetchone()
+        return row[0] if row else -1
+
+    def test_marks_single_path_executed(self, tmp_path):
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": "/a.jpg", "action": "MOVE",
+                  "duplicate_of": None, "hamming_distance": None}),
+        ])
+        ManifestRepository().mark_executed(str(db), ["/a.jpg"])
+        assert self._read_executed(db, "/a.jpg") == 1
+
+    def test_marks_multiple_paths(self, tmp_path):
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": "/a.jpg", "action": "MOVE",
+                  "duplicate_of": None, "hamming_distance": None}),
+            _row({"source_path": "/b.jpg", "action": "MOVE",
+                  "duplicate_of": None, "hamming_distance": None}),
+        ])
+        ManifestRepository().mark_executed(str(db), ["/a.jpg", "/b.jpg"])
+        assert self._read_executed(db, "/a.jpg") == 1
+        assert self._read_executed(db, "/b.jpg") == 1
+
+    def test_noop_for_unknown_path(self, tmp_path):
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": "/a.jpg", "action": "MOVE",
+                  "duplicate_of": None, "hamming_distance": None}),
+        ])
+        ManifestRepository().mark_executed(str(db), ["/does_not_exist.jpg"])
+        assert self._read_executed(db, "/a.jpg") == 0
+
+    def test_does_not_affect_other_rows(self, tmp_path):
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": "/a.jpg", "action": "MOVE",
+                  "duplicate_of": None, "hamming_distance": None}),
+            _row({"source_path": "/b.jpg", "action": "MOVE",
+                  "duplicate_of": None, "hamming_distance": None}),
+        ])
+        ManifestRepository().mark_executed(str(db), ["/a.jpg"])
+        assert self._read_executed(db, "/a.jpg") == 1
+        assert self._read_executed(db, "/b.jpg") == 0

--- a/tests/test_selection_service.py
+++ b/tests/test_selection_service.py
@@ -1,0 +1,129 @@
+"""Tests for core.services.selection_service.RegexSelectionService."""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from core.services.selection_service import RegexSelectionService
+
+
+# ── fake accessor ──────────────────────────────────────────────────────────────
+
+_GROUP_LEVEL = frozenset({"Match", "Group Count"})
+
+
+class _Group:
+    def __init__(self, group_text: str, count_text: str, children: list[dict]) -> None:
+        self.group_text = group_text
+        self.count_text = count_text
+        self.children = children  # list of {field: value}
+
+
+class FakeAccessor:
+    def __init__(self, groups: list[_Group]) -> None:
+        self._groups = groups
+        self.checked: set[tuple[int, int]] = set()
+
+    def iter_groups(self) -> list[_Group]:
+        return self._groups
+
+    def iter_children(self, group: _Group) -> list[int]:
+        return list(range(len(group.children)))
+
+    def get_field_text(self, group: _Group, child: int | None, field_name: str) -> str | None:
+        if child is None:
+            if field_name not in _GROUP_LEVEL:
+                return None
+            if field_name == "Match":
+                return group.group_text
+            if field_name == "Group Count":
+                return group.count_text
+            return None
+        return group.children[child].get(field_name, "")
+
+    def set_checked(self, group: _Group, child: int, checked: bool) -> None:
+        gidx = self._groups.index(group)
+        key = (gidx, child)
+        if checked:
+            self.checked.add(key)
+        else:
+            self.checked.discard(key)
+
+
+def _svc(*groups: _Group) -> tuple[RegexSelectionService, FakeAccessor]:
+    acc = FakeAccessor(list(groups))
+    return RegexSelectionService(acc), acc
+
+
+# ── tests ──────────────────────────────────────────────────────────────────────
+
+class TestGroupLevelField:
+    def test_match_selects_all_children(self):
+        g = _Group("EXACT", "3", [{"Action": ""}, {"Action": ""}, {"Action": ""}])
+        svc, acc = _svc(g)
+        svc.apply("Match", "EXACT", True)
+        assert acc.checked == {(0, 0), (0, 1), (0, 2)}
+
+    def test_no_match_skips_group(self):
+        g = _Group("MOVE", "1", [{"Action": ""}])
+        svc, acc = _svc(g)
+        svc.apply("Match", "EXACT", True)
+        assert acc.checked == set()
+
+    def test_uncheck_clears_children(self):
+        g = _Group("EXACT", "2", [{"Action": ""}, {"Action": ""}])
+        svc, acc = _svc(g)
+        acc.checked = {(0, 0), (0, 1)}
+        svc.apply("Match", "EXACT", False)
+        assert acc.checked == set()
+
+
+class TestFileLevelField:
+    def test_selects_matching_child_only(self):
+        g = _Group("EXACT", "2", [
+            {"Action": "delete"},
+            {"Action": "keep"},
+        ])
+        svc, acc = _svc(g)
+        svc.apply("Action", "delete", True)
+        assert acc.checked == {(0, 0)}
+
+    def test_uncheck_leaves_non_matching(self):
+        g = _Group("EXACT", "2", [
+            {"Action": "delete"},
+            {"Action": "keep"},
+        ])
+        svc, acc = _svc(g)
+        acc.checked = {(0, 0), (0, 1)}
+        svc.apply("Action", "delete", False)
+        assert acc.checked == {(0, 1)}  # keep child untouched
+
+    def test_empty_text_skipped(self):
+        """Children with empty text are never matched regardless of pattern."""
+        g = _Group("MOVE", "1", [{"Action": ""}])
+        svc, acc = _svc(g)
+        svc.apply("Action", ".*", True)
+        assert acc.checked == set()
+
+    def test_multiple_groups_file_level(self):
+        g1 = _Group("EXACT", "1", [{"File Name": "photo.jpg"}])
+        g2 = _Group("MOVE", "1", [{"File Name": "video.mp4"}])
+        svc, acc = _svc(g1, g2)
+        svc.apply("File Name", r"\.jpg$", True)
+        assert acc.checked == {(0, 0)}
+        assert (1, 0) not in acc.checked
+
+
+class TestEdgeCases:
+    def test_invalid_regex_raises(self):
+        g = _Group("EXACT", "1", [{"Action": "delete"}])
+        svc, _ = _svc(g)
+        with pytest.raises(re.error):
+            svc.apply("Action", "[invalid", True)
+
+    def test_empty_groups_noop(self):
+        svc, acc = _svc()
+        svc.apply("Match", ".*", True)
+        assert acc.checked == set()

--- a/tests/test_sort_service.py
+++ b/tests/test_sort_service.py
@@ -1,0 +1,70 @@
+"""Tests for core.services.sort_service.SortService."""
+
+from __future__ import annotations
+
+from core.models import PhotoGroup, PhotoRecord
+from core.services.sort_service import SortService
+
+
+def _rec(path: str, size: int = 0, folder: str = "") -> PhotoRecord:
+    return PhotoRecord(
+        group_number=1,
+        is_mark=False,
+        is_locked=False,
+        folder_path=folder,
+        file_path=path,
+        capture_date=None,
+        modified_date=None,
+        file_size_bytes=size,
+    )
+
+
+def _group(*recs: PhotoRecord) -> PhotoGroup:
+    return PhotoGroup(group_number=1, items=list(recs))
+
+
+class TestSortService:
+    def test_single_key_ascending(self):
+        g = _group(_rec("/b.jpg", size=200), _rec("/a.jpg", size=100))
+        SortService().sort([g], [("file_size_bytes", True)])
+        assert [r.file_size_bytes for r in g.items] == [100, 200]
+
+    def test_single_key_descending(self):
+        g = _group(_rec("/a.jpg", size=100), _rec("/b.jpg", size=200))
+        SortService().sort([g], [("file_size_bytes", False)])
+        assert [r.file_size_bytes for r in g.items] == [200, 100]
+
+    def test_multi_key_stable(self):
+        # primary: size desc; tiebreak: path asc
+        g = _group(
+            _rec("/c.jpg", size=100),
+            _rec("/a.jpg", size=200),
+            _rec("/b.jpg", size=100),
+        )
+        SortService().sort([g], [("file_size_bytes", False), ("file_path", True)])
+        paths = [r.file_path for r in g.items]
+        assert paths == ["/a.jpg", "/b.jpg", "/c.jpg"]
+
+    def test_none_value_treated_as_empty_string(self):
+        # None folder_path coerces to "" → sorts before any real folder string
+        g = _group(_rec("/b.jpg", folder="Z"), _rec("/a.jpg", folder=None))
+        SortService().sort([g], [("folder_path", True)])
+        assert g.items[0].file_path == "/a.jpg"  # None/"" sorts first
+
+    def test_empty_sort_keys_noop(self):
+        recs = [_rec("/b.jpg"), _rec("/a.jpg")]
+        g = _group(*recs)
+        SortService().sort([g], [])
+        assert [r.file_path for r in g.items] == ["/b.jpg", "/a.jpg"]
+
+    def test_updates_group_items(self):
+        g = _group(_rec("/b.jpg", size=2), _rec("/a.jpg", size=1))
+        SortService().sort([g], [("file_size_bytes", True)])
+        assert [r.file_size_bytes for r in g.items] == [1, 2]
+
+    def test_multiple_groups_independent(self):
+        g1 = _group(_rec("/b.jpg", size=2), _rec("/a.jpg", size=1))
+        g2 = _group(_rec("/d.jpg", size=4), _rec("/c.jpg", size=3))
+        SortService().sort([g1, g2], [("file_size_bytes", True)])
+        assert [r.file_size_bytes for r in g1.items] == [1, 2]
+        assert [r.file_size_bytes for r in g2.items] == [3, 4]


### PR DESCRIPTION
## Summary

- Fixes Set Action always being grayed after opening a manifest
- Adds dual Set Action entry points: "Activated Files" (highlighted rows) vs "Selected (Sel) Files" (checkbox rows)
- Fixes SQLite file growing unboundedly on Remove from List (adds VACUUM)
- Fixes Save Manifest Decisions: now opens a file-picker for export instead of silently overwriting
- Fixes group-level column sorting: aggregates across all files in the group instead of using only the first item
- Adds test coverage for SortService, RegexSelectionService, mark_executed, set_decision_to_highlighted, save_manifest_decisions

## Changes

- `.gitignore`: add `*.sqlite`
- `menu_controller.py`: replace single "Set Action" submenu with two submenus (Activated / Sel)
- `file_operations.py`: enable all 6 manifest-dependent actions on load; add `set_decision_to_highlighted()`; save dialog with optional copy
- `main_window.py`: wire new menu keys; pass `highlighted_items_provider=self.tree_controller`
- `manifest_repository.py`: add `VACUUM` after `remove_from_review()` commit
- `tree_model_builder.py`: group SORT_ROLE uses `min`/`max` aggregation across all files
- New test files: `test_sort_service.py`, `test_selection_service.py`
- Updated: `test_manifest_repository.py` (TestMarkExecuted), `test_file_operations.py` (TestSetDecisionToHighlighted, TestSaveManifestDecisions)

## Test plan

- [ ] `python -m pytest tests/ -q` — 216 tests pass
- [ ] Open manifest → both "Set Action to Activated Files" and "Set Action to Selected (Sel) Files" become enabled
- [ ] Highlight a row → Set Action to Activated → decision updates for that row only
- [ ] Check rows → Set Action to Selected → decision updates for checked rows only
- [ ] Remove from List → `.sqlite` file size stays stable (VACUUM runs)
- [ ] Save Manifest Decisions → file picker appears; selecting new path exports a copy
- [ ] Sort by Action column → groups reorder by their best-decided file, not just first file

🤖 Generated with [Claude Code](https://claude.com/claude-code)