### PR TITLE
feat: dynamic multi-source scan — unlimited folders, per-source recursive toggle

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: update-docs
+description: Use after implementing any fix or new feature in photo-manager to keep documentation in sync. Checks README.md, DESIGN.md, pyproject.toml, python_style_guide.md, and LINTING_GUIDE.md against what actually changed. Applies only surgical edits to affected sections.
+origin: local
+---
+
+# Update Docs After Each Fix / Feature
+
+Activate this skill after implementing any non-trivial change to photo-manager so that documentation stays in sync with the code.
+
+## When to activate
+
+- After adding, renaming, or deleting a source file
+- After adding a test file
+- After changing the SQLite schema (new columns, renamed columns)
+- After adding or removing a service, interface, or module
+- After changing menu actions or UI flow
+- After bumping the Python version
+- After adding or removing a `settings.json` key
+- After deprecating or deleting code
+
+---
+
+## Docs map for `photo-manager`
+
+| File | What it tracks | Sections / spots to check |
+|------|---------------|--------------------------|
+| `README.md` | Project structure tree, test list, test count | `## Project structure` block; `tests/` subtree; `# 270+ tests` comment |
+| `DESIGN.md` | Architecture, dir structure, service interfaces, menu actions, manifest schema, settings | §2 services, §4 directory tree, §6 interfaces, §8 UI/menus, §12 settings, §20 manifest schema + GUI integration |
+| `pyproject.toml` | Python version for Black / Ruff / Pylint | `target-version = ["py3XX"]`, `target-version = "py3XX"`, `py-version = "3.XX"` |
+| `python_style_guide.md` | Python version requirement | First line `請用 Python 3.XX+` |
+| `LINTING_GUIDE.md` | Python version + pyproject.toml excerpts | Title line, installation section, config code block (3 occurrences of py3XX/3.XX) |
+
+---
+
+## Checklist
+
+Work through every item below. Check only the items relevant to your change.
+
+### Files changed?
+- [ ] Added a `.py` file → add it to `README.md` project structure tree at the right indentation level
+- [ ] Added a test file `tests/test_*.py` → add it to `README.md` test list; bump the `# 270+ tests` count
+- [ ] Removed or deprecated a file → mark `[deprecated]` in `README.md` + `DESIGN.md` §4; do **not** delete the entry
+- [ ] Renamed a file → update both `README.md` and `DESIGN.md` §4
+
+### Schema changed?
+- [ ] Added column(s) to `migration_manifest` → add row(s) to `DESIGN.md` §20 manifest schema table
+- [ ] Updated `_MIGRATIONS` list → verify §20 migration note is still accurate
+
+### Service / interface changed?
+- [ ] Added or changed a class in `core/services/interfaces.py` → update `DESIGN.md` §6
+- [ ] Added `SortService` / `RegexSelectionService` method → update §6 if the interface is documented there
+- [ ] Added or removed an infrastructure class → update `README.md` infrastructure tree
+
+### UI / menu changed?
+- [ ] Added or removed a menu item → update `DESIGN.md` §8 operations bullet list
+- [ ] Changed a dialog → update `README.md` dialogs tree + `DESIGN.md` §4 if the dialog is named there
+
+### Settings changed?
+- [ ] Added a new `settings.json` key → add it to `DESIGN.md` §12 settings list + `README.md` Configuration section
+- [ ] Removed a key → remove or annotate it in both places
+
+### Python version bumped?
+- [ ] `pyproject.toml` — update `target-version` (Black + Ruff) and `py-version` (Pylint)
+- [ ] `python_style_guide.md` — update first line
+- [ ] `LINTING_GUIDE.md` — update title, installation section, and all three spots in the config code block
+
+### Background worker / major flow changed?
+- [ ] New `QThread` worker → add to `README.md` workers/ subtree + `DESIGN.md` §4 + §20 GUI integration paragraph
+- [ ] Removed or replaced a flow entry point → update `DESIGN.md` §20 GUI integration paragraph
+
+---
+
+## How to apply
+
+1. Read the changed source file(s) to understand exactly what changed.
+2. For each checked item above, read the relevant doc section.
+3. Apply **surgical edits** — replace only the stale sentence/row/bullet; do not rewrite entire sections.
+4. After all edits, run `python -m pytest tests/ -q --tb=short` to confirm no regressions.
+5. Commit the doc changes alongside the code change (or as an immediate follow-up commit on the same branch).
+
+---
+
+## Example edit patterns
+
+**New file added** (`app/views/dialogs/export_dialog.py`):
+```
+# In README.md project structure, find the dialogs/ block and add:
+│   │   │   ├── export_dialog.py            # Export decisions to CSV
+# In DESIGN.md §4, add the file to the dialogs/ section.
+```
+
+**New manifest column** (`reason TEXT`):
+```
+# In DESIGN.md §20 schema table, add a row:
+| `reason` | TEXT | Human-readable classification reason |
+```
+
+**New settings key** (`"preview_max_side": 1024`):
+```
+# In DESIGN.md §12 bullet list, add:
+  - `preview_max_side` (縮圖預覽最大邊長，預設 1024)
+# In README.md Configuration section, add the key to the example JSON block.
+```
+
+**Deprecated a file** (`app/views/dialogs/legacy_dialog.py`):
+```
+# In README.md project structure, change:
+│   │   │   └── legacy_dialog.py
+# to:
+│   │   │   └── legacy_dialog.py            # [deprecated — legacy stub]
+# Same update in DESIGN.md §4.
+```

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -105,7 +105,7 @@ photo-manager/
     delete_service.py
     settings.py
 
-  tests/                   # 270+ tests
+  tests/                   # 308+ tests
     conftest.py
     test_dedup.py           test_hasher.py          test_walker.py
     test_review.py          test_manifest_repository.py
@@ -114,7 +114,7 @@ photo-manager/
     test_main_vm.py         test_file_operations.py test_sort_service.py
     test_selection_service.py  test_context_menu.py
     test_execute_action_dialog.py  test_group_deletion_check_dialog.py
-    test_manifest_load_worker.py
+    test_manifest_load_worker.py    test_scan_dialog.py
 ```
 
 ---
@@ -132,7 +132,7 @@ photo-manager/
   - `creation_date:datetime|None` — 檔案系統建立時間
   - `shot_date:datetime|None` — EXIF DateTimeOriginal
   - `file_size_bytes:int`（以 `os.path.getsize` 重新讀取）
-  - `action:str` — Scanner 分類（唯讀）：`EXACT` / `REVIEW_DUPLICATE` / `MOVE` / `KEEP` / `UNDATED` / `""` (reference role)
+  - `action:str` — Scanner 分類（唯讀）：`EXACT` / `REVIEW_DUPLICATE` / `MOVE` / `UNDATED` / `""` (all sources treated equally; no source receives KEEP)
   - `user_decision:str` — 使用者操作決定（可寫）：`"delete"` / `"keep"` / `""` (undecided)
 - `PhotoGroup`
   - `group_number:int`
@@ -244,6 +244,8 @@ photo-manager/
 ## 12. 設定與國際化
 
 - `settings.json`：
+  - `sources.list`（`[{"path": "…", "recursive": true}, …]`）— 掃描來源資料夾清單（新格式）；優先順序由索引決定（index 0 最高）
+  - `sources.output`（manifest 輸出路徑）
   - `thumbnail_size`（256/512/1024）
   - `thumbnail_mem_cache`（如 512）
   - `thumbnail_disk_cache_dir`
@@ -251,6 +253,7 @@ photo-manager/
   - `sorting.defaults`（欄位/方向陣列）
   - `ui.locale`（"zh-TW"）
 - 所有字串集中管理，預設中文
+- 舊格式（`sources.iphone` / `sources.takeout` / `sources.jdrive`）在首次開啟掃描對話框時自動遷移至 `sources.list`；舊鍵保留但已不再寫入。
 
 > **注意**：`delete.confirm_group_full_delete` 與 `ui.locale` 目前儲存於 `settings.json` 但尚未被應用程式碼讀取。
 
@@ -359,17 +362,24 @@ scan_sources()  →  batch_read_dates()  →  compute_sha256/phash()  →  class
 | No EXIF DateTimeOriginal | `UNDATED` |
 | Otherwise | `MOVE` |
 
-Source priority (EXACT_DUPLICATE): `iphone > takeout > jdrive`  
-Format priority (FORMAT_DUPLICATE): `heic > jpeg > png > others`
+**Source priority** (EXACT_DUPLICATE): positional — determined by the order sources
+appear in the scan dialog or `--source` CLI flags (index 0 = highest priority).
+Passed to `classify()` as `source_priority: dict[str, int]`; auto-inferred from
+record order when omitted. No source receives a hardcoded `KEEP` action.  
+**Format priority** (FORMAT_DUPLICATE): `heic > jpeg > png > others`
 
 ### GUI integration
 
-`ScanDialog` (in `app/views/dialogs/`) lets the user pick source folders and
-runs `ScanWorker` (a `QThread`) in the background. On completion the manifest
-path is passed to `ManifestLoadWorker` (a `QThread` in `app/views/workers/`),
-which calls `ManifestRepository.load()` in the background and emits
-`finished(list[PhotoGroup])` when done. `FileOperationsHandler` receives the
-signal and populates the review tree — keeping the UI fully responsive during load.
+`ScanDialog` (in `app/views/dialogs/`) embeds a `_FolderTreePanel`
+(`QFileSystemModel` + `QTreeView`, directories only) and a `_SourceListWidget`
+(`QTableWidget` with per-source Recursive checkbox and ↑↓ priority reorder).
+Any number of source folders can be added; order determines dedup priority.
+The dialog runs `ScanWorker` (a `QThread`) in the background, passing
+`recursive_map` and `source_priority` built from the source list. On completion
+the manifest path is passed to `ManifestLoadWorker` (a `QThread` in
+`app/views/workers/`), which calls `ManifestRepository.load()` in the background
+and emits `finished(list[PhotoGroup])` when done. `FileOperationsHandler` receives
+the signal and populates the review tree — keeping the UI fully responsive during load.
 
 `ManifestRepository.save()` writes `user_decision` values (`delete`/`keep`/`""`) back
 to the manifest for each record.  The `action` column (scanner classification) is
@@ -378,10 +388,16 @@ never modified by the GUI.
 ### CLI
 
 ```bash
+# Recursive sources (priority: first listed = highest)
 python scan.py \
-  --source iphone="\NAS\Photos\MobileBackup" \
-  --source takeout="D:\Downloads\Takeout" \
-  --source jdrive="J:\圖片" \
+  --source photos="\NAS\Photos\MobileBackup" \
+  --source archive="D:\Archive" \
+  --output migration_manifest.sqlite
+
+# Mix recursive + flat (non-recursive) sources
+python scan.py \
+  --source archive="D:\Archive" \
+  --source-flat inbox="D:\Inbox" \
   --output migration_manifest.sqlite
 
 python scan.py ... --limit 200 --dry-run   # bounded debug run
@@ -392,9 +408,9 @@ python scan.py ... --limit 200 --dry-run   # bounded debug run
 | Column | Type | Notes |
 |--------|------|-------|
 | `source_path` | TEXT | Absolute path |
-| `source_label` | TEXT | `iphone` / `takeout` / `jdrive` |
+| `source_label` | TEXT | Auto-generated from folder basename (e.g. `Photos`, `Takeout`) |
 | `dest_path` | TEXT | NULL for EXACT/UNDATED |
-| `action` | TEXT | Scanner classification: `EXACT` / `REVIEW_DUPLICATE` / `MOVE` / `KEEP` / `UNDATED` |
+| `action` | TEXT | Scanner classification: `EXACT` / `REVIEW_DUPLICATE` / `MOVE` / `UNDATED` |
 | `source_hash` | TEXT | SHA-256 hex |
 | `phash` | TEXT | 64-bit perceptual hash hex; NULL for video |
 | `hamming_distance` | INTEGER | Distance to `duplicate_of`'s phash |

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Produces `migration_manifest.sqlite` consumed by **[photo-transfer](https://gith
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │  1. SCAN (photo-manager)                                                    │
 │     GUI: File > Scan Sources…  —or—  CLI: python scan.py …                │
-│     Walks iphone / takeout / jdrive, hashes every file,                    │
+│     Walks any number of source folders, hashes every file,                 │
 │     writes  migration_manifest.sqlite                                       │
 │                                                                             │
 │  2. REVIEW (photo-manager)                                                  │
@@ -84,16 +84,18 @@ The PySide6 desktop app is the primary interface. Launch it with `run.bat`.
 
 **File › Scan Sources…** opens the scan dialog.
 
-1. Fill in (or Browse to) each source folder:
-   - **iphone** — iPhone backup folder (NAS or local)
-   - **takeout** — Google Takeout export folder
-   - **jdrive** — J:\圖片 archive (or any third source)
-   - **output** — path for `migration_manifest.sqlite`
-2. Click **Start Scan**. Progress is streamed to the log pane.
-3. When the scan finishes, click **Close & Load** — the manifest loads
+1. Browse the embedded folder tree to find source directories.
+   - Double-click or press **+ Add Selected Folder** to add a folder to the list.
+   - Use **↑ / ↓** buttons to reorder sources (top row = highest dedup priority).
+   - Tick or untick the **Recursive** checkbox per source — recursive scans all
+     subdirectories; unticked scans only the immediate folder.
+   - Use **×** to remove a source; **Remove All** to clear the list.
+2. Set the **Save manifest to** path (defaults to `migration_manifest.sqlite`).
+3. Click **Start Scan**. Progress is streamed to the log pane.
+4. When the scan finishes, click **Close & Load** — the manifest loads
    directly into the review tree.
 
-Source paths are remembered in `settings.json` for the next session.
+Source paths are persisted to `settings.json` (`sources.list`) between sessions.
 
 ### Step 2 — Review groups
 
@@ -143,11 +145,16 @@ immediately before execution.
 ### `scan.py` — Deduplication scanner
 
 ```powershell
-# Full scan
+# Full recursive scan (sources listed in priority order)
 python scan.py `
-  --source iphone="\\NAS\Photos\MobileBackup\iPhone" `
-  --source takeout="D:\Downloads\Takeout\Google 相簿" `
-  --source jdrive="J:\圖片" `
+  --source photos="\\NAS\Photos\MobileBackup" `
+  --source archive="D:\Archive" `
+  --output migration_manifest.sqlite
+
+# Mix recursive + flat (non-recursive) sources
+python scan.py `
+  --source archive="D:\Archive" `
+  --source-flat inbox="D:\Inbox" `
   --output migration_manifest.sqlite
 
 # Bounded debug run — stops after 200 files per source
@@ -185,17 +192,16 @@ Decisions persist immediately — the session is resumable at any time.
 | pHash hamming = 0, one RAW + one lossy | `MOVE` both (complementary — always kept together) |
 | pHash hamming 1–threshold | `REVIEW_DUPLICATE` — needs human triage |
 | No EXIF `DateTimeOriginal` | `UNDATED` |
-| iPhone source | `KEEP` (reference copy, stays in place) |
 | Everything else | `MOVE` |
 
-**Source priority** (exact duplicates): `iphone > takeout > jdrive`  
+**Source priority** (exact duplicates): positional — order in the scan dialog (top = highest priority) or `--source` CLI flag order. No source receives a hardcoded `KEEP`.  
 **Format priority** (FORMAT_DUPLICATE): `heic > jpeg > png > others`
 
 ---
 
 ## Scanner features
 
-- **SHA-256** exact duplicate detection across all three sources
+- **SHA-256** exact duplicate detection across all source folders
 - **pHash** (imagehash) cross-format detection — JPEG vs HEIC vs RAW vs PNG
 - **Hamming distance** configurable near-duplicate threshold
 - **Live Photo pairs** — same-stem HEIC + MOV treated as an atomic unit
@@ -282,7 +288,7 @@ photo-manager/
 │
 ├── settings.json            # User configuration (source paths, thumbnail cache, …)
 │
-└── tests/                   # 270+ tests — scanner, infra, viewmodel, GUI handlers
+└── tests/                   # 308+ tests — scanner, infra, viewmodel, GUI handlers
     ├── conftest.py              # Shared fixtures (qapp)
     ├── test_dedup.py
     ├── test_hasher.py
@@ -301,7 +307,8 @@ photo-manager/
     ├── test_execute_action_dialog.py
     ├── test_group_deletion_check_dialog.py
     ├── test_context_menu.py
-    └── test_manifest_load_worker.py
+    ├── test_manifest_load_worker.py
+    └── test_scan_dialog.py      # _auto_label, _SourceListWidget, ScanDialog settings
 ```
 
 ---
@@ -311,10 +318,12 @@ photo-manager/
 ```json
 {
   "sources": {
-    "iphone":  "",
-    "takeout": "",
-    "jdrive":  "",
-    "output":  "migration_manifest.sqlite"
+    "list": [
+      { "path": "D:\\Archive",           "recursive": true  },
+      { "path": "\\\\NAS\\MobileBackup", "recursive": true  },
+      { "path": "D:\\Inbox",             "recursive": false }
+    ],
+    "output": "migration_manifest.sqlite"
   },
   "thumbnail_size": 512,
   "sorting": {
@@ -326,7 +335,12 @@ photo-manager/
 }
 ```
 
-Source paths set via **File › Scan Sources…** are saved here automatically.
+Source paths and recursive flags set via **File › Scan Sources…** are saved here
+automatically. List order determines dedup priority (index 0 = highest priority).
+
+> **Migration**: if `settings.json` contains the old `sources.iphone` / `sources.takeout` /
+> `sources.jdrive` keys, they are automatically converted to `sources.list` format on
+> the first open of the Scan Sources dialog.
 
 ---
 

--- a/app/views/dialogs/scan_dialog.py
+++ b/app/views/dialogs/scan_dialog.py
@@ -1,96 +1,280 @@
-"""ScanDialog — folder picker + background scan with live progress log."""
+"""ScanDialog — multi-source folder picker + background scan with live progress log."""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import QDir, QModelIndex, Qt, Signal
+from PySide6.QtGui import QCloseEvent
 from PySide6.QtWidgets import (
+    QCheckBox,
     QDialog,
-    QDialogButtonBox,
     QFileDialog,
-    QFormLayout,
+    QFileSystemModel,
+    QGroupBox,
     QHBoxLayout,
+    QHeaderView,
     QLabel,
     QLineEdit,
     QMessageBox,
     QPlainTextEdit,
     QPushButton,
     QSizePolicy,
+    QSplitter,
+    QTableWidget,
+    QTableWidgetItem,
+    QTreeView,
     QVBoxLayout,
     QWidget,
 )
 
 from app.views.workers.scan_worker import ScanWorker
 
-# (internal_key, display_label, placeholder_hint)
-# Internal keys are stored in settings.json under "sources.*".
-# Priority order: first entry wins when the same file appears in multiple folders.
-_SOURCES = [
-    ("iphone",  "Folder 1  (highest priority)", "Browse to select a source folder…"),
-    ("takeout", "Folder 2",                     "Browse to select a source folder…"),
-    ("jdrive",  "Folder 3  (lowest priority)",  "Browse to select a source folder…"),
-]
+
+@dataclass
+class _SourceEntry:
+    """One user-selected source folder with its scan options."""
+
+    path: str
+    recursive: bool = True
 
 
-class _SourceRow(QWidget):
-    """One row: label + path field + Browse button (directory picker)."""
+def _auto_label(name: str, existing: set[str]) -> str:
+    """Return a unique label derived from ``name``.
 
-    def __init__(self, label: str, hint: str, parent: QWidget | None = None) -> None:
+    Appends ``_2``, ``_3``, … until the label is not already in ``existing``.
+
+    Args:
+        name: Preferred label (typically the folder's basename).
+        existing: Set of labels already in use.
+
+    Returns:
+        A label string not present in ``existing``.
+    """
+    label = name
+    counter = 2
+    while label in existing:
+        label = f"{name}_{counter}"
+        counter += 1
+    return label
+
+
+class _FolderTreePanel(QWidget):
+    """Embedded filesystem tree for browsing and selecting source folders.
+
+    Emits ``folder_requested(path)`` when the user double-clicks a folder
+    or presses the "Add Selected Folder" button.
+    """
+
+    folder_requested = Signal(str)
+
+    def __init__(self, parent: QWidget | None = None) -> None:
         super().__init__(parent)
-        layout = QHBoxLayout(self)
+        self._model: QFileSystemModel
+        self._tree: QTreeView
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        """Construct the directory tree view and add button."""
+        layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
 
-        self.field = QLineEdit()
-        self.field.setPlaceholderText(hint)
-        self.field.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Fixed)
+        self._model = QFileSystemModel(self)
+        self._model.setFilter(QDir.AllDirs | QDir.NoDotAndDotDot)
+        root_index = self._model.setRootPath("")
 
-        browse = QPushButton("Browse…")
-        browse.setFixedWidth(80)
-        browse.clicked.connect(self._browse)
+        self._tree = QTreeView()
+        self._tree.setModel(self._model)
+        self._tree.setRootIndex(root_index)
+        for col in range(1, self._model.columnCount()):
+            self._tree.hideColumn(col)
+        self._tree.setHeaderHidden(True)
+        self._tree.doubleClicked.connect(self._on_double_click)
 
-        layout.addWidget(self.field)
-        layout.addWidget(browse)
+        home = str(Path.home())
+        home_index = self._model.index(home)
+        if home_index.isValid():
+            self._tree.expand(home_index)
+            self._tree.scrollTo(home_index)
 
-    def _browse(self) -> None:
-        start = self.field.text() or ""
-        chosen = QFileDialog.getExistingDirectory(self, "Select folder", start)
-        if chosen:
-            self.field.setText(chosen)
+        add_btn = QPushButton("+ Add Selected Folder")
+        add_btn.setSizePolicy(QSizePolicy.Policy.Expanding, QSizePolicy.Policy.Fixed)
+        add_btn.clicked.connect(self._on_add)
 
-    @property
-    def path(self) -> str:
-        return self.field.text().strip()
+        layout.addWidget(self._tree)
+        layout.addWidget(add_btn)
 
-    @path.setter
-    def path(self, value: str) -> None:
-        self.field.setText(value)
+    def _on_add(self) -> None:
+        """Emit ``folder_requested`` for the currently highlighted directory."""
+        index = self._tree.currentIndex()
+        if index.isValid():
+            path = self._model.filePath(index)
+            self.folder_requested.emit(path)
+
+    def _on_double_click(self, index: QModelIndex) -> None:
+        """Emit ``folder_requested`` on double-click."""
+        path = self._model.filePath(index)
+        self.folder_requested.emit(path)
 
 
-class _OutputRow(_SourceRow):
-    """Output row: uses a file-save dialog filtered to .sqlite files."""
+class _SourceListWidget(QWidget):
+    """Table managing the ordered list of selected source folders.
 
-    def _browse(self) -> None:
-        start = self.field.text() or "migration_manifest.sqlite"
-        chosen, _ = QFileDialog.getSaveFileName(
-            self,
-            "Save Manifest As",
-            start,
-            "SQLite manifest (*.sqlite);;All files (*)",
-        )
-        if chosen:
-            # Ensure .sqlite extension
-            if not chosen.lower().endswith(".sqlite"):
-                chosen += ".sqlite"
-            self.field.setText(chosen)
+    Columns: priority #, path, Recursive checkbox, ↑↓ reorder buttons, × remove.
+
+    Signals:
+        changed: Emitted whenever the list content or order changes.
+    """
+
+    changed = Signal()
+
+    def __init__(self, parent: QWidget | None = None) -> None:
+        super().__init__(parent)
+        self._entries: list[_SourceEntry] = []
+        self._table: QTableWidget
+        self._build_ui()
+
+    def _build_ui(self) -> None:
+        """Construct the header row and source table."""
+        layout = QVBoxLayout(self)
+        layout.setContentsMargins(0, 0, 0, 0)
+
+        header_row = QHBoxLayout()
+        header_row.addWidget(QLabel("Source folders (top = highest priority):"))
+        header_row.addStretch()
+        remove_all_btn = QPushButton("Remove All")
+        remove_all_btn.clicked.connect(self.clear)
+        header_row.addWidget(remove_all_btn)
+        layout.addLayout(header_row)
+
+        self._table = QTableWidget(0, 5)
+        self._table.setHorizontalHeaderLabels(["#", "Path", "Recursive", "", ""])
+        hdr = self._table.horizontalHeader()
+        hdr.setSectionResizeMode(0, QHeaderView.ResizeMode.ResizeToContents)
+        hdr.setSectionResizeMode(1, QHeaderView.ResizeMode.Stretch)
+        hdr.setSectionResizeMode(2, QHeaderView.ResizeMode.ResizeToContents)
+        hdr.setSectionResizeMode(3, QHeaderView.ResizeMode.ResizeToContents)
+        hdr.setSectionResizeMode(4, QHeaderView.ResizeMode.ResizeToContents)
+        self._table.verticalHeader().setVisible(False)
+        self._table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
+        self._table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
+        self._table.setAlternatingRowColors(True)
+        layout.addWidget(self._table)
+
+    # ------------------------------------------------------------------ public API
+
+    def add_entry(self, path: str, recursive: bool = True) -> None:
+        """Add a source folder; silently ignore duplicate paths.
+
+        Args:
+            path: Absolute folder path.
+            recursive: Whether to scan subdirectories (default ``True``).
+        """
+        if any(entry.path == path for entry in self._entries):
+            return
+        self._entries.append(_SourceEntry(path=path, recursive=recursive))
+        self._rebuild_table()
+        self.changed.emit()
+
+    def clear(self) -> None:
+        """Remove all source entries from the list."""
+        self._entries.clear()
+        self._rebuild_table()
+        self.changed.emit()
+
+    def entries(self) -> list[_SourceEntry]:
+        """Return a shallow copy of the current entry list."""
+        return list(self._entries)
+
+    def set_entries(self, entries: list[_SourceEntry]) -> None:
+        """Replace the current list with ``entries`` (does not emit ``changed``)."""
+        self._entries = list(entries)
+        self._rebuild_table()
+
+    # ------------------------------------------------------------------ private
+
+    def _rebuild_table(self) -> None:
+        """Repopulate the table widget from ``self._entries``."""
+        self._table.setRowCount(0)
+        for row_idx, entry in enumerate(self._entries):
+            self._table.insertRow(row_idx)
+
+            num_item = QTableWidgetItem(str(row_idx + 1))
+            num_item.setTextAlignment(Qt.AlignmentFlag.AlignCenter)
+            self._table.setItem(row_idx, 0, num_item)
+            self._table.setItem(row_idx, 1, QTableWidgetItem(entry.path))
+
+            check = QCheckBox()
+            check.setChecked(entry.recursive)
+            check.stateChanged.connect(
+                lambda state, row=row_idx: self._on_recursive_changed(row, state)
+            )
+            self._table.setCellWidget(row_idx, 2, self._centered(check))
+
+            ud_widget = QWidget()
+            ud_layout = QHBoxLayout(ud_widget)
+            ud_layout.setContentsMargins(2, 0, 2, 0)
+            ud_layout.setSpacing(2)
+            up_btn = QPushButton("↑")
+            up_btn.setFixedWidth(26)
+            up_btn.setToolTip("Move up (higher priority)")
+            up_btn.clicked.connect(lambda _, row=row_idx: self._move(row, -1))
+            dn_btn = QPushButton("↓")
+            dn_btn.setFixedWidth(26)
+            dn_btn.setToolTip("Move down (lower priority)")
+            dn_btn.clicked.connect(lambda _, row=row_idx: self._move(row, +1))
+            ud_layout.addWidget(up_btn)
+            ud_layout.addWidget(dn_btn)
+            self._table.setCellWidget(row_idx, 3, ud_widget)
+
+            rm_btn = QPushButton("×")
+            rm_btn.setFixedWidth(26)
+            rm_btn.setToolTip("Remove from list")
+            rm_btn.clicked.connect(lambda _, row=row_idx: self._remove(row))
+            self._table.setCellWidget(row_idx, 4, rm_btn)
+
+    @staticmethod
+    def _centered(widget: QWidget) -> QWidget:
+        """Wrap ``widget`` in a horizontally-centred container widget."""
+        wrapper = QWidget()
+        lay = QHBoxLayout(wrapper)
+        lay.addWidget(widget)
+        lay.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        lay.setContentsMargins(0, 0, 0, 0)
+        return wrapper
+
+    def _on_recursive_changed(self, row: int, state: int) -> None:
+        """Update the recursive flag for the entry at ``row``."""
+        if 0 <= row < len(self._entries):
+            self._entries[row].recursive = bool(state)
+            self.changed.emit()
+
+    def _move(self, row: int, delta: int) -> None:
+        """Swap the entry at ``row`` with the entry at ``row + delta``."""
+        new_row = row + delta
+        if 0 <= new_row < len(self._entries):
+            self._entries[row], self._entries[new_row] = (
+                self._entries[new_row],
+                self._entries[row],
+            )
+            self._rebuild_table()
+            self.changed.emit()
+
+    def _remove(self, row: int) -> None:
+        """Delete the entry at ``row``."""
+        if 0 <= row < len(self._entries):
+            self._entries.pop(row)
+            self._rebuild_table()
+            self.changed.emit()
 
 
 class ScanDialog(QDialog):
-    """Modal dialog that lets the user pick source folders and run a scan.
+    """Modal dialog for picking source folders and running a deduplication scan.
 
-    After a successful scan the manifest path is available via `.manifest_path`.
-    The caller should connect `on_scan_complete` to be notified.
+    After a successful scan the manifest path is available via ``.manifest_path``.
+    Pass ``on_scan_complete`` to receive a callback when the user clicks Close & Load.
     """
 
     def __init__(
@@ -101,11 +285,19 @@ class ScanDialog(QDialog):
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Scan Sources")
-        self.setMinimumWidth(600)
+        self.setMinimumWidth(700)
+        self.setMinimumHeight(600)
         self.settings = settings
         self._on_complete = on_scan_complete
         self._worker: ScanWorker | None = None
         self.manifest_path: str | None = None
+
+        self._tree_panel: _FolderTreePanel
+        self._source_list: _SourceListWidget
+        self._output_field: QLineEdit
+        self._log_widget: QPlainTextEdit
+        self._btn_scan: QPushButton
+        self._btn_close: QPushButton
 
         self._build_ui()
         self._load_from_settings()
@@ -113,9 +305,9 @@ class ScanDialog(QDialog):
     # ------------------------------------------------------------------ UI
 
     def _build_ui(self) -> None:
+        """Construct the full dialog layout."""
         root = QVBoxLayout(self)
 
-        # Read-only notice
         notice = QLabel(
             "Read-only scan — no files are moved or deleted. "
             "MOVE / SKIP in the log are planned actions stored in the manifest only."
@@ -124,43 +316,40 @@ class ScanDialog(QDialog):
         notice.setStyleSheet("color: #555; font-style: italic; padding: 4px 0;")
         root.addWidget(notice)
 
-        # Source folder rows
-        form = QFormLayout()
-        form.setLabelAlignment(Qt.AlignRight)
-        self._source_rows: dict[str, _SourceRow] = {}
-        for key, display, hint in _SOURCES:
-            row = _SourceRow(key, hint, self)
-            self._source_rows[key] = row
-            form.addRow(QLabel(display + ":"), row)
+        splitter = QSplitter(Qt.Orientation.Vertical)
 
-        # Manifest output path (file-save dialog, enforces .sqlite extension)
-        self._output_row = _OutputRow("output", "migration_manifest.sqlite", self)
-        self._output_row.field.setPlaceholderText("Output manifest path (.sqlite)")
-        form.addRow(QLabel("Save manifest to:"), self._output_row)
+        tree_group = QGroupBox("Browse source folders:")
+        tree_layout = QVBoxLayout(tree_group)
+        self._tree_panel = _FolderTreePanel(self)
+        self._tree_panel.folder_requested.connect(self._on_folder_requested)
+        tree_layout.addWidget(self._tree_panel)
+        splitter.addWidget(tree_group)
 
-        root.addLayout(form)
+        self._source_list = _SourceListWidget(self)
+        splitter.addWidget(self._source_list)
+        splitter.setSizes([320, 160])
+        root.addWidget(splitter, stretch=1)
 
-        # Priority note
-        priority_note = QLabel(
-            "When the same photo exists in multiple folders, "
-            "the copy from the highest-priority folder is kept."
-        )
-        priority_note.setWordWrap(True)
-        priority_note.setStyleSheet("color: #666; font-size: 11px; padding: 2px 0 6px 0;")
-        root.addWidget(priority_note)
+        output_row = QHBoxLayout()
+        output_row.addWidget(QLabel("Save manifest to:"))
+        self._output_field = QLineEdit()
+        self._output_field.setPlaceholderText("Output manifest path (.sqlite)")
+        output_row.addWidget(self._output_field, stretch=1)
+        browse_out_btn = QPushButton("Browse…")
+        browse_out_btn.setFixedWidth(80)
+        browse_out_btn.clicked.connect(self._browse_output)
+        output_row.addWidget(browse_out_btn)
+        root.addLayout(output_row)
 
-        # Progress log
         self._log_widget = QPlainTextEdit()
         self._log_widget.setReadOnly(True)
-        self._log_widget.setMinimumHeight(200)
+        self._log_widget.setMinimumHeight(150)
         self._log_widget.setPlaceholderText("Scan progress will appear here…")
         root.addWidget(self._log_widget)
 
-        # Buttons
         self._btn_scan = QPushButton("Start Scan")
         self._btn_scan.setDefault(True)
         self._btn_scan.clicked.connect(self._start_scan)
-
         self._btn_close = QPushButton("Close")
         self._btn_close.clicked.connect(self.reject)
 
@@ -170,58 +359,133 @@ class ScanDialog(QDialog):
         btn_row.addWidget(self._btn_close)
         root.addLayout(btn_row)
 
+    # ------------------------------------------------------------------ slots
+
+    def _on_folder_requested(self, path: str) -> None:
+        """Add the path emitted by the tree panel to the source list."""
+        self._source_list.add_entry(path)
+
+    def _browse_output(self) -> None:
+        """Open a save-file dialog to choose the manifest output path."""
+        start = self._output_field.text() or "migration_manifest.sqlite"
+        chosen, _ = QFileDialog.getSaveFileName(
+            self,
+            "Save Manifest As",
+            start,
+            "SQLite manifest (*.sqlite);;All files (*)",
+        )
+        if chosen:
+            if not chosen.lower().endswith(".sqlite"):
+                chosen += ".sqlite"
+            self._output_field.setText(chosen)
+
     # ------------------------------------------------------------------ settings
 
     def _load_from_settings(self) -> None:
-        for key in self._source_rows:
-            saved = self.settings.get(f"sources.{key}", "")
-            if saved:
-                self._source_rows[key].path = saved
+        """Populate the dialog from saved settings (new list format or legacy keys)."""
+        sources_list = self.settings.get("sources.list")
+        if sources_list:
+            entries = [
+                _SourceEntry(path=item["path"], recursive=item.get("recursive", True))
+                for item in sources_list
+                if isinstance(item, dict) and item.get("path")
+            ]
+            self._source_list.set_entries(entries)
+        else:
+            # Migrate from the legacy three-key format (iphone / takeout / jdrive)
+            entries = []
+            for key in ("iphone", "takeout", "jdrive"):
+                path = self.settings.get(f"sources.{key}", "")
+                if path:
+                    entries.append(_SourceEntry(path=path, recursive=True))
+            self._source_list.set_entries(entries)
+
         saved_out = self.settings.get("sources.output", "migration_manifest.sqlite")
-        self._output_row.path = saved_out
+        self._output_field.setText(saved_out or "migration_manifest.sqlite")
 
     def _save_to_settings(self) -> None:
-        for key, row in self._source_rows.items():
-            if row.path:
-                self.settings.set(f"sources.{key}", row.path)
-        if self._output_row.path:
-            self.settings.set("sources.output", self._output_row.path)
+        """Persist the current source list and output path to settings."""
+        entries = self._source_list.entries()
+        self.settings.set("sources.list", [
+            {"path": entry.path, "recursive": entry.recursive} for entry in entries
+        ])
+        output = self._output_field.text().strip()
+        if output:
+            self.settings.set("sources.output", output)
         try:
             self.settings.save()
-        except Exception:  # pylint: disable=broad-exception-caught
-            pass
+        except OSError:
+            pass  # Non-fatal — settings-save failure should not interrupt the UI
 
     # ------------------------------------------------------------------ scan
 
-    def _start_scan(self) -> None:
-        sources = {k: row.path for k, row in self._source_rows.items() if row.path}
-        output = self._output_row.path
+    def _build_sources(
+        self,
+    ) -> tuple[dict[str, str], dict[str, bool], dict[str, int]]:
+        """Build sources, recursive_map, and source_priority from the source list.
 
-        if not sources:
-            QMessageBox.warning(self, "No sources", "Please select at least one source folder.")
+        Labels are auto-generated from folder basenames (internal only; not shown
+        to the user — the full path is already visible in the table).
+
+        Returns:
+            A 3-tuple of (sources, recursive_map, source_priority) dicts keyed
+            by the auto-generated label.
+        """
+        entries = self._source_list.entries()
+        used_labels: set[str] = set()
+        sources: dict[str, str] = {}
+        recursive_map: dict[str, bool] = {}
+        source_priority: dict[str, int] = {}
+
+        for priority, entry in enumerate(entries):
+            folder_name = Path(entry.path).name or "source"
+            label = _auto_label(folder_name, used_labels)
+            used_labels.add(label)
+            sources[label] = entry.path
+            recursive_map[label] = entry.recursive
+            source_priority[label] = priority
+
+        return sources, recursive_map, source_priority
+
+    def _start_scan(self) -> None:
+        """Validate inputs and launch the background scan worker."""
+        if not self._source_list.entries():
+            QMessageBox.warning(self, "No sources", "Please add at least one source folder.")
             return
+        output = self._output_field.text().strip()
         if not output:
-            QMessageBox.warning(self, "No output", "Please specify an output path for the manifest.")
+            QMessageBox.warning(
+                self, "No output", "Please specify an output path for the manifest."
+            )
             return
 
         self._save_to_settings()
+        sources, recursive_map, source_priority = self._build_sources()
+
         self._log_widget.clear()
         self._log("Starting scan…")
         self._btn_scan.setEnabled(False)
 
-        self._worker = ScanWorker(sources=sources, output_path=output)
+        self._worker = ScanWorker(
+            sources=sources,
+            output_path=output,
+            recursive_map=recursive_map,
+            source_priority=source_priority,
+        )
         self._worker.progress.connect(self._log)
         self._worker.finished.connect(self._on_finished)
         self._worker.failed.connect(self._on_failed)
         self._worker.start()
 
     def _log(self, msg: str) -> None:
+        """Append ``msg`` to the progress log and scroll to the bottom."""
         self._log_widget.appendPlainText(msg)
         self._log_widget.verticalScrollBar().setValue(
             self._log_widget.verticalScrollBar().maximum()
         )
 
     def _on_finished(self, manifest_path: str) -> None:
+        """Handle scan completion: switch Close button to Close & Load."""
         self.manifest_path = manifest_path
         self._btn_scan.setEnabled(True)
         self._btn_close.setText("Close & Load")
@@ -229,16 +493,19 @@ class ScanDialog(QDialog):
         self._btn_close.clicked.connect(self._load_and_close)
 
     def _on_failed(self, error: str) -> None:
+        """Handle scan failure: log the error and re-enable the scan button."""
         self._log(f"\nERROR: {error}")
         self._btn_scan.setEnabled(True)
         QMessageBox.critical(self, "Scan Failed", error)
 
     def _load_and_close(self) -> None:
+        """Call the completion callback and close the dialog."""
         if self._on_complete and self.manifest_path:
             self._on_complete(self.manifest_path)
         self.accept()
 
-    def closeEvent(self, event) -> None:
+    def closeEvent(self, event: QCloseEvent) -> None:
+        """Stop any running scan worker before closing."""
         if self._worker and self._worker.isRunning():
             self._worker.requestInterruption()
             self._worker.wait(3000)

--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -22,14 +22,18 @@ class ScanWorker(QThread):
 
     def __init__(
         self,
-        sources: dict[str, str],   # label → path string
+        sources: dict[str, str],                    # label → path string
         output_path: str,
+        recursive_map: dict[str, bool] | None = None,
+        source_priority: dict[str, int] | None = None,
         threshold: int = 10,
         limit: int | None = None,
     ) -> None:
         super().__init__()
         self.sources = {k: Path(v) for k, v in sources.items() if v.strip()}
         self.output_path = Path(output_path)
+        self.recursive_map = recursive_map or {}
+        self.source_priority = source_priority   # None → auto-inferred in classify()
         self.threshold = threshold
         self.limit = limit
 
@@ -59,8 +63,13 @@ class ScanWorker(QThread):
         self._emit(f"Scanning {len(self.sources)} source(s)…")
         records = []
         for label, root in self.sources.items():
-            self._emit(f"  Walking {label}: {root} …")
-            partial = scan_sources({label: root}, limit=self.limit)
+            mode = "flat" if self.recursive_map.get(label) is False else "recursive"
+            self._emit(f"  Walking {label} ({mode}): {root} …")
+            partial = scan_sources(
+                {label: root},
+                limit=self.limit,
+                recursive_map={label: self.recursive_map.get(label, True)},
+            )
             self._emit(f"  → {len(partial):,} files")
             records.extend(partial)
         self._emit(f"  Total: {len(records):,} media files")
@@ -111,7 +120,11 @@ class ScanWorker(QThread):
 
         # --- 4. Classify ---
         self._emit("Classifying…")
-        rows = classify(hash_results, threshold=self.threshold)
+        rows = classify(
+            hash_results,
+            threshold=self.threshold,
+            source_priority=self.source_priority,
+        )
 
         # Capture print_summary output and re-emit as progress
         buf = io.StringIO()

--- a/scan.py
+++ b/scan.py
@@ -1,15 +1,20 @@
 """scan.py — Deduplication scanner CLI.
 
-Walks 3 source directories, computes SHA-256 + pHash for every media file,
-detects exact duplicates, cross-format duplicates, and near-duplicates, then
-writes a non-destructive migration_manifest.sqlite for human review.
+Walks one or more source directories, computes SHA-256 + pHash for every media
+file, detects exact duplicates, cross-format duplicates, and near-duplicates,
+then writes a non-destructive migration_manifest.sqlite for human review.
 
 Usage examples:
-  # Full scan
+  # Full recursive scan (all subdirectories included)
   python scan.py \\
-    --source iphone="C:\\path\\to\\iphone\\backup" \\
-    --source takeout="C:\\path\\to\\google\\takeout" \\
-    --source jdrive="C:\\path\\to\\photo\\library" \\
+    --source photos="C:\\path\\to\\photo\\library" \\
+    --source backup="\\\\NAS\\Photos\\MobileBackup" \\
+    --output migration_manifest.sqlite
+
+  # Mix recursive + top-level-only sources
+  python scan.py \\
+    --source archive="D:\\Archive" \\
+    --source-flat inbox="D:\\Inbox" \\
     --output migration_manifest.sqlite
 
   # Summary only, no DB written
@@ -53,8 +58,16 @@ def main() -> int:
         "--source",
         action="append",
         metavar="LABEL=PATH",
-        required=True,
-        help="Source to scan, e.g. iphone='\\\\NAS\\Photos\\MobileBackup\\iPhone' (repeatable)",
+        help="Recursive source to scan, e.g. photos='D:\\Pictures' (repeatable). "
+             "Sources are listed in priority order (first = highest priority).",
+    )
+    parser.add_argument(
+        "--source-flat",
+        action="append",
+        metavar="LABEL=PATH",
+        dest="source_flat",
+        help="Like --source but scans only the immediate folder (non-recursive). "
+             "Flat sources are listed after --source entries in priority order.",
     )
     parser.add_argument(
         "--output",
@@ -83,10 +96,27 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    if not args.source and not args.source_flat:
+        parser.error("at least one --source or --source-flat is required")
+
     sources: dict[str, Path] = {}
-    for raw in args.source:
+    recursive_map: dict[str, bool] = {}
+    source_priority: dict[str, int] = {}
+    priority = 0
+
+    for raw in (args.source or []):
         label, path = _parse_source(raw)
         sources[label] = path
+        recursive_map[label] = True
+        source_priority[label] = priority
+        priority += 1
+
+    for raw in (args.source_flat or []):
+        label, path = _parse_source(raw)
+        sources[label] = path
+        recursive_map[label] = False
+        source_priority[label] = priority
+        priority += 1
 
     # --- Import scanner modules (deferred so --help works without dependencies) ---
     from scanner.walker import scan_sources
@@ -103,8 +133,13 @@ def main() -> int:
     print(f"Scanning {len(sources)} source(s){limit_note}…", flush=True)
     records = []
     for label, root in sources.items():
-        print(f"  Walking {label}: {root} …", end=" ", flush=True)
-        partial = scan_sources({label: root}, limit=args.limit)
+        mode = "flat" if recursive_map.get(label) is False else "recursive"
+        print(f"  Walking {label} ({mode}): {root} …", end=" ", flush=True)
+        partial = scan_sources(
+            {label: root},
+            limit=args.limit,
+            recursive_map={label: recursive_map.get(label, True)},
+        )
         print(f"{len(partial):,} files", flush=True)
         records.extend(partial)
     print(f"  Total: {len(records):,} media files", flush=True)
@@ -148,7 +183,7 @@ def main() -> int:
         print("  Hashing done.", flush=True)
 
     print("Classifying…", flush=True)
-    rows = classify(hash_results, threshold=args.threshold)
+    rows = classify(hash_results, threshold=args.threshold, source_priority=source_priority)
 
     print_summary(rows)
 

--- a/scanner/dedup.py
+++ b/scanner/dedup.py
@@ -1,4 +1,4 @@
-"""Classify files as KEEP/MOVE/EXACT/REVIEW_DUPLICATE/UNDATED.
+"""Classify files as MOVE/EXACT/REVIEW_DUPLICATE/UNDATED.
 
 Classification rules:
   SHA-256 match                          → EXACT (exact duplicate)
@@ -6,9 +6,11 @@ Classification rules:
   pHash hamming == 0, one RAW + lossy    → MOVE both (complementary)
   pHash hamming 1–threshold              → REVIEW_DUPLICATE
   no EXIF date                           → UNDATED
-  otherwise                              → MOVE (or KEEP for iphone source)
+  otherwise                              → MOVE
 
-Source priority: iphone > takeout > jdrive
+Source priority: positional (index 0 = highest priority).
+  Pass ``source_priority`` dict to ``classify()``; omit it for auto-inference
+  from the order labels first appear in the input records.
 Format priority (lossy only): heic > jpeg > png > others
 """
 
@@ -31,8 +33,6 @@ from scanner.walker import FileRecord
 # ---------------------------------------------------------------------------
 # Priority tables
 # ---------------------------------------------------------------------------
-
-SOURCE_PRIORITY = {"iphone": 0, "takeout": 1, "jdrive": 2}
 
 FORMAT_PRIORITY = {"heic": 0, "jpeg": 1, "png": 2, "gif": 3, "webp": 4, "raw": -1}
 # raw is intentionally -1 (not comparable with lossy — RAW+lossy always co-exist)
@@ -79,40 +79,64 @@ class ManifestRow:
 # ---------------------------------------------------------------------------
 
 
-def classify(records: list[HashResult], threshold: int = 10) -> list[ManifestRow]:
+def classify(
+    records: list[HashResult],
+    threshold: int = 10,
+    source_priority: dict[str, int] | None = None,
+) -> list[ManifestRow]:
     """Assign an action to every record and return ManifestRows.
 
-    iPhone files always receive KEEP (already in place; used as dedup reference).
+    Args:
+        records: All hashed file records to classify.
+        threshold: Maximum Hamming distance to flag as REVIEW_DUPLICATE.
+        source_priority: Mapping of source label → priority integer (lower wins).
+            When ``None``, priority is inferred from the order labels first appear
+            in ``records`` (first seen = priority 0).
     """
+    if source_priority is None:
+        seen: dict[str, int] = {}
+        for hr in records:
+            label = hr.record.source_label
+            if label not in seen:
+                seen[label] = len(seen)
+        source_priority = seen
+
     rows: dict[Path, ManifestRow] = {}
 
     # Pass 1: exact SHA-256 duplicates
-    _classify_exact(records, rows)
+    _classify_exact(records, rows, source_priority)
 
     # Pass 2: pHash-based (cross-format + near-duplicate)
-    _classify_phash(records, rows, threshold)
+    _classify_phash(records, rows, threshold, source_priority)
 
-    # Pass 3: remaining unclassified files
+    # Pass 3: remaining unclassified files — all sources treated equally
     for hr in records:
         if hr.record.path in rows:
             continue
-        if hr.record.source_label == "iphone":
-            rows[hr.record.path] = _make_row(hr, "KEEP", reason="iphone source — stays in place")
-        elif hr.exif_date is None:
+        if hr.exif_date is None:
             rows[hr.record.path] = _make_row(hr, "UNDATED", reason="no EXIF DateTimeOriginal")
         else:
             rows[hr.record.path] = _make_row(
                 hr, "MOVE", reason="unique", dest=_dest_path(hr)
             )
 
-    # Pass 4: propagate SKIP/KEEP to Live Photo MOV partners
+    # Pass 4: propagate EXACT/KEEP actions to Live Photo MOV partners
     _propagate_pairs(records, rows)
 
     return list(rows.values())
 
 
-def _classify_exact(records: list[HashResult], rows: dict[Path, ManifestRow]) -> None:
-    """Group by SHA-256; mark lower-priority copies as SKIP."""
+def _priority(label: str, source_priority: dict[str, int]) -> int:
+    """Return sort priority for a source label (lower integer = higher priority)."""
+    return source_priority.get(label, len(source_priority))
+
+
+def _classify_exact(
+    records: list[HashResult],
+    rows: dict[Path, ManifestRow],
+    source_priority: dict[str, int],
+) -> None:
+    """Group by SHA-256; mark lower-priority copies as EXACT."""
     by_hash: dict[str, list[HashResult]] = {}
     for hr in records:
         by_hash.setdefault(hr.sha256, []).append(hr)
@@ -120,7 +144,7 @@ def _classify_exact(records: list[HashResult], rows: dict[Path, ManifestRow]) ->
     for group in by_hash.values():
         if len(group) < 2:
             continue
-        group.sort(key=lambda h: (SOURCE_PRIORITY.get(h.record.source_label, 99),))
+        group.sort(key=lambda h: _priority(h.record.source_label, source_priority))
         keeper = group[0]
         for duplicate in group[1:]:
             rows[duplicate.record.path] = _make_row(
@@ -132,7 +156,10 @@ def _classify_exact(records: list[HashResult], rows: dict[Path, ManifestRow]) ->
 
 
 def _classify_phash(
-    records: list[HashResult], rows: dict[Path, ManifestRow], threshold: int
+    records: list[HashResult],
+    rows: dict[Path, ManifestRow],
+    threshold: int,
+    source_priority: dict[str, int],
 ) -> None:
     """Group by pHash; classify FORMAT_DUPLICATE and REVIEW_DUPLICATE."""
     # Only consider records not already classified and with a valid pHash
@@ -147,14 +174,17 @@ def _classify_phash(
     for group in by_phash.values():
         if len(group) < 2:
             continue
-        _classify_format_group(group, rows)
+        _classify_format_group(group, rows, source_priority)
 
     # Near-duplicate scan: compare all pairs with hamming distance ≤ threshold
-    # Use bucket approach: compare within pHash prefix buckets to limit O(n²)
-    _classify_near_duplicates(candidates, rows, threshold)
+    _classify_near_duplicates(candidates, rows, threshold, source_priority)
 
 
-def _classify_format_group(group: list[HashResult], rows: dict[Path, ManifestRow]) -> None:
+def _classify_format_group(
+    group: list[HashResult],
+    rows: dict[Path, ManifestRow],
+    source_priority: dict[str, int],
+) -> None:
     """Within a pHash==0 group, apply RAW+lossy exception and format priority."""
     has_raw = any(hr.record.file_type == "raw" for hr in group)
     lossy = [hr for hr in group if hr.record.file_type in LOSSY_TYPES]
@@ -169,7 +199,7 @@ def _classify_format_group(group: list[HashResult], rows: dict[Path, ManifestRow
     # All lossy FORMAT_DUPLICATE: keep highest-format × highest-source-priority
     lossy.sort(key=lambda h: (
         FORMAT_PRIORITY.get(h.record.file_type, 99),
-        SOURCE_PRIORITY.get(h.record.source_label, 99),
+        _priority(h.record.source_label, source_priority),
     ))
     keeper = lossy[0]
     for duplicate in lossy[1:]:
@@ -186,7 +216,10 @@ def _classify_format_group(group: list[HashResult], rows: dict[Path, ManifestRow
 
 
 def _classify_near_duplicates(
-    candidates: list[HashResult], rows: dict[Path, ManifestRow], threshold: int
+    candidates: list[HashResult],
+    rows: dict[Path, ManifestRow],
+    threshold: int,
+    source_priority: dict[str, int],
 ) -> None:
     """Flag pHash pairs with hamming distance 1–threshold as REVIEW_DUPLICATE."""
     if not _IMAGEHASH_AVAILABLE:
@@ -206,7 +239,7 @@ def _classify_near_duplicates(
                 # Flag the lower-priority file as REVIEW_DUPLICATE
                 ordered = sorted(
                     [hr_a, hr_b],
-                    key=lambda h: SOURCE_PRIORITY.get(h.record.source_label, 99),
+                    key=lambda h: _priority(h.record.source_label, source_priority),
                 )
                 flagged = ordered[1]
                 if flagged.record.path not in rows:

--- a/scanner/walker.py
+++ b/scanner/walker.py
@@ -21,7 +21,7 @@ class FileRecord:
     """A single media file discovered during a source scan."""
 
     path: Path
-    source_label: str        # 'iphone' | 'takeout' | 'jdrive'
+    source_label: str        # user-supplied label (e.g. folder name or custom key)
     file_type: str           # 'jpeg' | 'heic' | 'raw' | 'png' | 'mp4' | 'mov' | …
     pair_partner: Optional[Path] = None  # MOV partner for Live Photo HEIC, or vice versa
     misnamed: bool = False   # True if magic bytes differ from file extension
@@ -30,27 +30,46 @@ class FileRecord:
 def scan_sources(
     sources: dict[str, Path],
     limit: int | None = None,
+    recursive_map: dict[str, bool] | None = None,
 ) -> list[FileRecord]:
     """Walk each source directory and return all discovered FileRecords.
 
     Args:
         sources: Mapping of label → root path.
         limit: If set, stop after this many files per source (for debug/dry-run).
+        recursive_map: Optional per-label recursive flag.  ``True`` (or absent)
+            means walk all subdirectories; ``False`` means top-level files only.
+            When ``None`` all sources are scanned recursively (original behaviour).
     """
     records: list[FileRecord] = []
     for label, root in sources.items():
         if not root.exists():
             raise FileNotFoundError(f"Source directory not found: {root}")
-        records.extend(_scan_dir(root, label, limit=limit))
+        recursive = True if recursive_map is None else recursive_map.get(label, True)
+        records.extend(_scan_dir(root, label, limit=limit, recursive=recursive))
     return records
 
 
-def _scan_dir(root: Path, label: str, limit: int | None = None) -> list[FileRecord]:
-    """Recursively walk root and return FileRecords with Live Photo pairs resolved."""
+def _scan_dir(
+    root: Path,
+    label: str,
+    limit: int | None = None,
+    recursive: bool = True,
+) -> list[FileRecord]:
+    """Walk root and return FileRecords with Live Photo pairs resolved.
+
+    Args:
+        root: Root directory to scan.
+        label: Source label assigned to every returned record.
+        limit: Stop after this many files (for debug/dry-run).
+        recursive: When ``True`` walk all subdirectories (default); when
+            ``False`` scan only the immediate files in ``root``.
+    """
     # Collect all media files grouped by directory for efficient pairing
     by_dir: dict[Path, list[Path]] = {}
     total = 0
-    for path in root.rglob("*"):
+    glob_fn = root.rglob if recursive else root.glob
+    for path in glob_fn("*"):
         if not path.is_file():
             continue
         if path.name.lower() in SKIP_FILENAMES:

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -54,45 +54,60 @@ def _hr(
 
 
 # ---------------------------------------------------------------------------
-# KEEP for iPhone source
-# ---------------------------------------------------------------------------
-
-class TestIphoneKeep:
-    def test_iphone_always_keep(self):
-        hr = _hr("/iphone/IMG_001.HEIC", source_label="iphone", exif_date=_dt())
-        rows = classify([hr])
-        assert rows[0].action == "KEEP"
-
-    def test_iphone_keep_even_when_duplicate_elsewhere(self):
-        iphone = _hr("/iphone/IMG_001.HEIC", sha256="abc", source_label="iphone",
-                     exif_date=_dt())
-        jdrive = _hr("/jdrive/IMG_001.jpg", sha256="abc", source_label="jdrive",
-                     exif_date=_dt())
-        rows = _rows(classify([iphone, jdrive]))
-        assert rows["/iphone/IMG_001.HEIC"].action == "KEEP"
-        assert rows["/jdrive/IMG_001.jpg"].action == "EXACT"
-
-
-# ---------------------------------------------------------------------------
 # EXACT_DUPLICATE
 # ---------------------------------------------------------------------------
 
 class TestExactDuplicate:
     def test_lower_priority_source_skipped(self):
-        iphone = _hr("/iphone/a.jpg", sha256="same", source_label="iphone", exif_date=_dt())
-        takeout = _hr("/takeout/a.jpg", sha256="same", source_label="takeout", exif_date=_dt())
-        jdrive = _hr("/jdrive/a.jpg", sha256="same", source_label="jdrive", exif_date=_dt())
-        rows = _rows(classify([iphone, takeout, jdrive]))
-        assert rows["/iphone/a.jpg"].action == "KEEP"
-        assert rows["/takeout/a.jpg"].action == "EXACT"
-        assert rows["/jdrive/a.jpg"].action == "EXACT"
+        src_a = _hr("/src_a/a.jpg", sha256="same", source_label="src_a", exif_date=_dt())
+        src_b = _hr("/src_b/a.jpg", sha256="same", source_label="src_b", exif_date=_dt())
+        src_c = _hr("/src_c/a.jpg", sha256="same", source_label="src_c", exif_date=_dt())
+        rows = _rows(classify(
+            [src_a, src_b, src_c],
+            source_priority={"src_a": 0, "src_b": 1, "src_c": 2},
+        ))
+        assert rows["/src_a/a.jpg"].action == "MOVE"   # survivor — MOVE, not KEEP
+        assert rows["/src_b/a.jpg"].action == "EXACT"
+        assert rows["/src_c/a.jpg"].action == "EXACT"
 
     def test_skip_points_to_kept_file(self):
         a = _hr("/jdrive/a.jpg", sha256="x", source_label="jdrive", exif_date=_dt())
         b = _hr("/takeout/b.jpg", sha256="x", source_label="takeout", exif_date=_dt())
-        rows = _rows(classify([a, b]))
-        kept = "/takeout/b.jpg"  # takeout > jdrive
+        rows = _rows(classify([a, b], source_priority={"takeout": 0, "jdrive": 1}))
+        kept = "/takeout/b.jpg"  # takeout priority 0 > jdrive priority 1
         assert Path(rows["/jdrive/a.jpg"].duplicate_of).as_posix() == kept
+
+
+# ---------------------------------------------------------------------------
+# Dynamic source priority
+# ---------------------------------------------------------------------------
+
+class TestDynamicSourcePriority:
+    def test_first_source_wins_exact_dup(self):
+        """Source with priority 0 wins; lower-priority copy gets EXACT."""
+        a = _hr("/src_a/photo.jpg", sha256="same", source_label="src_a", exif_date=_dt())
+        b = _hr("/src_b/photo.jpg", sha256="same", source_label="src_b", exif_date=_dt())
+        rows = _rows(classify([a, b], source_priority={"src_a": 0, "src_b": 1}))
+        assert rows["/src_a/photo.jpg"].action == "MOVE"
+        assert rows["/src_b/photo.jpg"].action == "EXACT"
+
+    def test_second_source_priority_reversed(self):
+        """With reversed priority, src_b wins."""
+        a = _hr("/src_a/photo.jpg", sha256="same", source_label="src_a", exif_date=_dt())
+        b = _hr("/src_b/photo.jpg", sha256="same", source_label="src_b", exif_date=_dt())
+        rows = _rows(classify([a, b], source_priority={"src_a": 1, "src_b": 0}))
+        assert rows["/src_b/photo.jpg"].action == "MOVE"
+        assert rows["/src_a/photo.jpg"].action == "EXACT"
+
+    def test_no_source_priority_auto_infers_from_order(self):
+        """Without explicit source_priority, first-seen label gets priority 0."""
+        first = _hr("/first/photo.jpg", sha256="dup", source_label="first_src",
+                    exif_date=_dt())
+        second = _hr("/second/photo.jpg", sha256="dup", source_label="second_src",
+                     exif_date=_dt())
+        rows = _rows(classify([first, second]))   # no source_priority
+        assert rows["/first/photo.jpg"].action == "MOVE"   # first-seen wins
+        assert rows["/second/photo.jpg"].action == "EXACT"
 
 
 # ---------------------------------------------------------------------------
@@ -159,10 +174,10 @@ class TestUndated:
         rows = classify([hr])
         assert rows[0].action == "UNDATED"
 
-    def test_iphone_undated_still_keep(self):
-        hr = _hr("/iphone/IMG.HEIC", source_label="iphone", exif_date=None)
+    def test_undated_file_from_any_source_becomes_undated(self):
+        hr = _hr("/any_source/IMG.HEIC", source_label="any_source", exif_date=None)
         rows = classify([hr])
-        assert rows[0].action == "KEEP"
+        assert rows[0].action == "UNDATED"
 
 
 # ---------------------------------------------------------------------------
@@ -184,7 +199,7 @@ class TestLivePhotoPair:
         orig = _hr(str(orig_heic_path), sha256="x", source_label="iphone",
                    file_type="heic", exif_date=_dt())
 
-        rows = _rows(classify([heic, mov, orig]))
+        rows = _rows(classify([heic, mov, orig], source_priority={"iphone": 0, "jdrive": 1}))
         assert rows[heic_path.as_posix()].action == "EXACT"
         assert rows[mov_path.as_posix()].action == "EXACT"
 

--- a/tests/test_scan_dialog.py
+++ b/tests/test_scan_dialog.py
@@ -1,0 +1,371 @@
+"""Tests for app/views/dialogs/scan_dialog.py — _auto_label and _SourceListWidget."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from app.views.dialogs.scan_dialog import _SourceEntry, _SourceListWidget, _auto_label
+
+
+# ---------------------------------------------------------------------------
+# _auto_label
+# ---------------------------------------------------------------------------
+
+class TestAutoLabel:
+    def test_uses_name_when_not_in_use(self):
+        assert _auto_label("Photos", set()) == "Photos"
+
+    def test_appends_2_on_first_collision(self):
+        assert _auto_label("Photos", {"Photos"}) == "Photos_2"
+
+    def test_appends_3_on_second_collision(self):
+        assert _auto_label("Photos", {"Photos", "Photos_2"}) == "Photos_3"
+
+    def test_skips_occupied_numbers(self):
+        existing = {"Photos", "Photos_2", "Photos_3"}
+        assert _auto_label("Photos", existing) == "Photos_4"
+
+    def test_empty_existing_set(self):
+        assert _auto_label("Downloads", set()) == "Downloads"
+
+    def test_does_not_modify_existing_set(self):
+        existing: set[str] = {"Foo"}
+        _auto_label("Foo", existing)
+        assert existing == {"Foo"}
+
+
+# ---------------------------------------------------------------------------
+# _SourceListWidget
+# ---------------------------------------------------------------------------
+
+class TestSourceListWidget:
+    def test_starts_empty(self, qapp):
+        widget = _SourceListWidget()
+        assert widget.entries() == []
+
+    def test_add_entry(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a")
+        entries = widget.entries()
+        assert len(entries) == 1
+        assert entries[0].path == "/path/a"
+        assert entries[0].recursive is True
+
+    def test_add_entry_with_recursive_false(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/b", recursive=False)
+        assert widget.entries()[0].recursive is False
+
+    def test_duplicate_path_silently_ignored(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a")
+        widget.add_entry("/path/a")
+        assert len(widget.entries()) == 1
+
+    def test_add_multiple_entries(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a")
+        widget.add_entry("/path/b")
+        widget.add_entry("/path/c")
+        assert len(widget.entries()) == 3
+
+    def test_clear_removes_all(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a")
+        widget.add_entry("/path/b")
+        widget.clear()
+        assert widget.entries() == []
+
+    def test_remove_first_entry(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a")
+        widget.add_entry("/path/b")
+        widget._remove(0)
+        entries = widget.entries()
+        assert len(entries) == 1
+        assert entries[0].path == "/path/b"
+
+    def test_remove_last_entry(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a")
+        widget.add_entry("/path/b")
+        widget._remove(1)
+        assert widget.entries()[0].path == "/path/a"
+
+    def test_remove_out_of_range_is_noop(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a")
+        widget._remove(5)
+        assert len(widget.entries()) == 1
+
+    def test_move_up(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a")
+        widget.add_entry("/path/b")
+        widget._move(1, -1)   # move b up
+        assert widget.entries()[0].path == "/path/b"
+        assert widget.entries()[1].path == "/path/a"
+
+    def test_move_down(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a")
+        widget.add_entry("/path/b")
+        widget._move(0, +1)   # move a down
+        assert widget.entries()[0].path == "/path/b"
+        assert widget.entries()[1].path == "/path/a"
+
+    def test_move_up_at_top_is_noop(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a")
+        widget.add_entry("/path/b")
+        widget._move(0, -1)   # already at top
+        assert widget.entries()[0].path == "/path/a"
+
+    def test_move_down_at_bottom_is_noop(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a")
+        widget.add_entry("/path/b")
+        widget._move(1, +1)   # already at bottom
+        assert widget.entries()[1].path == "/path/b"
+
+    def test_set_entries_replaces_list(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/old/path")
+        widget.set_entries([
+            _SourceEntry(path="/new/a", recursive=True),
+            _SourceEntry(path="/new/b", recursive=False),
+        ])
+        entries = widget.entries()
+        assert len(entries) == 2
+        assert entries[0].path == "/new/a"
+        assert entries[1].path == "/new/b"
+        assert entries[1].recursive is False
+
+    def test_changed_signal_on_add(self, qapp):
+        widget = _SourceListWidget()
+        received: list[None] = []
+        widget.changed.connect(lambda: received.append(None))
+        widget.add_entry("/path/x")
+        assert len(received) == 1
+
+    def test_changed_signal_on_remove(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/x")
+        received: list[None] = []
+        widget.changed.connect(lambda: received.append(None))
+        widget._remove(0)
+        assert len(received) == 1
+
+    def test_changed_signal_on_clear(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/x")
+        received: list[None] = []
+        widget.changed.connect(lambda: received.append(None))
+        widget.clear()
+        assert len(received) == 1
+
+    def test_changed_signal_on_move(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a")
+        widget.add_entry("/path/b")
+        received: list[None] = []
+        widget.changed.connect(lambda: received.append(None))
+        widget._move(0, +1)
+        assert len(received) == 1
+
+    def test_on_recursive_changed_true(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a", recursive=False)
+        widget._on_recursive_changed(0, 2)   # 2 = Qt.CheckState.Checked value
+        assert widget.entries()[0].recursive is True
+
+    def test_on_recursive_changed_false(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a", recursive=True)
+        widget._on_recursive_changed(0, 0)   # 0 = unchecked
+        assert widget.entries()[0].recursive is False
+
+    def test_on_recursive_changed_out_of_range_is_noop(self, qapp):
+        widget = _SourceListWidget()
+        widget.add_entry("/path/a")
+        widget._on_recursive_changed(99, 2)  # no-op
+        assert widget.entries()[0].recursive is True
+
+
+# ---------------------------------------------------------------------------
+# ScanDialog — settings loading / saving (tested without showing the dialog)
+# ---------------------------------------------------------------------------
+
+class TestScanDialogSettings:
+    def _make_settings_file(self, tmp_path: Path, data: dict) -> Path:
+        """Write JSON to a temp settings file and return the path."""
+        p = tmp_path / "settings.json"
+        p.write_text(json.dumps(data), encoding="utf-8")
+        return p
+
+    def test_load_new_format(self, qapp, tmp_path):
+        """sources.list entries are loaded into the source list."""
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = self._make_settings_file(tmp_path, {
+            "sources": {
+                "list": [
+                    {"path": "/foo/bar", "recursive": True},
+                    {"path": "/baz/qux", "recursive": False},
+                ],
+                "output": "/out/manifest.sqlite",
+            }
+        })
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+
+        entries = dlg._source_list.entries()
+        assert len(entries) == 2
+        assert entries[0].path == "/foo/bar"
+        assert entries[0].recursive is True
+        assert entries[1].path == "/baz/qux"
+        assert entries[1].recursive is False
+        assert dlg._output_field.text() == "/out/manifest.sqlite"
+
+    def test_migrate_legacy_format(self, qapp, tmp_path):
+        """Old iphone/takeout/jdrive keys are migrated to entries."""
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = self._make_settings_file(tmp_path, {
+            "sources": {
+                "iphone": "/nas/iphone",
+                "takeout": "/nas/takeout",
+                "jdrive": "/nas/jdrive",
+                "output": "migration_manifest.sqlite",
+            }
+        })
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+
+        entries = dlg._source_list.entries()
+        assert len(entries) == 3
+        paths = [e.path for e in entries]
+        assert "/nas/iphone" in paths
+        assert "/nas/takeout" in paths
+        assert "/nas/jdrive" in paths
+        # All migrated entries default to recursive=True
+        assert all(e.recursive for e in entries)
+
+    def test_migrate_skips_empty_legacy_keys(self, qapp, tmp_path):
+        """Empty legacy source keys are not added as entries."""
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = self._make_settings_file(tmp_path, {
+            "sources": {
+                "iphone": "/nas/iphone",
+                "takeout": "",           # empty — should be skipped
+                "jdrive": "",            # empty — should be skipped
+                "output": "manifest.sqlite",
+            }
+        })
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+
+        entries = dlg._source_list.entries()
+        assert len(entries) == 1
+        assert entries[0].path == "/nas/iphone"
+
+    def test_save_writes_list_format(self, qapp, tmp_path):
+        """_save_to_settings writes the new sources.list format."""
+        from app.views.dialogs.scan_dialog import ScanDialog, _SourceEntry
+        from infrastructure.settings import JsonSettings
+
+        settings_path = self._make_settings_file(tmp_path, {"sources": {}})
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+
+        dlg._source_list.set_entries([
+            _SourceEntry(path="/new/a", recursive=True),
+            _SourceEntry(path="/new/b", recursive=False),
+        ])
+        dlg._output_field.setText("/out/manifest.sqlite")
+        dlg._save_to_settings()
+
+        saved = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert saved["sources"]["list"] == [
+            {"path": "/new/a", "recursive": True},
+            {"path": "/new/b", "recursive": False},
+        ]
+        assert saved["sources"]["output"] == "/out/manifest.sqlite"
+
+
+# ---------------------------------------------------------------------------
+# _build_sources (label auto-generation + source_priority ordering)
+# ---------------------------------------------------------------------------
+
+class TestBuildSources:
+    def test_labels_derived_from_folder_name(self, qapp, tmp_path):
+        from app.views.dialogs.scan_dialog import ScanDialog, _SourceEntry
+        from infrastructure.settings import JsonSettings
+
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text('{"sources":{}}', encoding="utf-8")
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+
+        dlg._source_list.set_entries([
+            _SourceEntry(path="/nas/Takeout", recursive=True),
+            _SourceEntry(path="/nas/Photos", recursive=False),
+        ])
+        sources, recursive_map, source_priority = dlg._build_sources()
+
+        assert "Takeout" in sources
+        assert "Photos" in sources
+        assert recursive_map["Takeout"] is True
+        assert recursive_map["Photos"] is False
+
+    def test_source_priority_matches_list_order(self, qapp, tmp_path):
+        from app.views.dialogs.scan_dialog import ScanDialog, _SourceEntry
+        from infrastructure.settings import JsonSettings
+
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text('{"sources":{}}', encoding="utf-8")
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+
+        dlg._source_list.set_entries([
+            _SourceEntry(path="/nas/First"),
+            _SourceEntry(path="/nas/Second"),
+            _SourceEntry(path="/nas/Third"),
+        ])
+        _, _, source_priority = dlg._build_sources()
+
+        # Keys may differ (from folder names), but priority order must be 0, 1, 2
+        priorities = sorted(source_priority.values())
+        assert priorities == [0, 1, 2]
+        # The folder named "First" must have the lowest priority number
+        first_label = "First"
+        second_label = "Second"
+        third_label = "Third"
+        assert source_priority[first_label] < source_priority[second_label]
+        assert source_priority[second_label] < source_priority[third_label]
+
+    def test_duplicate_folder_names_get_unique_labels(self, qapp, tmp_path):
+        from app.views.dialogs.scan_dialog import ScanDialog, _SourceEntry
+        from infrastructure.settings import JsonSettings
+
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text('{"sources":{}}', encoding="utf-8")
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+
+        dlg._source_list.set_entries([
+            _SourceEntry(path="/drive1/Photos"),
+            _SourceEntry(path="/drive2/Photos"),   # same folder name
+        ])
+        sources, _, _ = dlg._build_sources()
+
+        assert len(sources) == 2
+        assert "Photos" in sources
+        assert "Photos_2" in sources

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -110,3 +110,46 @@ class TestLivePhotoPairing:
         records = scan_sources({"test": tmp_path})
         heic = next(r for r in records if r.path.suffix.upper() == ".HEIC")
         assert heic.pair_partner is not None
+
+
+class TestFlatScan:
+    def test_flat_scan_finds_top_level_file(self, tmp_path):
+        from scanner.walker import scan_sources
+        _write_jpeg(tmp_path / "photo.jpg")
+        records = scan_sources({"test": tmp_path}, recursive_map={"test": False})
+        assert len(records) == 1
+
+    def test_flat_scan_ignores_nested_file(self, tmp_path):
+        from scanner.walker import scan_sources
+        subdir = tmp_path / "sub"
+        subdir.mkdir()
+        _write_jpeg(subdir / "photo.jpg")
+        records = scan_sources({"test": tmp_path}, recursive_map={"test": False})
+        assert records == []
+
+    def test_recursive_map_none_means_all_recursive(self, tmp_path):
+        """Omitting recursive_map preserves existing fully-recursive behaviour."""
+        from scanner.walker import scan_sources
+        subdir = tmp_path / "sub"
+        subdir.mkdir()
+        _write_jpeg(subdir / "nested.jpg")
+        records = scan_sources({"test": tmp_path})   # no recursive_map
+        assert len(records) == 1
+
+    def test_recursive_map_per_source(self, tmp_path):
+        from scanner.walker import scan_sources
+        flat_dir = tmp_path / "flat"
+        rec_dir = tmp_path / "rec"
+        flat_dir.mkdir()
+        rec_dir.mkdir()
+        (flat_dir / "sub").mkdir()
+        (rec_dir / "sub").mkdir()
+        _write_jpeg(flat_dir / "sub" / "a.jpg")   # nested in flat — excluded
+        _write_jpeg(rec_dir / "sub" / "b.jpg")    # nested in recursive — included
+        records = scan_sources(
+            {"flat": flat_dir, "rec": rec_dir},
+            recursive_map={"flat": False, "rec": True},
+        )
+        labels = {r.source_label for r in records}
+        assert "flat" not in labels
+        assert "rec" in labels


### PR DESCRIPTION
## Summary

- **Unlimited source folders** — the scan dialog now embeds a `QFileSystemModel` filesystem tree; users double-click or press *+ Add Selected Folder* to add any number of sources (previously hard-capped at 3: iphone/takeout/jdrive)
- **Per-source Recursive toggle** — each source has a checkbox: ticked = scan all subdirectories (default), unticked = top-level files only (`--source-flat` in CLI)
- **Dynamic source priority** — list order drives dedup priority (top row = highest); no hardcoded source names or iphone→KEEP special-case; all sources are treated equally
- **Settings migration** — old `sources.iphone / takeout / jdrive` keys auto-migrate to `sources.list: [{path, recursive}, …]` on first open

## Changed files

| File | Change |
|------|--------|
| `scanner/dedup.py` | Drop `SOURCE_PRIORITY` constant + iphone→KEEP; `classify()` gains `source_priority` param (auto-inferred when omitted) |
| `scanner/walker.py` | `scan_sources()` gains `recursive_map` param; `_scan_dir()` gains `recursive` flag |
| `app/views/workers/scan_worker.py` | Thread `recursive_map` + `source_priority` to backend |
| `app/views/dialogs/scan_dialog.py` | Full redesign: `_FolderTreePanel`, `_SourceListWidget`, `_auto_label`, settings migration |
| `scan.py` | Add `--source-flat`; explicit `source_priority` from arg order |
| `tests/test_dedup.py` | Drop iphone-KEEP tests; add `TestDynamicSourcePriority` |
| `tests/test_walker.py` | Add `TestFlatScan` |
| `tests/test_scan_dialog.py` | New — 30 tests for `_auto_label`, `_SourceListWidget`, `ScanDialog` settings |
| `README.md` / `DESIGN.md` | Sync docs |

## Test plan

- [x] 308 tests pass (`python -m pytest tests/ -q`)
- [x] TDD: RED → GREEN cycle verified for each changed module
- [ ] Manual: launch `python main.py` → File > Scan Sources… → tree loads, add folders, reorder, toggle Recursive, Start Scan

🤖 Generated with [Claude Code](https://claude.com/claude-code)