### PR TITLE
feat(scanner): pixel dimensions from open PIL image, Resolution column in UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,8 +93,12 @@ settings.json
 # Databases
 *.sqlite
 *.sqlite3
+*.sqlite-shm
+*.sqlite-wal
 *.db
 *.db-journal
+*.db-shm
+*.db-wal
 
 # Temporary files
 tmp/

--- a/app/views/constants.py
+++ b/app/views/constants.py
@@ -17,6 +17,7 @@ HEADERS: list[str] = [
     "Group Count",
     "Creation Date",
     "Shot Date",
+    "Resolution",
 ]
 
 COL_GROUP: int = 0
@@ -28,7 +29,8 @@ COL_SIZE_BYTES: int = 5
 COL_GROUP_COUNT: int = 6
 COL_CREATION_DATE: int = 7
 COL_SHOT_DATE: int = 8
-NUM_COLUMNS: int = 9
+COL_RESOLUTION: int = 9
+NUM_COLUMNS: int = 10
 
 
 # Data roles

--- a/app/views/tree_model_builder.py
+++ b/app/views/tree_model_builder.py
@@ -13,6 +13,7 @@ from app.views.constants import (
     COL_GROUP,
     COL_GROUP_COUNT,
     COL_NAME,
+    COL_RESOLUTION,
     COL_SEL,
     COL_SHOT_DATE,
     COL_SIZE_BYTES,
@@ -76,15 +77,16 @@ def build_model(
 
         group_count_val = len(items_list)
         group_row = [
-            group_item,                              # COL_GROUP  (0)
-            QStandardItem(""),                       # COL_SEL    (1)
-            QStandardItem(""),                       # COL_ACTION (2) — decision at file level
-            QStandardItem(""),                       # COL_NAME   (3)
-            QStandardItem(""),                       # COL_FOLDER (4)
+            group_item,                              # COL_GROUP      (0)
+            QStandardItem(""),                       # COL_SEL        (1)
+            QStandardItem(""),                       # COL_ACTION     (2) — decision at file level
+            QStandardItem(""),                       # COL_NAME       (3)
+            QStandardItem(""),                       # COL_FOLDER     (4)
             QStandardItem(""),                       # COL_SIZE_BYTES (5)
             QStandardItem(str(group_count_val)),     # COL_GROUP_COUNT (6)
             QStandardItem(""),                       # COL_CREATION_DATE (7)
-            QStandardItem(""),                       # COL_SHOT_DATE (8)
+            QStandardItem(""),                       # COL_SHOT_DATE  (8)
+            QStandardItem(""),                       # COL_RESOLUTION (9) — group level empty
         ]
         for it in group_row:
             it.setEditable(False)
@@ -160,6 +162,14 @@ def build_model(
             group_row[COL_SHOT_DATE].setData(min(sd_timestamps, default=0), SORT_ROLE)
         except Exception:
             pass
+        try:
+            megapixels = [
+                (getattr(it, "pixel_width", None) or 0) * (getattr(it, "pixel_height", None) or 0)
+                for it in items_list
+            ]
+            group_row[COL_RESOLUTION].setData(max(megapixels, default=0), SORT_ROLE)
+        except Exception:
+            pass
 
         model.appendRow(group_row)
 
@@ -171,6 +181,10 @@ def build_model(
             creation_dt = getattr(p, "creation_date", None)
             shot_txt = shot_dt.strftime("%Y-%m-%d %H:%M:%S") if shot_dt else ""
             creation_txt = creation_dt.strftime("%Y-%m-%d %H:%M:%S") if creation_dt else ""
+            px_w = getattr(p, "pixel_width", None)
+            px_h = getattr(p, "pixel_height", None)
+            resolution_txt = f"{px_w}×{px_h}" if px_w and px_h else ""
+            resolution_mp = (px_w or 0) * (px_h or 0)
 
             # Col 0 at file row: similarity % for duplicates, "Ref" for the source file
             file_action = getattr(p, "action", "") or ""
@@ -190,15 +204,16 @@ def build_model(
                 pass
 
             child_row = [
-                QStandardItem(file_match),          # COL_GROUP  (0) — match type
-                check,                               # COL_SEL    (1)
-                QStandardItem(item_decision),        # COL_ACTION (2) — user decision
-                QStandardItem(name),                 # COL_NAME   (3)
-                QStandardItem(folder),               # COL_FOLDER (4)
+                QStandardItem(file_match),           # COL_GROUP      (0) — match type
+                check,                               # COL_SEL        (1)
+                QStandardItem(item_decision),        # COL_ACTION     (2) — user decision
+                QStandardItem(name),                 # COL_NAME       (3)
+                QStandardItem(folder),               # COL_FOLDER     (4)
                 QStandardItem(str(size_num)),        # COL_SIZE_BYTES (5)
                 QStandardItem(""),                   # COL_GROUP_COUNT (6) — group level only
                 QStandardItem(creation_txt),         # COL_CREATION_DATE (7)
-                QStandardItem(shot_txt),             # COL_SHOT_DATE (8)
+                QStandardItem(shot_txt),             # COL_SHOT_DATE  (8)
+                QStandardItem(resolution_txt),       # COL_RESOLUTION (9)
             ]
 
             try:
@@ -235,6 +250,10 @@ def build_model(
                 child_row[COL_SHOT_DATE].setData(
                     int(shot_dt.timestamp()) if shot_dt else 0, SORT_ROLE
                 )
+            except Exception:
+                pass
+            try:
+                child_row[COL_RESOLUTION].setData(resolution_mp, SORT_ROLE)
             except Exception:
                 pass
             try:

--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -95,9 +95,12 @@ class ScanWorker(QThread):
             idx, record = idx_record
             if cancel_flag.is_set():
                 return idx, None
-            sha256, phash, mean_color, raw_date = compute_hashes(record.path, record.file_type)
+            sha256, phash, mean_color, raw_date, px_w, px_h = compute_hashes(record.path, record.file_type)
             pil_date = parse_exif_date(raw_date) if raw_date else None
-            return idx, HashResult(record=record, sha256=sha256, phash=phash, mean_color=mean_color, exif_date=pil_date)
+            return idx, HashResult(
+                record=record, sha256=sha256, phash=phash, mean_color=mean_color,
+                exif_date=pil_date, pixel_width=px_w, pixel_height=px_h,
+            )
 
         self._emit(f"Hashing {len(records):,} files (workers={self.workers})…")
         hash_results: list[HashResult] = [None] * len(records)  # type: ignore[list-item]

--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -48,7 +48,8 @@ def _connect(path: str) -> sqlite3.Connection:
 _LOAD_ALL_SQL = """
 SELECT id, source_path, source_label, group_id, hamming_distance, reason,
        action, executed, user_decision,
-       file_size_bytes, shot_date, creation_date, mtime
+       file_size_bytes, shot_date, creation_date, mtime,
+       pixel_width, pixel_height
 FROM   migration_manifest
 ORDER  BY
     group_id NULLS LAST,
@@ -72,6 +73,8 @@ _MIGRATIONS = [
     ("creation_date",   "TEXT"),
     ("mtime",           "TEXT"),
     ("group_id",        "TEXT"),
+    ("pixel_width",     "INTEGER"),
+    ("pixel_height",    "INTEGER"),
 ]
 
 _UPDATE_DECISION_SQL = """
@@ -100,6 +103,8 @@ def _photo_record(
     db_creation_date: "str | None" = None,
     db_mtime: "str | None" = None,
     hamming_distance: "int | None" = None,
+    db_pixel_width: "int | None" = None,
+    db_pixel_height: "int | None" = None,
 ) -> PhotoRecord:
     """Build a PhotoRecord, preferring cached DB metadata over filesystem reads.
 
@@ -161,6 +166,8 @@ def _photo_record(
         action=action,
         user_decision=user_decision,
         hamming_distance=hamming_distance,
+        pixel_width=db_pixel_width,
+        pixel_height=db_pixel_height,
     )
 
 
@@ -238,6 +245,8 @@ class ManifestRepository:
                         db_creation_date=row["creation_date"],
                         db_mtime=row["mtime"],
                         hamming_distance=row["hamming_distance"],
+                        db_pixel_width=row["pixel_width"],
+                        db_pixel_height=row["pixel_height"],
                     )
                 except Exception as exc:  # pylint: disable=broad-exception-caught
                     logger.warning("Skipping {}: {}", source_path, exc)

--- a/scan.py
+++ b/scan.py
@@ -166,9 +166,12 @@ def main() -> int:
 
     def _hash_one(idx_record: tuple) -> tuple:
         idx, record = idx_record
-        sha256, phash, mean_color, raw_date = compute_hashes(record.path, record.file_type)
+        sha256, phash, mean_color, raw_date, px_w, px_h = compute_hashes(record.path, record.file_type)
         pil_date = parse_exif_date(raw_date) if raw_date else None
-        return idx, HashResult(record=record, sha256=sha256, phash=phash, mean_color=mean_color, exif_date=pil_date)
+        return idx, HashResult(
+            record=record, sha256=sha256, phash=phash, mean_color=mean_color,
+            exif_date=pil_date, pixel_width=px_w, pixel_height=px_h,
+        )
 
     done = 0
     with ThreadPoolExecutor(max_workers=args.workers) as pool:

--- a/scanner/dedup.py
+++ b/scanner/dedup.py
@@ -52,7 +52,9 @@ class HashResult:
     sha256: str
     phash: Optional[str]       # None for video or hash failure
     exif_date: Optional[datetime]
-    mean_color: Optional[str] = None  # "R,G,B" average pixel; None for video/RAW/failure
+    mean_color: Optional[str] = None   # "R,G,B" average pixel; None for video/RAW/failure
+    pixel_width: Optional[int] = None  # image width in pixels; None for video/failure
+    pixel_height: Optional[int] = None # image height in pixels; None for video/failure
 
 
 @dataclass
@@ -74,6 +76,8 @@ class ManifestRow:
     creation_date: Optional[str] = None  # ISO 8601 filesystem ctime
     mtime: Optional[str] = None          # ISO 8601 filesystem mtime
     group_id: Optional[str] = None       # canonical root path of connected component; written to DB
+    pixel_width: Optional[int] = None    # image width in pixels; written to DB
+    pixel_height: Optional[int] = None   # image height in pixels; written to DB
 
 
 # ---------------------------------------------------------------------------
@@ -385,6 +389,8 @@ def _make_row(
         shot_date=_shot,
         creation_date=_ctime.isoformat() if _ctime else None,
         mtime=_mtime,
+        pixel_width=hr.pixel_width,
+        pixel_height=hr.pixel_height,
     )
 
 

--- a/scanner/hasher.py
+++ b/scanner/hasher.py
@@ -37,55 +37,61 @@ def compute_sha256(path: Path) -> str:
     return h.hexdigest()
 
 
-def compute_hashes(path: Path, file_type: str) -> tuple[str, Optional[str], Optional[str], Optional[str]]:
-    """Single file read: ``(sha256, phash, mean_color, raw_exif_date)``. One network round-trip.
+def compute_hashes(
+    path: Path, file_type: str
+) -> tuple[str, Optional[str], Optional[str], Optional[str], Optional[int], Optional[int]]:
+    """Single file read: ``(sha256, phash, mean_color, raw_exif_date, width, height)``.
 
-    mean_color is the average RGB of the image, computed from the same PIL image as
-    pHash via a 1×1 LANCZOS downscale — no extra file open, no degenerate edge cases.
-    Stored as ``"R,G,B"`` (e.g. ``"132,133,114"``). Used as a false-positive gate in
-    near-duplicate classification: two images with similar pHash but very different mean
-    colors are almost certainly not duplicates.
-
+    All six values are derived from one in-memory read — no extra file open.
+    ``width``/``height`` are the pixel dimensions of the decoded image (or ``None``
+    for video/skip and on decode failure).  For RAW files the embedded JPEG preview
+    dimensions are used (accurate for relative comparisons).
+    ``mean_color`` is the average RGB via a 1×1 LANCZOS downscale.
     ``raw_date_str`` is ``None`` for RAW/video; callers pass those to exiftool.
     For videos SHA-256 is streamed in 64 KB chunks so large files never load into RAM.
     """
     if file_type in ("mp4", "mov", "gif", "skip"):
-        return compute_sha256(path), None, None, None
+        return compute_sha256(path), None, None, None, None, None
 
-    # Single read: derive all four values from memory.
+    # Single read: derive all six values from memory.
     data = path.read_bytes()
     sha = hashlib.sha256(data).hexdigest()
 
     if not _HASH_AVAILABLE:
-        return sha, None, None, None
+        return sha, None, None, None, None, None
 
     img: Optional[Image.Image] = None
     raw_date: Optional[str] = None
+    px_w: Optional[int] = None
+    px_h: Optional[int] = None
 
     if file_type == "raw":
         img = _load_raw_preview_from_bytes(data)
         if img is None:
             # rawpy.open_buffer not available in this version; re-use path-based loader.
             img = _load_raw_preview(path)
+        if img is not None:
+            px_w, px_h = img.size
         # RAW EXIF dates are not reliably readable via PIL — caller uses exiftool.
     else:
         try:
             with Image.open(io.BytesIO(data)) as pil_img:
                 # Extract date BEFORE convert() — that creates a new image without EXIF.
                 raw_date = _raw_exif_date(pil_img)
+                px_w, px_h = pil_img.size
                 img = pil_img.convert("RGB")
                 img.load()
         except (OSError, ValueError):
             img = None
 
     if img is None:
-        return sha, None, None, raw_date
+        return sha, None, None, raw_date, None, None
     try:
         tiny = img.resize((1, 1), Image.LANCZOS)
         mc = tiny.getpixel((0, 0))[:3]
-        return sha, str(imagehash.phash(img)), f"{mc[0]},{mc[1]},{mc[2]}", raw_date
+        return sha, str(imagehash.phash(img)), f"{mc[0]},{mc[1]},{mc[2]}", raw_date, px_w, px_h
     except (ValueError, TypeError):
-        return sha, None, None, raw_date
+        return sha, None, None, raw_date, None, None
 
 
 def _raw_exif_date(img: "Image.Image") -> Optional[str]:

--- a/scanner/manifest.py
+++ b/scanner/manifest.py
@@ -24,7 +24,9 @@ CREATE TABLE IF NOT EXISTS migration_manifest (
     file_size_bytes  INTEGER,
     shot_date        TEXT,
     creation_date    TEXT,
-    mtime            TEXT
+    mtime            TEXT,
+    pixel_width      INTEGER,
+    pixel_height     INTEGER
 );
 CREATE INDEX IF NOT EXISTS idx_source_hash ON migration_manifest(source_hash);
 CREATE INDEX IF NOT EXISTS idx_phash       ON migration_manifest(phash);
@@ -36,8 +38,9 @@ _INSERT = """
 INSERT INTO migration_manifest
     (source_path, source_label, dest_path, action, source_hash,
      phash, hamming_distance, group_id, reason,
-     file_size_bytes, shot_date, creation_date, mtime)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?)
+     file_size_bytes, shot_date, creation_date, mtime,
+     pixel_width, pixel_height)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?, ?, ?)
 """
 
 
@@ -68,6 +71,8 @@ def write_manifest(rows: list[ManifestRow], output: Path) -> None:
                     r.shot_date,
                     r.creation_date,
                     r.mtime,
+                    r.pixel_width,
+                    r.pixel_height,
                 )
                 for r in rows
             ],

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -162,7 +162,7 @@ class TestComputeHashes:
         from scanner.hasher import compute_hashes
         f = tmp_path / "img.jpg"
         _write_jpeg(f, color=(100, 180, 60))
-        sha, ph, _, _date = compute_hashes(f, "jpeg")
+        sha, ph, _, _date, *_ = compute_hashes(f, "jpeg")
         assert isinstance(sha, str) and len(sha) == 64
         assert isinstance(ph, str) and len(ph) == 16
 
@@ -187,7 +187,7 @@ class TestComputeHashes:
         from scanner.hasher import compute_hashes, compute_sha256
         f = tmp_path / "clip.mov"
         f.write_bytes(b"fake video data " * 100)
-        sha, ph, ch, dt = compute_hashes(f, "mov")
+        sha, ph, ch, dt, *_ = compute_hashes(f, "mov")
         assert ph is None
         assert ch is None
         assert dt is None
@@ -207,7 +207,7 @@ class TestComputeHashes:
         from scanner.hasher import compute_hashes
         f = tmp_path / "bad.jpg"
         f.write_bytes(b"\xff\xd8" + b"\x00" * 50)  # JPEG magic but corrupt body
-        sha, ph, ch, dt = compute_hashes(f, "jpeg")
+        sha, ph, ch, dt, *_ = compute_hashes(f, "jpeg")
         assert len(sha) == 64
         assert ph is None
         assert ch is None
@@ -218,7 +218,7 @@ class TestComputeHashes:
         from scanner.hasher import compute_hashes
         f = tmp_path / "img.jpg"
         _write_jpeg(f)
-        _, _, ch, _ = compute_hashes(f, "jpeg")
+        _, _, ch, *_ = compute_hashes(f, "jpeg")
         assert ch is not None
         assert isinstance(ch, str)
         parts = ch.split(",")
@@ -230,7 +230,7 @@ class TestComputeHashes:
         from scanner.hasher import compute_hashes
         f = tmp_path / "clip.mov"
         f.write_bytes(b"fake video data " * 100)
-        _, _, ch, _ = compute_hashes(f, "mov")
+        _, _, ch, *_ = compute_hashes(f, "mov")
         assert ch is None
 
     def test_jpeg_with_exif_date_returns_raw_date_string(self, tmp_path):
@@ -244,7 +244,7 @@ class TestComputeHashes:
         f = tmp_path / "dated.jpg"
         img.save(str(f), "JPEG", exif=exif.tobytes())
 
-        _, _, _, raw_date = compute_hashes(f, "jpeg")
+        _, _, _, raw_date, *_ = compute_hashes(f, "jpeg")
         assert raw_date == "2024:06:15 10:30:00"
 
     def test_jpeg_without_exif_date_returns_none_date(self, tmp_path):
@@ -252,6 +252,6 @@ class TestComputeHashes:
         from scanner.hasher import compute_hashes
         f = tmp_path / "nodated.jpg"
         _write_jpeg(f)
-        _, _, _, raw_date = compute_hashes(f, "jpeg")
+        _, _, _, raw_date, *_ = compute_hashes(f, "jpeg")
         # Plain solid-colour JPEG written by PIL has no DateTimeOriginal
         assert raw_date is None


### PR DESCRIPTION
## Summary

- **Zero extra I/O**: PIL image is already in memory when computing pHash/mean_color; `img.size` is captured before `convert("RGB")`, costing nothing
- **Full pipeline**: `hasher` → `dedup` → `manifest` (DDL + INSERT) → `manifest_repository` (auto-migration + load) → `PhotoRecord`
- **UI**: new \"Resolution\" column (W×H text, sortable by megapixels) in the tree view; shown in the single-file preview pane

## Changes

| Layer | What changed |
|---|---|
| `scanner/hasher.py` | `compute_hashes` returns 6-tuple; dimensions captured before convert |
| `scanner/dedup.py` | `HashResult` + `ManifestRow` gain `pixel_width`/`pixel_height` |
| `scanner/manifest.py` | DDL + INSERT include new columns |
| `scan.py` + `scan_worker.py` | Unpack 6-tuple, populate `HashResult` |
| `infrastructure/manifest_repository.py` | Auto-migration adds columns; `_photo_record` + load propagate to `PhotoRecord` |
| `app/views/constants.py` | `COL_RESOLUTION = 9`, `HEADERS` adds \"Resolution\", `NUM_COLUMNS = 10` |
| `app/views/tree_model_builder.py` | Group + child rows: display text + megapixel sort role |
| `app/views/main_window.py` | Reads `COL_RESOLUTION` on selection change |
| `app/views/preview_pane.py` | Shows \"Resolution: W×H\" in single-file info |
| `.gitignore` | Add `*.sqlite-shm`, `*.sqlite-wal` WAL artifacts |
| `tests/test_hasher.py` | Update 7 unpack patterns from 4-tuple to 6-tuple with `*_` |

## Test plan

- [x] `python -m pytest` — 374 passed, 0 failed
- [ ] Open a manifest with known-resolution images; verify \"Resolution\" column shows correct W×H
- [ ] Click a file row in the tree; verify preview pane shows \"Resolution: W×H\"
- [ ] Sort by Resolution column; verify larger-megapixel groups sort higher
- [ ] Old manifest (pre-migration): open without error; pixel columns auto-added via ALTER TABLE

🤖 Generated with [Claude Code](https://claude.com/claude-code)