### PR TITLE
fix(ui): sort Similarity column by group_number, not scanner action type

### DIFF
--- a/app/views/tree_model_builder.py
+++ b/app/views/tree_model_builder.py
@@ -92,11 +92,7 @@ def build_model(
         # reorders groups by their "best" file's value (first file after in-group sort).
         # Min-priority wins for ranked fields (delete=1 < keep=2 < ""=3); max wins for size.
         try:
-            group_row[COL_GROUP].setData(
-                min((_ACTION_SORT.get(getattr(it, "action", ""), 6) for it in items_list),
-                    default=6),
-                SORT_ROLE,
-            )
+            group_row[COL_GROUP].setData(group_number, SORT_ROLE)
         except Exception:
             pass
         try:


### PR DESCRIPTION
## Summary
- The Similarity/Group column (col 0) was sorting groups by the minimum `_ACTION_SORT` priority of their files (scanner action type) instead of by `group_number`
- Fix: set `SORT_ROLE` on the group row's `COL_GROUP` cell to `group_number` directly

## Test plan
- [ ] `python -m pytest` — all tests pass
- [ ] Manual: open manifest, click Group column header → groups reorder as Group 1, Group 2, Group 3…

🤖 Generated with [Claude Code](https://claude.com/claude-code)