### PR TITLE
fix(scanner,db): correct DNG resolution + exclude executed rows on reload

### DIFF
--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -51,6 +51,7 @@ SELECT id, source_path, source_label, group_id, hamming_distance, reason,
        file_size_bytes, shot_date, creation_date, mtime,
        pixel_width, pixel_height
 FROM   migration_manifest
+WHERE  executed = 0
 ORDER  BY
     group_id NULLS LAST,
     CASE action

--- a/scanner/hasher.py
+++ b/scanner/hasher.py
@@ -70,8 +70,18 @@ def compute_hashes(
         if img is None:
             # rawpy.open_buffer not available in this version; re-use path-based loader.
             img = _load_raw_preview(path)
-        if img is not None:
-            px_w, px_h = img.size
+        # True sensor dimensions come from rawpy metadata, not the embedded thumbnail.
+        # Thumbnails are typically low-res previews (e.g. 1024×768 for a 12 MP DNG).
+        if _RAWPY_AVAILABLE:
+            try:
+                with rawpy.open_buffer(data) as raw:
+                    px_w, px_h = raw.sizes.width, raw.sizes.height
+            except (OSError, ValueError, AttributeError):
+                try:
+                    with rawpy.imread(str(path)) as raw:
+                        px_w, px_h = raw.sizes.width, raw.sizes.height
+                except (OSError, ValueError):
+                    pass
         # RAW EXIF dates are not reliably readable via PIL — caller uses exiftool.
     else:
         try:


### PR DESCRIPTION
## Summary
- **DNG resolution**: `compute_hashes` was storing the embedded JPEG thumbnail dimensions (e.g. 1024×768) instead of the true sensor size. Now reads `raw.sizes.width/height` from rawpy metadata; thumbnail is still used for perceptual hashing
- **DB reload**: `_LOAD_ALL_SQL` had no `WHERE` clause, so rows marked `executed=1` after deletion reappeared on every manifest reopen. Added `WHERE executed = 0` to permanently exclude them

## Test plan
- [ ] `python -m pytest` — all tests pass
- [ ] Manual: scan a DNG — Resolution column shows sensor dimensions (e.g. 4000×3000) not thumbnail size
- [ ] Manual: execute deletions → reopen manifest → deleted files no longer appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)