### PR TITLE
fix: restore dev-requirements.txt with pytest and linter pins

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ cd photo-manager
 python -m venv .venv
 .venv\Scripts\Activate.ps1
 pip install -r requirements.txt
+pip install -r dev-requirements.txt        # pytest, black, ruff, pylint
 copy settings.json.example settings.json   # local config — never committed
 ```
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,0 +1,6 @@
+pytest>=8.0
+black==25.1.0
+isort==6.0.1
+ruff==0.13.0
+pylint==3.3.8
+pre-commit>=4.0.0


### PR DESCRIPTION
## Summary

Fixes a mistake from #35 — `dev-requirements.txt` was deleted as "redundant" but `requirements.txt` only contains runtime dependencies. The dev file is required to install `pytest`, `black`, `isort`, `ruff`, and `pylint` into the venv.

Also adds the missing `pytest>=8.0` pin (pytest was never explicitly listed before).

**Install dev dependencies with:**
```powershell
pip install -r dev-requirements.txt
```

## What broke
After #35 merged and venv was recreated, `pytest` was missing — `python -m pytest` failed with `No module named pytest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)