### PR TITLE
chore(ci): coverage gate + scanner.media tests + impact-map skill + GitHub Actions

### DIFF
--- a/.claude/skills/impact-map/SKILL.md
+++ b/.claude/skills/impact-map/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: impact-map
+description: Use BEFORE editing any function, class, or module in photo-manager.
+  Maps upstream callers and downstream dependencies so you know which tests must
+  pass and which behaviors might shift. Pairs with update-docs (post-change).
+origin: local
+---
+
+# Impact map — before editing a non-trivial symbol
+
+The point: no code change ships in `photo-manager` without first knowing
+who calls what and which test exercises that path. If a caller has no test
+and you're about to change behavior the caller relies on, write the test
+*before* the edit.
+
+## When to activate
+
+- Modifying a public function/class signature
+- Changing return shape, raised exceptions, or side-effect behavior
+- Renaming or deleting a symbol
+- Touching a SQLite migration, a `settings.json` key, or a background worker
+- Changing scanner pipeline stages (walker, hasher, exif, dedup, manifest)
+- Changing any `infrastructure/` service that other modules import
+
+Skip for: typo fixes, comment-only edits, or strictly internal refactors of
+a private helper that is verifiably called from one place and is fully
+covered by an existing test.
+
+## Checklist (run all of it before the edit)
+
+1. **Upstream callers** — `Grep` the symbol name across `app/`, `scanner/`,
+   `core/`, `infrastructure/`, and `tests/`. List every call site with
+   `file:line`.
+2. **Downstream dependencies** — what does the function call into? Note any
+   I/O (DB, FS, subprocess, Qt) it relies on, since changes there cascade.
+3. **Tests covering each call site** — for every caller in (1), identify
+   which test file exercises that path. Flag callers with NO test coverage.
+4. **Behavior contract** — write down (in chat, not a file) the inputs,
+   outputs, raised exceptions, and side-effects you intend to *preserve*
+   versus *change*.
+5. **Plan test updates** — if behavior is changing, list the existing tests
+   that must be updated. If a caller has NO test and your change could
+   break it, add a test before editing the symbol.
+
+## Output format
+
+A short table in chat, then proceed:
+
+```
+| Caller                                          | Test                                              | Action needed                              |
+|-------------------------------------------------|---------------------------------------------------|--------------------------------------------|
+| app/views/handlers/file_operations.py:127       | tests/test_file_operations.py::test_batch_update  | none                                       |
+| scanner/dedup.py:88                             | (no test)                                         | add test before changing signature         |
+| infrastructure/manifest_repository.py:204       | tests/test_manifest_repository.py::test_save      | update assertion for new return shape      |
+```
+
+After the edit, switch to the `update-docs` skill to keep `README.md` and
+`pyproject.toml` in sync.
+
+## Why this exists
+
+The project has 416 unit tests but they only protect what they cover. A
+change to a function used in five places is only safe if all five places
+are tested — or if you confirm in advance that the change preserves the
+behavior the untested callers depend on. This skill makes that confirmation
+explicit instead of assumed.

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -68,6 +68,8 @@ Work through every item below. Check only the items relevant to your change.
 2. For each checked item above, read the relevant doc section.
 3. Apply **surgical edits** — replace only the stale sentence/row/bullet; do not rewrite entire sections.
 4. After all edits, run `python -m pytest tests/ -q --tb=short` to confirm no regressions.
+   If coverage drops below the configured `fail_under` threshold in `pyproject.toml`,
+   add tests for the new code before committing.
 5. Commit the doc changes alongside the code change (or as an immediate follow-up commit on the same branch).
 
 ---

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,45 @@
+name: tests
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  pytest:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            dev-requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
+
+      - name: Run pytest with coverage
+        env:
+          QT_QPA_PLATFORM: offscreen
+        run: python -m pytest
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: .coverage
+          if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ run.bat          # activates .venv and starts main.py
 .venv\Scripts\python -m pytest
 ```
 
+The default `pytest` invocation runs with coverage (configured in `pyproject.toml`)
+and fails if branch coverage drops below the `fail_under` threshold. CI runs the
+same command on every push and pull request to `master` via `.github/workflows/tests.yml`.
+
 ---
 
 ## Usage — GUI
@@ -347,7 +351,7 @@ photo-manager/
 │
 ├── settings.json            # User configuration (source paths, thumbnail cache, …)
 │
-└── tests/                   # 341 tests — scanner, infra, viewmodel, GUI handlers
+└── tests/                   # 391 tests — scanner, infra, viewmodel, GUI handlers
     ├── conftest.py              # Shared fixtures (qapp)
     ├── test_dedup.py
     ├── test_hasher.py
@@ -359,6 +363,7 @@ photo-manager/
     ├── test_delete_service.py
     ├── test_scanner_exif.py
     ├── test_scanner_manifest.py
+    ├── test_scanner_media.py    # magic-byte detection, Takeout filename parsing
     ├── test_main_vm.py
     ├── test_file_operations.py  # set_decision, execute_action
     ├── test_sort_service.py

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 pytest>=8.0
+pytest-cov>=5.0
 black==25.1.0
 isort==6.0.1
 ruff==0.13.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,5 +45,36 @@ max-line-length = 100
 [tool.pylint.variables]
 additional-builtins = ["Data1", "Data2", "Data3", "Data4"]
 
+[tool.pytest.ini_options]
+addopts = "-q --cov=. --cov-report=term-missing --cov-config=pyproject.toml"
+testpaths = ["tests"]
 
+[tool.coverage.run]
+branch = true
+source = ["scanner", "core", "infrastructure", "app"]
+omit = [
+  "tests/*",
+  "scripts/*",
+  ".claude/*",
+  # Top-level entry-point scripts and dev tooling
+  "main.py",
+  "scan.py",
+  "review.py",
+  "run_all_linters.py",
+  # Qt/UI glue and bootstrap — low test ROI
+  "infrastructure/image_service.py",
+  "infrastructure/logging.py",
+  "app/views/workers/scan_worker.py",
+  "app/views/media_utils.py",
+  # Unused legacy module
+  "app/viewmodels/photo_vm.py",
+]
 
+[tool.coverage.report]
+exclude_lines = [
+  "pragma: no cover",
+  "if TYPE_CHECKING:",
+  "raise NotImplementedError",
+  "if __name__ == .__main__.:",
+]
+fail_under = 75

--- a/tests/test_scanner_media.py
+++ b/tests/test_scanner_media.py
@@ -1,0 +1,230 @@
+"""Tests for scanner.media — magic-byte detection and filename parsing."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from scanner.media import (
+    DUPE_RE,
+    EDITED_SUFFIXES,
+    LOSSY_EXTENSIONS,
+    MEDIA_EXTENSIONS,
+    PHOTO_EXTENSIONS,
+    RAW_EXTENSIONS,
+    VIDEO_EXTENSIONS,
+    get_file_type,
+    parse_media_filename,
+)
+
+
+# ---------------------------------------------------------------------------
+# Magic-byte fixtures (minimum bytes the detector inspects)
+# ---------------------------------------------------------------------------
+
+JPEG_MAGIC = b"\xff\xd8\xff\xe0\x00\x10JFIF"
+PNG_MAGIC = b"\x89PNG\r\n\x1a\n" + b"\x00" * 4
+GIF87_MAGIC = b"GIF87a" + b"\x00" * 6
+GIF89_MAGIC = b"GIF89a" + b"\x00" * 6
+WEBP_MAGIC = b"RIFF\x00\x00\x00\x00WEBP"
+HEIC_MAGIC = b"\x00\x00\x00\x18ftypheic"
+MP4_MAGIC = b"\x00\x00\x00\x18ftypmp42"
+MOV_MAGIC = b"\x00\x00\x00\x18ftypqt  "
+
+
+def _write(tmp_path: Path, name: str, data: bytes) -> Path:
+    p = tmp_path / name
+    p.write_bytes(data)
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Module constants
+# ---------------------------------------------------------------------------
+
+class TestModuleConstants:
+    def test_photo_and_video_partition_media(self):
+        assert PHOTO_EXTENSIONS | VIDEO_EXTENSIONS == MEDIA_EXTENSIONS
+        assert PHOTO_EXTENSIONS & VIDEO_EXTENSIONS == set()
+
+    def test_raw_subset_of_photos(self):
+        assert RAW_EXTENSIONS.issubset(PHOTO_EXTENSIONS)
+
+    def test_lossy_disjoint_from_raw(self):
+        assert LOSSY_EXTENSIONS & RAW_EXTENSIONS == set()
+
+
+# ---------------------------------------------------------------------------
+# get_file_type
+# ---------------------------------------------------------------------------
+
+class TestGetFileType:
+    @pytest.mark.parametrize(
+        "name,data,expected",
+        [
+            ("a.jpg", JPEG_MAGIC, "jpeg"),
+            ("a.jpeg", JPEG_MAGIC, "jpeg"),
+            ("a.png", PNG_MAGIC, "png"),
+            ("a.gif", GIF87_MAGIC, "gif"),
+            ("a.gif", GIF89_MAGIC, "gif"),
+            ("a.webp", WEBP_MAGIC, "webp"),
+            ("a.heic", HEIC_MAGIC, "heic"),
+            ("a.heif", HEIC_MAGIC, "heic"),
+            ("a.mp4", MP4_MAGIC, "mp4"),
+            ("a.m4v", MP4_MAGIC, "mp4"),
+            ("a.mov", MOV_MAGIC, "mov"),
+        ],
+    )
+    def test_extension_matches_magic(self, tmp_path, name, data, expected):
+        path = _write(tmp_path, name, data)
+        kind, mismatch = get_file_type(path)
+        assert kind == expected
+        assert mismatch is False
+
+    @pytest.mark.parametrize(
+        "ext", [".dng", ".cr2", ".cr3", ".nef", ".arw", ".raf", ".rw2", ".tif", ".tiff"]
+    )
+    def test_raw_extensions_not_magic_checked(self, tmp_path, ext):
+        # RAW formats have varied magic bytes; the detector trusts the extension
+        # unless magic happens to match a known non-RAW format. Random bytes
+        # should be returned as "raw" with no mismatch.
+        path = _write(tmp_path, f"a{ext}", b"\x00" * 32)
+        kind, mismatch = get_file_type(path)
+        assert kind == "raw"
+        assert mismatch is False
+
+    def test_unknown_extension_returns_skip(self, tmp_path):
+        path = _write(tmp_path, "notes.txt", b"hello")
+        kind, mismatch = get_file_type(path)
+        assert kind == "skip"
+        assert mismatch is False
+
+    def test_case_insensitive_extension(self, tmp_path):
+        path = _write(tmp_path, "PHOTO.JPG", JPEG_MAGIC)
+        kind, _ = get_file_type(path)
+        assert kind == "jpeg"
+
+    def test_magic_mismatch_flags_caller(self, tmp_path):
+        # File named .png but actually JPEG bytes — detector should flag mismatch
+        path = _write(tmp_path, "fake.png", JPEG_MAGIC)
+        kind, mismatch = get_file_type(path)
+        assert kind == "jpeg"
+        assert mismatch is True
+
+    def test_heic_extension_with_mp4_magic_flags_mismatch(self, tmp_path):
+        path = _write(tmp_path, "fake.heic", MP4_MAGIC)
+        kind, mismatch = get_file_type(path)
+        assert kind == "mp4"
+        assert mismatch is True
+
+    def test_jpeg_magic_check_skipped(self, tmp_path):
+        # JPEG and MP4/MOV are NOT in the magic-verification list — corrupted
+        # JPEG header with .jpg extension still returns "jpeg" without mismatch.
+        path = _write(tmp_path, "x.jpg", b"\x00" * 32)
+        kind, mismatch = get_file_type(path)
+        assert kind == "jpeg"
+        assert mismatch is False
+
+    def test_unreadable_file_falls_through_to_declared(self, tmp_path):
+        # Empty file: magic returns None → declared type is returned without mismatch
+        path = _write(tmp_path, "empty.png", b"")
+        kind, mismatch = get_file_type(path)
+        assert kind == "png"
+        assert mismatch is False
+
+    def test_nonexistent_path_returns_declared(self, tmp_path):
+        # OSError path: read fails, magic returns None, declared type wins
+        path = tmp_path / "ghost.heic"
+        kind, mismatch = get_file_type(path)
+        assert kind == "heic"
+        assert mismatch is False
+
+    def test_heic_brand_variants(self, tmp_path):
+        for brand in (b"heic", b"heix", b"mif1", b"msf1", b"heim", b"heis", b"hevc"):
+            data = b"\x00\x00\x00\x18ftyp" + brand
+            path = _write(tmp_path, f"x_{brand.decode()}.heic", data)
+            kind, mismatch = get_file_type(path)
+            assert kind == "heic", f"brand {brand!r}"
+            assert mismatch is False
+
+
+# ---------------------------------------------------------------------------
+# parse_media_filename
+# ---------------------------------------------------------------------------
+
+class TestParseMediaFilename:
+    def test_plain_filename(self):
+        mf = parse_media_filename(Path("IMG_1234.jpg"))
+        assert mf.base_stem == "IMG_1234"
+        assert mf.number is None
+        assert mf.suffix == ".jpg"
+        assert mf.is_edited is False
+        assert mf.clean_stem == "IMG_1234"
+
+    def test_takeout_numbered_duplicate(self):
+        mf = parse_media_filename(Path("IMG_9556(1).HEIC"))
+        assert mf.base_stem == "IMG_9556"
+        assert mf.number == 1
+        assert mf.suffix == ".HEIC"  # original case preserved
+        assert mf.is_edited is False
+        assert mf.clean_stem == "IMG_9556"
+
+    def test_takeout_multi_digit(self):
+        mf = parse_media_filename(Path("photo(42).jpg"))
+        assert mf.base_stem == "photo"
+        assert mf.number == 42
+
+    @pytest.mark.parametrize("suffix", EDITED_SUFFIXES)
+    def test_each_edited_suffix_recognized(self, suffix):
+        mf = parse_media_filename(Path(f"IMG_1{suffix}.jpg"))
+        assert mf.is_edited is True
+        assert mf.clean_stem == "IMG_1"
+        assert mf.base_stem == f"IMG_1{suffix}"
+
+    def test_combined_numbered_and_edited(self):
+        mf = parse_media_filename(Path("IMG_1234(2)-edited.jpg"))
+        # DUPE_RE matches stem "IMG_1234(2)-edited" — but the trailing
+        # "-edited" prevents the (N) regex from firing (since the regex
+        # requires the (N) to be at end-of-string). Verify actual behavior.
+        # Expected: number=None, base_stem="IMG_1234(2)-edited",
+        # is_edited=True, clean_stem="IMG_1234(2)"
+        assert mf.number is None
+        assert mf.base_stem == "IMG_1234(2)-edited"
+        assert mf.is_edited is True
+        assert mf.clean_stem == "IMG_1234(2)"
+
+    def test_no_edited_suffix(self):
+        mf = parse_media_filename(Path("vacation.png"))
+        assert mf.is_edited is False
+        assert mf.clean_stem == mf.base_stem == "vacation"
+
+    def test_dupe_regex_requires_trailing_paren(self):
+        # "(1)foo" should NOT match — the (N) must be at end of stem
+        assert DUPE_RE.match("(1)foo") is None
+        assert DUPE_RE.match("foo(1)") is not None
+
+    def test_suffix_case_preserved(self):
+        mf = parse_media_filename(Path("a.JPEG"))
+        assert mf.suffix == ".JPEG"
+
+    def test_chinese_edited_suffix(self):
+        mf = parse_media_filename(Path("IMG_5-已編輯.heic"))
+        assert mf.is_edited is True
+        assert mf.clean_stem == "IMG_5"
+
+    def test_paren_edited_suffix(self):
+        mf = parse_media_filename(Path("IMG_5(已編輯).heic"))
+        assert mf.is_edited is True
+        assert mf.clean_stem == "IMG_5"
+
+    def test_first_matching_suffix_wins(self):
+        # If a stem ends with two recognized suffixes back-to-back, only the
+        # first match in EDITED_SUFFIXES order is stripped.
+        # "-edited(已編輯)" ends with "(已編輯)" first in iteration → that strips.
+        # The leading "-edited" remains in clean_stem.
+        mf = parse_media_filename(Path("IMG_5-edited(已編輯).heic"))
+        assert mf.is_edited is True
+        # The exact strip depends on EDITED_SUFFIXES iteration order; assert
+        # that one suffix was stripped and the result is shorter than base.
+        assert len(mf.clean_stem) < len(mf.base_stem)


### PR DESCRIPTION
## Summary
- Adds GitHub Actions CI (`windows-latest`, Python 3.11, headless Qt) that runs the full pytest suite on push and PR to `master`. Closes the gap of having 391 tests but no automated regression catch.
- Wires `pytest-cov` into `pyproject.toml` with `fail_under = 75` (current branch coverage: **79.44%**). Top-level scripts, Qt workers, logging bootstrap, and the unused `photo_vm.py` are omitted to keep the gate measuring testable logic.
- Audit of the 19 existing test files found zero candidates for removal — every file exercises real logic against real fixtures (real SQLite, PIL-generated JPEGs, real `QApplication`).
- Closes the only genuine coverage gap by adding **47 tests** for `scanner/media.py` (magic-byte detection + Google Takeout filename parsing) in `tests/test_scanner_media.py`.
- Adds `.claude/skills/impact-map/SKILL.md` to require upstream-caller / downstream-dep mapping *before* non-trivial edits — addresses the request to "map all upstream/downstream affected by the code change". The existing post-change `update-docs` skill now also flags coverage drops.

Tracking: deferred items added to [#38](https://github.com/jackal998/photo-manager/issues/38) — decide on `app/viewmodels/photo_vm.py` (looks unused) and bump `fail_under` 75 → 80 once a few near-threshold modules get more tests.

## Test plan
- [ ] Watch the `tests` workflow run on this PR — should be green on `windows-latest`
- [ ] Confirm coverage report artifact uploads
- [ ] Locally: `.venv\Scripts\python -m pytest` → 389 passed, 2 skipped (pre-existing platform-conditional symlink tests), coverage 79.44%, gate passes
- [ ] In a fresh session, invoke `/impact-map` to confirm the skill activates with the right description

🤖 Generated with [Claude Code](https://claude.com/claude-code)