### PR TITLE
fix(scanner): one bad file no longer aborts the whole scan (#46)

### DIFF
--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -90,12 +90,18 @@ class ScanWorker(QThread):
         chunk_size = 500
         _EXIFTOOL_TYPES = frozenset(("heic", "raw", "mov", "mp4"))
         cancel_flag = threading.Event()
+        skipped: list[tuple[Path, str, str]] = []  # (path, exc type, exc msg)
 
         def _hash_one(idx_record: tuple) -> tuple:
             idx, record = idx_record
             if cancel_flag.is_set():
                 return idx, None
-            sha256, phash, mean_color, raw_date, px_w, px_h = compute_hashes(record.path, record.file_type)
+            try:
+                sha256, phash, mean_color, raw_date, px_w, px_h = compute_hashes(record.path, record.file_type)
+            except Exception as exc:  # pylint: disable=broad-exception-caught
+                # One bad file must never abort the whole scan — log + skip.
+                skipped.append((record.path, type(exc).__name__, str(exc)))
+                return idx, None
             pil_date = parse_exif_date(raw_date) if raw_date else None
             return idx, HashResult(
                 record=record, sha256=sha256, phash=phash, mean_color=mean_color,
@@ -121,8 +127,15 @@ class ScanWorker(QThread):
                 if done % 100 == 0 or done == len(records):
                     self._emit(f"  Hashed {done:,}/{len(records):,}")
 
-        # Remove any None slots (cancelled futures that didn't run)
+        # Remove any None slots (cancelled futures that didn't run, or skipped files)
         hash_results = [r for r in hash_results if r is not None]
+
+        if skipped:
+            self._emit(f"  Skipped {len(skipped):,} unreadable file(s):")
+            for p, exc_type, exc_msg in skipped[:10]:
+                self._emit(f"    {p}  [{exc_type}: {exc_msg}]")
+            if len(skipped) > 10:
+                self._emit(f"    … and {len(skipped) - 10:,} more")
 
         # --- 3. exiftool for HEIC / RAW / MOV / MP4 only ---
         # JPEG and PNG dates already populated from the PIL pass above.

--- a/scan.py
+++ b/scan.py
@@ -163,10 +163,16 @@ def main() -> int:
 
     print(f"Hashing {len(records):,} files (workers={args.workers})…", flush=True)
     hash_results: list[HashResult] = [None] * len(records)  # type: ignore[list-item]
+    skipped: list[tuple] = []  # (path, exc type, exc msg)
 
     def _hash_one(idx_record: tuple) -> tuple:
         idx, record = idx_record
-        sha256, phash, mean_color, raw_date, px_w, px_h = compute_hashes(record.path, record.file_type)
+        try:
+            sha256, phash, mean_color, raw_date, px_w, px_h = compute_hashes(record.path, record.file_type)
+        except Exception as exc:  # pylint: disable=broad-exception-caught
+            # One bad file must never abort the whole scan — log + skip.
+            skipped.append((record.path, type(exc).__name__, str(exc)))
+            return idx, None
         pil_date = parse_exif_date(raw_date) if raw_date else None
         return idx, HashResult(
             record=record, sha256=sha256, phash=phash, mean_color=mean_color,
@@ -186,6 +192,15 @@ def main() -> int:
                 print(f"  Hashed {done:,}/{len(records):,}", end="\r", flush=True)
     if not _TQDM:
         print(f"  Hashed {len(records):,}/{len(records):,}", flush=True)
+
+    # Drop skipped slots (None entries) before downstream stages.
+    hash_results = [r for r in hash_results if r is not None]
+    if skipped:
+        print(f"  Skipped {len(skipped):,} unreadable file(s):", file=sys.stderr, flush=True)
+        for p, exc_type, exc_msg in skipped[:10]:
+            print(f"    {p}  [{exc_type}: {exc_msg}]", file=sys.stderr, flush=True)
+        if len(skipped) > 10:
+            print(f"    … and {len(skipped) - 10:,} more", file=sys.stderr, flush=True)
 
     # --- exiftool for HEIC / RAW / MOV / MP4 only ---
     # JPEG and PNG dates are already populated from the PIL pass above.

--- a/scanner/hasher.py
+++ b/scanner/hasher.py
@@ -76,11 +76,11 @@ def compute_hashes(
             try:
                 with rawpy.open_buffer(data) as raw:
                     px_w, px_h = raw.sizes.width, raw.sizes.height
-            except (OSError, ValueError, AttributeError):
+            except (OSError, ValueError, AttributeError, rawpy.LibRawError):
                 try:
                     with rawpy.imread(str(path)) as raw:
                         px_w, px_h = raw.sizes.width, raw.sizes.height
-                except (OSError, ValueError):
+                except (OSError, ValueError, rawpy.LibRawError):
                     pass
         # RAW EXIF dates are not reliably readable via PIL — caller uses exiftool.
     else:
@@ -177,7 +177,7 @@ def _load_raw_preview(path: Path) -> Optional[Image.Image]:
             # Full decode fallback — slower but always works
             rgb = raw.postprocess(use_auto_wb=True, output_bps=8)
             return Image.fromarray(rgb).convert("RGB")
-    except (OSError, ValueError):
+    except (OSError, ValueError, rawpy.LibRawError):
         return None
 
 
@@ -201,6 +201,6 @@ def _load_raw_preview_from_bytes(data: bytes) -> Optional[Image.Image]:
                 pass
             rgb = raw.postprocess(use_auto_wb=True, output_bps=8)
             return Image.fromarray(rgb).convert("RGB")
-    except (OSError, ValueError, AttributeError):
+    except (OSError, ValueError, AttributeError, rawpy.LibRawError):
         # AttributeError → rawpy.open_buffer not available in this rawpy build.
         return None

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -255,3 +255,36 @@ class TestComputeHashes:
         _, _, _, raw_date, *_ = compute_hashes(f, "jpeg")
         # Plain solid-colour JPEG written by PIL has no DateTimeOriginal
         assert raw_date is None
+
+    def test_raw_unsupported_format_returns_sha_only(self, tmp_path):
+        """Misrouted RAW (e.g. non-camera TIFF) → LibRawFileUnsupportedError must not propagate.
+
+        Regression for issue #46: rawpy.LibRawFileUnsupportedError used to abort
+        the whole scan. Now it degrades to a sha-only record (same shape as a
+        corrupted JPEG) and the caller can continue.
+        """
+        import rawpy as _rawpy
+
+        from scanner.hasher import compute_hashes, compute_sha256
+
+        f = tmp_path / "fake.tif"
+        f.write_bytes(b"II*\x00" + b"\x00" * 64)  # TIFF magic but unparseable
+
+        unsupported = _rawpy.LibRawFileUnsupportedError("Unsupported file format or not RAW file")
+
+        with patch("scanner.hasher.rawpy") as mock_rawpy, \
+             patch("scanner.hasher._RAWPY_AVAILABLE", True):
+            # Preserve the real exception class so isinstance/except matches.
+            mock_rawpy.LibRawError = _rawpy.LibRawError
+            mock_rawpy.LibRawNoThumbnailError = _rawpy.LibRawNoThumbnailError
+            mock_rawpy.open_buffer.side_effect = unsupported
+            mock_rawpy.imread.side_effect = unsupported
+
+            sha, ph, ch, dt, w, h = compute_hashes(f, "raw")
+
+        assert sha == compute_sha256(f)
+        assert ph is None
+        assert ch is None
+        assert dt is None
+        assert w is None
+        assert h is None

--- a/tests/test_scan_worker.py
+++ b/tests/test_scan_worker.py
@@ -1,0 +1,73 @@
+"""Tests for app/views/workers/scan_worker.py — ScanWorker pipeline behaviour.
+
+Focus: regression test for issue #46 — one bad file must never abort the whole
+scan. Verifies that a per-file ``compute_hashes`` exception is logged and
+skipped, and the pipeline still produces a manifest.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from PIL import Image
+
+
+def _write_jpeg(path: Path, color=(128, 64, 32)) -> None:
+    Image.new("RGB", (32, 32), color).save(path, "JPEG")
+
+
+class TestScanWorkerSkipsBadFile:
+    def test_per_file_exception_does_not_abort_scan(self, qapp, tmp_path, monkeypatch):
+        """A LibRaw error on one file → that file is skipped, others scanned, manifest written.
+
+        Regression for issue #46 (rawpy.LibRawFileUnsupportedError aborted the whole scan).
+        """
+        # Need a fresh QApplication to deliver signals via DirectConnection in this thread.
+        from app.views.workers.scan_worker import ScanWorker
+
+        a = tmp_path / "a.jpg"
+        b = tmp_path / "b.jpg"
+        bad = tmp_path / "bad.tif"  # routes to file_type="raw"
+        _write_jpeg(a, color=(255, 0, 0))
+        _write_jpeg(b, color=(0, 255, 0))
+        bad.write_bytes(b"II*\x00" + b"\x00" * 64)  # TIFF magic, unparseable
+
+        # Patch compute_hashes at the source so the late import in _run_pipeline picks it up.
+        import scanner.hasher as _hasher
+        import rawpy
+
+        real_compute = _hasher.compute_hashes
+
+        def fake_compute(path, file_type):
+            if Path(path) == bad:
+                raise rawpy.LibRawFileUnsupportedError("Unsupported file format or not RAW file")
+            return real_compute(path, file_type)
+
+        monkeypatch.setattr(_hasher, "compute_hashes", fake_compute)
+
+        out = tmp_path / "manifest.csv"
+        worker = ScanWorker(
+            sources={"src": str(tmp_path)},
+            output_path=str(out),
+            recursive_map={"src": False},
+            workers=2,
+        )
+
+        progress: list[str] = []
+        finished: list[str] = []
+        failed: list[str] = []
+        worker.progress.connect(progress.append)
+        worker.finished.connect(finished.append)
+        worker.failed.connect(failed.append)
+
+        # Run synchronously in this thread — DirectConnection delivers signals immediately.
+        worker.run()
+
+        assert not failed, f"Scan must not have failed; got: {failed}"
+        assert finished == [str(out)], f"finished signal wrong: {finished}"
+        assert out.exists(), "manifest file should have been written"
+        assert any("Skipped 1 unreadable" in m for m in progress), \
+            f"skip summary missing from progress: {progress!r}"
+        assert any("bad.tif" in m for m in progress), \
+            f"skipped file path should appear in progress: {progress!r}"


### PR DESCRIPTION
## Summary
- Broaden rawpy except clauses in `scanner/hasher.py` to include `rawpy.LibRawError` (base class for `LibRawFileUnsupportedError`, `LibRawDataError`, etc.) so a misrouted `.tif`/`.tiff` degrades to a sha-only record.
- Wrap `_hash_one` in `ScanWorker` and `scan.py` CLI with a defensive try/except — bad files are appended to a `skipped` list and logged; the pool keeps running and a manifest is still written.
- Regression tests at both layers: hasher returns sha+Nones on `LibRawFileUnsupportedError`, and the worker pipeline emits `finished` (not `failed`) when one file raises mid-scan.

## Closes
Closes #46

## Test plan
- [x] `pytest tests/test_hasher.py -v` — new `test_raw_unsupported_format_returns_sha_only` passes
- [x] `pytest tests/test_scan_worker.py -v` — new end-to-end test passes (no `failed` signal, manifest written, skip logged)
- [x] `pytest` (full suite) — 391 passed, 2 skipped, coverage 80.30% (gate: 75%)
- [ ] Manual: `PHOTO_MANAGER_HOME=qa .venv/Scripts/python.exe main.py` → File → Scan Sources → Start Scan with all 13 fixture sources; expect scan to walk all files, log N skipped, write a manifest, and **not** show the "Scan Failed" modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)