### PR TITLE
QA: UIA-driven scenario drivers for /qa-explore

### DIFF
--- a/.claude/settings.json.example
+++ b/.claude/settings.json.example
@@ -1,6 +1,9 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
   "permissions": {
+    "allow": [
+      "Bash(.venv/Scripts/python.exe -m qa.scenarios.*:*)"
+    ],
     "ask": [
       "Bash(pip install*)",
       "Bash(pip3 install*)",

--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -142,37 +142,167 @@ ToolSearch(query: "computer-use", max_results: 30)
 This gets you `screenshot`, `left_click`, `type`, `key`, `scroll`,
 `request_access`, `open_application`, etc. Don't load them one by one.
 
+### 4.0.5 — UIA-first driving (the cheap navigation channel)
+
+photo-manager is a PySide6 app on Windows. Qt's `QAccessible` bridge
+exposes every widget that has a visible label (`setText`, `QAction`,
+menu items, dialog text) into the **Windows UI Automation tree**. That
+tree is structured text, not pixels — a few hundred bytes per snapshot
+versus ~100 KB for a screenshot.
+
+**Default this session to UIA, not screenshots.** Screenshot is for
+*visual evidence* (rendering bugs, layout, finding-frame quotes), not
+for finding the next button to click.
+
+**One-time install** (gated; ask the user before running):
+
+```
+.venv/Scripts/python.exe -m pip install -r qa/requirements.txt
+```
+
+This pulls `pywinauto` (UIA backend) into the project venv. Skip if a
+`pywinauto` import already succeeds.
+
+**Connect to the running app** (after step 3 launches it; wait the
+same ~3 s):
+
+```python
+from pywinauto import Application
+app = Application(backend="uia").connect(title_re=r".*Photo Manager.*")
+win = app.top_window()
+win.print_control_identifiers(depth=4)   # one-shot tree dump
+```
+
+Window title in this build is `Photo Manager - M1`. The regex above is
+robust to the suffix changing.
+
+**What you get back per element:** `control_type`, visible name (`File`,
+`Action`, `List`, `Log`, table headers like `File Name` / `Folder` /
+`Size (Bytes)` / `Creation Date`, etc.), bounding `rect`, `enabled`
+state, and an `auto_id` like `QApplication.MainWindow.QMenuBar.QAction`.
+
+**Click by name, not by pixel.** For top-level menu bar items and
+buttons:
+
+```python
+win.child_window(title="Start Scan", control_type="Button").invoke()
+```
+
+`invoke()` fires the UIA `Invoke` pattern (cheaper, more deterministic
+than `click_input()` which moves the real mouse). Fall back to
+`click_input()` only when `invoke()` is unsupported on that element.
+
+**Menu popups need a different pattern.** Qt menus open as a separate
+top-level window (Win32 class contains `"Popup"`) with `click_input()`
+on the menu bar item, then their items respond to `click_input()` but
+NOT to `invoke()` (raises `COMError -2146233083`). Pattern:
+
+```python
+import ctypes, ctypes.wintypes
+from pywinauto import Application
+
+# 1. Click the menu-bar item to open the popup
+win.child_window(title="File", control_type="MenuItem").click_input()
+time.sleep(0.5)
+
+# 2. Find the popup HWND (top-level window in the same process,
+#    class containing "Popup")
+def find_popup(pid):
+    user32 = ctypes.windll.user32
+    found = [None]
+    def cb(hwnd, _):
+        if user32.IsWindowVisible(hwnd):
+            ppid = ctypes.c_ulong()
+            user32.GetWindowThreadProcessId(hwnd, ctypes.byref(ppid))
+            if ppid.value == pid:
+                cls = ctypes.create_unicode_buffer(256)
+                user32.GetClassNameW(hwnd, cls, 256)
+                if "Popup" in cls.value:
+                    found[0] = hwnd
+                    return False
+        return True
+    proto = ctypes.WINFUNCTYPE(ctypes.c_int, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
+    user32.EnumWindows(proto(cb), 0)
+    return found[0]
+
+popup_hwnd = find_popup(win.process_id())
+popup = Application(backend="uia").connect(handle=popup_hwnd).window(handle=popup_hwnd)
+
+# 3. Click the item
+popup.child_window(title="Scan Sources…", control_type="MenuItem").click_input()
+```
+
+**Filter the noise:** the OS-level title bar shows up as `TitleBar`
+with locale-specific names (e.g. `系統`, `最小化` on a zh-TW Windows).
+Ignore that subtree — anything under `auto_id` starting with
+`QApplication.MainWindow` is the real app.
+
+**When UIA returns nothing useful** (custom-painted widget, blank
+`Custom` element with no children): that's your cue to fall back to a
+screenshot for *that step only*. Don't abandon UIA for the rest of the
+scenario.
+
 ### 4.1 — Per-scenario loop
 
-For each chosen scenario:
+Each chosen scenario has a **pre-built driver script** at
+`qa/scenarios/sNN_<title>.py`. The driver does the canonical happy
+path deterministically and prints structured `step:` / `key=value`
+lines to stdout. Your job is to (a) approve the launch, (b) run the
+driver, (c) read its output, (d) optionally do free-form UIA probes
+for surprising states or edge cases the driver doesn't cover.
+
+For each scenario:
 
 1. **Pause and ask** in chat: `"About to launch main.py for scenario
    N: <title>. OK?"` — wait for explicit yes. Do not batch this across
-   scenarios.
+   scenarios. (If the user asks for an end-to-end batch run, get a
+   single explicit "yes" up front for the whole batch and proceed.)
 
-2. **Request computer-use access** (only needed once per session, but
-   safe to call repeatedly):
+2. **Configure source folders** for this scenario (allowlisted, no prompt):
    ```
-   request_access(applications: ["python.exe", "pythonw.exe"])
+   .venv/Scripts/python.exe -m qa.scenarios.configure sNN_<name>
    ```
-   `python.exe` runs the Qt app; computer-use treats it as
-   "everything else" → tier `full` (mouse + keyboard allowed).
 
 3. **Launch the app** with Bash, run in background, with the QA
-   config root forced via env var:
+   config root and Qt accessibility forced via env vars:
    ```
-   PHOTO_MANAGER_HOME=qa .venv/Scripts/python.exe main.py
+   PHOTO_MANAGER_HOME=qa QT_ACCESSIBILITY=1 .venv/Scripts/python.exe main.py
    ```
-   This makes the app read `qa/settings.json` and ignore the user's
-   root `settings.json` / `migration_manifest.sqlite` entirely.
-   Wait ~3 seconds before the first screenshot — the window takes a
+   - `PHOTO_MANAGER_HOME=qa` — app reads `qa/settings.json` and ignores
+     the user's root `settings.json` / `migration_manifest.sqlite`.
+   - `QT_ACCESSIBILITY=1` — **required for menu navigation.** Without
+     it, Qt's `QMenu` popups (the dropdowns under File/Action/etc.) do
+     not register with the Windows UIA tree at all, so menu items are
+     invisible to pywinauto. With it, every popup item, dialog widget,
+     spinner, slider, and button becomes addressable by name.
+
+   Wait ~3 seconds before invoking the driver — the window takes a
    moment to appear.
 
-4. **Drive via screenshot → reason → act → screenshot.** Use
-   `mcp__computer-use__screenshot` **without `save_to_disk`** — the
-   image goes into your context for reasoning, and that's enough.
-   Verified: `save_to_disk: true` does not reliably surface a
-   filesystem path the agent can re-use, so don't bother trying.
+3. **Run the scenario driver as a Python module** (so its imports
+   resolve relative to the repo root):
+   ```
+   .venv/Scripts/python.exe -m qa.scenarios.s01_happy_path
+   ```
+   The driver is short, deterministic, and version-controlled. It
+   does the canonical happy path and prints structured output. Read
+   that output to populate findings; don't re-do the navigation by
+   hand.
+
+4. **Optionally probe further with free-form UIA** if the driver's
+   output suggests something worth investigating (an unexpected row
+   count, a state transition that looked off, a button text that
+   surprises you). Use the helpers in `qa/scenarios/_uia.py` —
+   `connect_main()`, `open_menu()`, `read_result_rows()`, etc. Don't
+   rebuild what's already there.
+
+   Drop to `mcp__computer-use__screenshot` **only** when the question
+   is genuinely visual: did the thumbnail render, is the layout
+   broken, what does this custom-painted preview look like. Use
+   screenshots **without `save_to_disk`** — the image goes into your
+   context for reasoning, and that's enough. Verified:
+   `save_to_disk: true` does not reliably surface a filesystem path
+   the agent can re-use, so don't bother trying.
 
    Findings are textual. The "Screenshot path" line in the issue
    body is **optional and usually omitted**. If a visual is genuinely
@@ -181,6 +311,8 @@ For each chosen scenario:
    it through the agent.
 
    **What NOT to screenshot** (these are noise; skip them):
+   - finding the next button to click — that's UIA's job
+   - reading dialog text — UIA gives it to you as a string
    - successful clicks landing on the right element
    - hover states, cursor moves, focus rings
    - routine scrolling between identical states
@@ -188,8 +320,9 @@ For each chosen scenario:
    - the desktop / start menu / taskbar (you're never testing those)
 
    **What IS worth a screenshot** (sparingly — once each):
-   - the moment a finding becomes visible (the bug frame)
-   - dialog text you need to quote in the issue body
+   - the moment a *visual* finding becomes visible (broken thumbnail,
+     mis-rendered preview, layout overflow, wrong icon)
+   - a custom-painted widget whose state UIA can't describe
    - unexpected visual state you want to confirm before acting
 
 5. **Be a human, not a script.** Try the obvious path first. Then
@@ -290,14 +423,83 @@ git operations, no PR. The user triages from the issues list.
 | Read source (Phase 1 only) | Read, Grep, Glob | orient |
 | List fixtures | Glob | Phase 2 |
 | Run sandbox script | Bash | Phase 2 (gated) |
+| Install QA deps (`pywinauto`) | Bash `pip install -r qa/requirements.txt` | Phase 4.0.5 (gated, one-time) |
 | Launch main.py | Bash, `run_in_background: true` | Phase 4 (gated, every time) |
-| Screenshot / click / type | `mcp__computer-use__*` | Phase 4 |
+| Read UI tree, click by name | `pywinauto` (UIA backend, in-process Python) | Phase 4 — default driver |
+| Visual evidence only | `mcp__computer-use__*` screenshot | Phase 4 — fallback / finding frames |
 | File findings | Bash `gh issue create` | Phase 5 (gated, batch-approved) |
+
+## Scenario drivers
+
+Each scenario in the menu has (or will have) a pre-built driver under
+`qa/scenarios/`. Drivers are version-controlled, deterministic, and
+print structured `step:` / `key=value` lines to stdout. Run them with
+`.venv/Scripts/python.exe -m qa.scenarios.<module>` while the app is
+running.
+
+| # | Scenario | Module | Status |
+|---|---|---|---|
+| 1 | Happy path: scan + review + mark | `qa.scenarios.s01_happy_path` | ✓ ready |
+| 2 | Empty folder | `qa.scenarios.s02_empty_folder` | ✓ ready |
+| 3 | Cancel scan mid-run | `qa.scenarios.s03_cancel_scan` | ✓ ready |
+| 4 | Corrupted file handling | `qa.scenarios.s04_corrupted` | ✓ ready |
+| 5 | Heavy preview interaction | `qa.scenarios.s05_huge_preview` | ✓ ready |
+| 6 | Multi-format scan | `qa.scenarios.s06_formats` | ✓ ready |
+| 7 | Format duplicate (HEIC vs JPG) | `qa.scenarios.s07_format_dup` | ✓ ready |
+| 8 | EXIF edge cases | `qa.scenarios.s08_exif_edge` | ✓ ready |
+| 9 | Walker exclusion rules | `qa.scenarios.s09_walker_exclusions` | ✓ ready |
+| 10 | Multi-source priority + dedup | `qa.scenarios.s10_multi_source` | ✓ ready |
+| 11 | Video + Live Photo | `qa.scenarios.s11_video_live` | ✓ ready |
+
+Source-folder configuration is per-scenario. Before launching the
+app, write the right `qa/settings.json` by running:
+
+```
+.venv/Scripts/python.exe -m qa.scenarios.configure <scenario_name>
+```
+
+This is allowlisted in `.claude/settings.json` so it doesn't prompt.
+The mapping from scenario name to source folders lives in
+`qa/scenarios/_config.py`.
+
+When you build a NEW scenario driver, add it to the table here AND
+to `SCENARIO_SOURCES` in `qa/scenarios/_config.py`. Keep drivers
+short — they should encode the canonical happy path, nothing more.
+Open-ended exploration is the LLM's job, on top of the driver's
+output.
+
+**Batch runner.** When the user wants to run several (or all) scenarios
+in one go, use `qa.scenarios._batch`:
+
+```
+.venv/Scripts/python.exe -m qa.scenarios._batch              # all 10 (s02–s11)
+.venv/Scripts/python.exe -m qa.scenarios._batch s04_corrupted s09_walker_exclusions
+```
+
+For each scenario it: configures `qa/settings.json` → launches
+`main.py` → waits 3.5 s → runs the driver → closes the window →
+waits for the subprocess to exit → moves to the next. Prints a final
+SUMMARY table with rc per scenario. The whole batch (10 scenarios)
+typically finishes in ~80–120 seconds. Each app launch is still a
+real launch — get the user's "yes batch" once before starting.
+
+**Optional optimization — skip the per-run Bash prompt.** Add this
+to `.allow` in `.claude/settings.json` so driver runs don't prompt:
+
+```json
+"Bash(.venv/Scripts/python.exe -m qa.scenarios.*:*)"
+```
+
+The launch of `main.py` itself stays gated by design — that's the
+security boundary. Driver runs are read-only against an
+already-running app, so allowlisting them is safe.
 
 ## Reference
 
 - Project security gates: `CLAUDE.md` at the repo root
 - Operator doc: `docs/qa/README.md`
+- Scenario drivers: `qa/scenarios/`
+- Shared UIA helpers: `qa/scenarios/_uia.py`
 - Existing fixture helpers: `scripts/make_qa_images.py`
   (`save_jpg`, `phash`, `hamming`, `sha_bytes`)
 - Sandbox generator: `scripts/make_qa_sandbox.py`

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -4,23 +4,32 @@ A Claude-driven exploratory tester for the PySide6 desktop app.
 
 ## What it is
 
-`/qa-explore` launches `main.py`, drives the UI via the `computer-use`
-MCP, and files findings as GitHub issues. It is a curious human tester,
-not a suite of assertions: each finding is grounded in observed
-behavior. Screenshots stay inline in the agent's context (used for
-reasoning); they're not saved to disk because `save_to_disk` doesn't
-reliably surface a usable path in this environment.
+`/qa-explore` launches `main.py`, drives the UI via the **Windows UI
+Automation tree** (using `pywinauto`), and files findings as GitHub
+issues. It is a curious human tester, not a suite of assertions: each
+finding is grounded in observed UI state.
+
+The agent reads the live UIA tree (button names, dialog widgets, table
+rows) instead of pixel screenshots — a few hundred bytes of structured
+text per step instead of ~100 KB of image data. Screenshots are kept as
+a fallback for genuine visual checks (broken thumbnail rendering, layout
+glitches), not for navigation.
+
+Each scenario has a pre-built **driver script** under
+`qa/scenarios/sNN_<title>.py`. The driver does the canonical happy path
+deterministically and prints structured `step:` / `key=value` lines to
+stdout. The agent reads that output, decides whether to do follow-up
+free-form UIA probes, and files findings.
 
 ## What it isn't
 
 - **Not a fixer.** It never edits source files, runs migrations, or
   opens PRs. Findings are observations; you triage and act.
-- **Not a perf benchmark.** LLM-loop latency dominates wall-clock,
-  so anything slower than "feels snappy" gets flagged qualitatively
-  ("feels slow") rather than measured.
+- **Not a perf benchmark.** Wall-clock numbers (e.g. scan elapsed) are
+  reported descriptively, not asserted.
 - **Not a regression suite.** Use `pytest` for that. The QA agent
   catches things tests don't: layout breakage, confusing copy, dead
-  buttons, dialog dismissal weirdness.
+  buttons, dialog dismissal weirdness, classifier-output sanity.
 
 ## How to invoke
 
@@ -30,23 +39,40 @@ In a Claude Code session at the project root:
 /qa-explore
 ```
 
-That's it. The skill self-loads its computer-use tools and walks the
-phases.
+That's it. The skill walks five phases (orient → seed fixtures → plan
+→ explore → triage). On first run it asks to install the QA-only
+dependency (`pywinauto`); subsequent runs skip that step.
+
+## Dependency
+
+QA needs one extra Python package not used by the app at runtime:
+
+```
+.venv/Scripts/python.exe -m pip install -r qa/requirements.txt
+```
+
+`pywinauto` reads the Windows UIA tree exposed by Qt's `QAccessible`
+bridge. The skill prompts for permission before installing.
 
 ## Isolation: nothing leaks outside `qa/`
 
-The QA agent always launches `main.py` with the env var
-`PHOTO_MANAGER_HOME=qa`. Three things follow from that:
+The QA agent always launches `main.py` with two env vars:
 
-- The app reads `qa/settings.json` (committed; only references
-  `qa/sandbox/`), **not** the root `settings.json` that points at
-  your real photo folders.
-- The app's default save-manifest path becomes `qa/run-manifest.sqlite`
-  (gitignored), **not** the root `migration_manifest.sqlite`.
-- The thumbnail disk cache goes to `qa/.thumb-cache/` (gitignored).
+```
+PHOTO_MANAGER_HOME=qa  QT_ACCESSIBILITY=1  .venv/Scripts/python.exe main.py
+```
 
-So your real settings, real manifest, and any prior scan state are
-never touched by a QA run. To reset QA state between runs, just
+- `PHOTO_MANAGER_HOME=qa` — app reads `qa/settings.json` (only
+  references `qa/sandbox/`), **not** the root `settings.json` that
+  points at your real photo folders. Manifest writes go to
+  `qa/run-manifest.sqlite` (gitignored), thumbnail cache to
+  `qa/.thumb-cache/` (gitignored).
+- `QT_ACCESSIBILITY=1` — required for menu navigation. Without it,
+  Qt's `QMenu` popups don't register with the UIA tree and the agent
+  can't click File / Action / List menu items.
+
+Your real settings, real manifest, and any prior scan state are never
+touched. To reset QA state between runs:
 `rm qa/run-manifest.sqlite qa/.thumb-cache -r`.
 
 ## What you'll be asked
@@ -55,25 +81,67 @@ The skill pauses for explicit chat approval at these moments:
 
 | Prompt | When | Why |
 |---|---|---|
+| "OK to install `pywinauto`?" | Phase 4 setup, only on first run | Pulls a new package into `.venv` |
 | "OK to run `make_qa_sandbox.py`?" | Phase 2, only if `qa/sandbox/` is missing or incomplete | Script writes ~2 MB of fixtures under `qa/sandbox/` |
-| "About to launch main.py for scenario N: ... OK?" | Phase 4, **once per scenario** | Per project CLAUDE.md, every app launch is gated; approvals are NOT batched |
-| "OK to `taskkill` python.exe?" | Phase 4, only on hang | Force-killing is state-changing and gated |
+| "About to launch main.py for scenario N: ... OK?" | Phase 4, **once per scenario** | Per project CLAUDE.md, every app launch is gated; if the user explicitly asks for a batch run, a single batch approval covers all launches |
 | "OK to file these N findings as GitHub issues?" | Phase 5, batch at the end of the run | Each `gh issue create` is also re-gated per call |
+
+Two commands are **allowlisted** (no prompt):
+
+- `python -m qa.scenarios.configure <scenario>` — writes the right
+  `qa/settings.json` for a scenario before launch
+- `python -m qa.scenarios.<driver>` — runs a driver against the
+  already-running app
+
+Both are read-only against the running process; only the launch itself
+crosses the security boundary.
 
 If you say no to any prompt, the skill stops cleanly with no
 side-effects beyond what's already happened.
 
 ## Expected runtime
 
-- Phase 1 (orient): ~30 s
-- Phase 2 (fixtures): ~30 s if regen needed, else instant
-- Phase 4 (explore): ~3–5 min per scenario, hard-capped at ~15 min total
-- Phase 5 (report): ~1 min per finding to file as a GitHub issue
+With the UIA-first drivers (current architecture):
 
-The skill ships with 11 standard scenarios across three groups (core,
-format/metadata, cross-cutting). Realistic per-run picks: **3–5
-scenarios**, ~12–18 min wall-clock including approvals. The agent
-recommends the "Smoke test" set (#1, #2, #9) if you're unsure.
+- Phase 1 (orient): ~10 s
+- Phase 2 (fixtures): ~30 s if regen needed, else instant
+- Phase 4 (explore): **~10–30 s per scenario** including launch +
+  scan + driver. The whole batch (10 scenarios via `_batch.py`) runs
+  end-to-end in ~80–120 s.
+- Phase 5 (report): ~10–30 s per finding to file as a GitHub issue
+
+The skill ships with 11 standard scenarios. A batch run of all 10
+non-s01 scenarios via `python -m qa.scenarios._batch` is realistic;
+the user can also pick subsets ("Smoke test" #1/#2/#9 etc.).
+
+## Scenario drivers
+
+| # | Module | Source folder(s) |
+|---|---|---|
+| 1 | `qa.scenarios.s01_happy_path` | `huge`, `near-duplicates`, `unique` |
+| 2 | `qa.scenarios.s02_empty_folder` | `empty` |
+| 3 | `qa.scenarios.s03_cancel_scan` | `near-duplicates`, `huge`, `unique` |
+| 4 | `qa.scenarios.s04_corrupted` | `corrupted` |
+| 5 | `qa.scenarios.s05_huge_preview` | `huge` |
+| 6 | `qa.scenarios.s06_formats` | `formats` |
+| 7 | `qa.scenarios.s07_format_dup` | `format-dup` |
+| 8 | `qa.scenarios.s08_exif_edge` | `exif-edge` |
+| 9 | `qa.scenarios.s09_walker_exclusions` | `walker-exclusions` |
+| 10 | `qa.scenarios.s10_multi_source` | `multi-source-a`, `multi-source-b` |
+| 11 | `qa.scenarios.s11_video_live` | `videos`, `live-photo` |
+
+Source-folder mapping lives in `qa/scenarios/_config.py`. To add a new
+scenario:
+
+1. Add an entry to `SCENARIO_SOURCES` in `_config.py`.
+2. Write `qa/scenarios/sNN_<title>.py` using helpers from `_uia.py`
+   (look at `s04_corrupted.py` for the canonical short template).
+3. Add a row to the table above and to the menu in `SKILL.md`.
+
+The shared helpers in `qa/scenarios/_uia.py` cover: connecting to the
+main window, opening menus (with the popup-HWND workaround), running a
+scan and waiting for `Done.`, reading the result tree, and basic
+title-bar dismissal.
 
 ## Output
 
@@ -89,9 +157,9 @@ issue is titled `[QA] <one-line title>` and contains:
 
 Screenshots are intentionally **not** attached or referenced — the
 `computer-use` `save_to_disk` flag doesn't surface a stable path in
-this environment, so the agent uses inline-only screenshots for
-reasoning and lets the user grab visual evidence manually if a
-specific issue benefits from it.
+this environment, and UIA covers ~all navigation needs anyway. If a
+specific finding benefits from a visual, grab one manually with the
+Windows snipping tool.
 
 ### Approval flow at the end of a run
 
@@ -168,7 +236,11 @@ license-clean MP4 into `videos/` manually before a run.
 (See `.claude/skills/qa-explore/SKILL.md` for the full text.)
 
 - Source code is read-only and only during Phase 1 orientation
-- No git operations of any kind
-- Writes restricted to `docs/qa/findings/**` and `qa/sandbox/**`
+- No git operations of any kind from inside `/qa-explore`
+- Writes restricted to `qa/sandbox/**` (only via `make_qa_sandbox.py`),
+  `qa/settings.json` (only via `qa.scenarios.configure`), and GitHub
+  issues
+- Findings live as GitHub issues, **never** as committed files under
+  `docs/qa/findings/`
 - Hard cap of ~15 min exploration time
 - Pause and ask the user if ≥10 findings accumulate before continuing

--- a/qa/requirements.txt
+++ b/qa/requirements.txt
@@ -1,0 +1,9 @@
+# QA-only dependencies. Not needed at app runtime — install only when
+# running `/qa-explore` or driving the UI from a script.
+#
+#     .venv/Scripts/python.exe -m pip install -r qa/requirements.txt
+#
+# pywinauto reads the Windows UI Automation tree, which PySide6 widgets
+# expose for free via QAccessible. Lets the QA agent locate and click
+# elements by name + control_type instead of by pixel coordinates.
+pywinauto>=0.6.9

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -1,0 +1,130 @@
+"""Run all qa.scenarios.sNN drivers sequentially in a single process.
+
+For each scenario:
+  1. configure qa/settings.json (writes scenario-specific source list)
+  2. launch main.py as a subprocess
+  3. wait 3s for the window
+  4. run the driver
+  5. close the window via UIA
+  6. wait for the subprocess to exit (or terminate if stuck)
+
+Usage:  .venv/Scripts/python.exe -m qa.scenarios._batch [scenarios...]
+        .venv/Scripts/python.exe -m qa.scenarios._batch s02_empty_folder s04_corrupted
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[2]
+PY = str(REPO / ".venv" / "Scripts" / "python.exe")
+
+ALL_SCENARIOS = [
+    "s02_empty_folder",
+    "s03_cancel_scan",
+    "s04_corrupted",
+    "s05_huge_preview",
+    "s06_formats",
+    "s07_format_dup",
+    "s08_exif_edge",
+    "s09_walker_exclusions",
+    "s10_multi_source",
+    "s11_video_live",
+]
+
+
+def _close_window() -> None:
+    code = (
+        "from pywinauto import Application;"
+        "import sys;"
+        "Application(backend='uia').connect(title_re=r'.*Photo Manager.*', timeout=3).top_window().close()"
+    )
+    subprocess.run([PY, "-c", code], cwd=REPO, capture_output=True, timeout=10)
+
+
+def run_one(name: str) -> tuple[int, str]:
+    print(f"\n===== {name} =====", flush=True)
+    # 1. Configure
+    r = subprocess.run(
+        [PY, "-m", "qa.scenarios.configure", name],
+        cwd=REPO, capture_output=True, text=True, timeout=15,
+    )
+    print(r.stdout, end="", flush=True)
+    if r.returncode != 0:
+        print(f"configure FAILED: {r.stderr}", flush=True)
+        return r.returncode, "configure failed"
+
+    # 2. Launch app
+    env = os.environ.copy()
+    env["PHOTO_MANAGER_HOME"] = "qa"
+    env["QT_ACCESSIBILITY"] = "1"
+    proc = subprocess.Popen(
+        [PY, "main.py"], cwd=REPO, env=env,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+    print(f"launched main.py pid={proc.pid}", flush=True)
+    time.sleep(3.5)
+
+    # 3. Drive
+    driver_rc = -1
+    driver_err = ""
+    try:
+        r = subprocess.run(
+            [PY, "-m", f"qa.scenarios.{name}"],
+            cwd=REPO, capture_output=True, text=True, timeout=180,
+        )
+        print(r.stdout, end="", flush=True)
+        if r.stderr.strip():
+            print(f"DRIVER_STDERR: {r.stderr.strip()[:1000]}", flush=True)
+        driver_rc = r.returncode
+        if driver_rc != 0:
+            driver_err = "non-zero exit"
+    except subprocess.TimeoutExpired:
+        driver_err = "driver timeout"
+        print(f"DRIVER TIMEOUT after 180s", flush=True)
+    except Exception as e:
+        driver_err = repr(e)
+        print(f"DRIVER EXC: {e!r}", flush=True)
+
+    # 4. Close window
+    try:
+        _close_window()
+    except Exception:
+        pass
+
+    # 5. Wait for subprocess
+    try:
+        proc.wait(timeout=8)
+    except subprocess.TimeoutExpired:
+        print(f"app did not exit cleanly, terminating", flush=True)
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+    return driver_rc, driver_err
+
+
+def main() -> int:
+    targets = sys.argv[1:] or ALL_SCENARIOS
+    print(f"batch: running {len(targets)} scenarios: {targets}", flush=True)
+    results: list[tuple[str, int, str]] = []
+    for name in targets:
+        rc, err = run_one(name)
+        results.append((name, rc, err))
+
+    print("\n===== BATCH SUMMARY =====", flush=True)
+    ok = sum(1 for _, rc, _ in results if rc == 0)
+    print(f"total: {len(results)}  ok: {ok}  failed: {len(results) - ok}")
+    for name, rc, err in results:
+        flag = "OK" if rc == 0 else "FAIL"
+        print(f"  [{flag}] {name}  rc={rc}  err={err!r}")
+    return 0 if ok == len(results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -1,0 +1,56 @@
+"""Per-scenario source-folder configurations.
+
+Each scenario needs a different source list in `qa/settings.json` before
+the app launches. /qa-explore calls `python -m qa.scenarios.configure
+<scenario_name>` between launches; that writes the right settings file
+based on the table below.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETTINGS_PATH = REPO_ROOT / "qa" / "settings.json"
+
+# Source folder lists per scenario. Keys are module names under qa.scenarios.
+SCENARIO_SOURCES: dict[str, list[str]] = {
+    "s01_happy_path":      ["qa/sandbox/huge", "qa/sandbox/near-duplicates", "qa/sandbox/unique"],
+    "s02_empty_folder":    ["qa/sandbox/empty"],
+    "s03_cancel_scan":     ["qa/sandbox/near-duplicates", "qa/sandbox/huge", "qa/sandbox/unique"],
+    "s04_corrupted":       ["qa/sandbox/corrupted"],
+    "s05_huge_preview":    ["qa/sandbox/huge"],
+    "s06_formats":         ["qa/sandbox/formats"],
+    "s07_format_dup":      ["qa/sandbox/format-dup"],
+    "s08_exif_edge":       ["qa/sandbox/exif-edge"],
+    "s09_walker_exclusions": ["qa/sandbox/walker-exclusions"],
+    "s10_multi_source":    ["qa/sandbox/multi-source-a", "qa/sandbox/multi-source-b"],
+    "s11_video_live":      ["qa/sandbox/videos", "qa/sandbox/live-photo"],
+}
+
+
+def build_settings(scenario_name: str) -> dict:
+    """Return the settings.json dict for a scenario."""
+    sources = SCENARIO_SOURCES.get(scenario_name)
+    if sources is None:
+        raise KeyError(
+            f"unknown scenario {scenario_name!r}; "
+            f"known: {sorted(SCENARIO_SOURCES)}"
+        )
+    return {
+        "_comment": f"Auto-written by qa.scenarios.configure for {scenario_name}.",
+        "thumbnail_size": 256,
+        "thumbnail_mem_cache": 128,
+        "thumbnail_disk_cache_dir": "qa/.thumb-cache",
+        "sorting": {"defaults": [{"field": "file_size_bytes", "asc": False}]},
+        "sources": {
+            "list": [{"path": p, "recursive": True} for p in sources],
+            "output": "qa/run-manifest.sqlite",
+        },
+    }
+
+
+def write_settings(scenario_name: str) -> Path:
+    cfg = build_settings(scenario_name)
+    SETTINGS_PATH.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
+    return SETTINGS_PATH

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -1,0 +1,298 @@
+"""Shared UIA helpers for /qa-explore scenario drivers.
+
+Names and structure of photo-manager's UI are defined in source — buttons,
+menu items, dialog titles, automation IDs are static. Encode them here as
+constants so individual scenario drivers stay short and the agent doesn't
+re-discover "what is the scan button called" each run.
+
+Rects (pixel positions) and state (enabled, visible, populated) are still
+queried live — those depend on runtime conditions.
+
+Conventions:
+- All driver entry points expect the app to be ALREADY RUNNING under
+  `PHOTO_MANAGER_HOME=qa QT_ACCESSIBILITY=1`. Launching is gated and
+  stays in /qa-explore.
+- Helpers print structured lines to stdout. The LLM reads stdout and
+  decides what to probe next. Don't `print()` decorative noise.
+"""
+from __future__ import annotations
+
+import ctypes
+import ctypes.wintypes
+import time
+from dataclasses import dataclass
+from typing import Iterable
+
+from pywinauto import Application
+from pywinauto.controls.uiawrapper import UIAWrapper
+
+
+# ---------------------------------------------------------------------------
+# Constants — element names defined by photo-manager's source
+# ---------------------------------------------------------------------------
+
+WINDOW_TITLE_RE = r".*Photo Manager.*"
+
+# Top-level menu bar
+MENU_FILE = "File"
+MENU_ACTION = "Action"
+MENU_LIST = "List"
+MENU_LOG = "Log"
+
+# File menu items
+FILE_SCAN_SOURCES = "Scan Sources…"
+FILE_OPEN_MANIFEST = "Open Manifest…"
+FILE_SAVE_MANIFEST = "Save Manifest Decisions…"
+FILE_EXIT = "Exit"
+
+# Action menu items
+ACTION_BY_REGEX = "Set Action by Field/Regex…"
+ACTION_EXECUTE = "Execute Action…"
+
+# Scan dialog
+SCAN_DIALOG_TITLE = "Scan Sources"
+SCAN_BTN_START = "Start Scan"
+SCAN_BTN_CLOSE_LOAD = "Close  Load"   # NB: literal double-space, see finding #1
+SCAN_BTN_BROWSE = "Browse…"
+SCAN_BTN_REMOVE_ALL = "Remove All"
+SCAN_BTN_ADD_SELECTED = "+ Add Selected Folder"
+SCAN_AID_LOG = "QApplication.ScanDialog.QPlainTextEdit"
+SCAN_AID_OUTPUT_PATH = "QApplication.ScanDialog.QLineEdit"
+SCAN_AID_SOURCE_TABLE = (
+    "QApplication.ScanDialog.QSplitter._SourceListWidget.QTableWidget"
+)
+
+
+# ---------------------------------------------------------------------------
+# Win32 plumbing — needed because Qt menu popups are top-level windows but
+# don't expose themselves through pywinauto's normal child traversal.
+# ---------------------------------------------------------------------------
+
+_user32 = ctypes.windll.user32
+_WNDENUMPROC = ctypes.WINFUNCTYPE(
+    ctypes.c_int, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM
+)
+
+
+def list_process_windows(pid: int) -> list[tuple[int, str, str]]:
+    """Return [(hwnd, win32_class, title)] for visible top-level windows owned by pid."""
+    out: list[tuple[int, str, str]] = []
+
+    def cb(hwnd, _):
+        if _user32.IsWindowVisible(hwnd):
+            ppid = ctypes.c_ulong()
+            _user32.GetWindowThreadProcessId(hwnd, ctypes.byref(ppid))
+            if ppid.value == pid:
+                title = ctypes.create_unicode_buffer(256)
+                _user32.GetWindowTextW(hwnd, title, 256)
+                cls = ctypes.create_unicode_buffer(256)
+                _user32.GetClassNameW(hwnd, cls, 256)
+                out.append((hwnd, cls.value, title.value))
+        return True
+
+    _user32.EnumWindows(_WNDENUMPROC(cb), 0)
+    return out
+
+
+def find_popup(pid: int) -> int | None:
+    """Find the Qt menu popup window owned by pid (Win32 class contains 'Popup')."""
+    for hwnd, cls, _title in list_process_windows(pid):
+        if "Popup" in cls:
+            return hwnd
+    return None
+
+
+def force_foreground(hwnd: int) -> None:
+    _user32.SwitchToThisWindow(hwnd, True)
+
+
+# ---------------------------------------------------------------------------
+# Connection helpers
+# ---------------------------------------------------------------------------
+
+
+def connect_main(timeout: float = 5) -> tuple[Application, UIAWrapper]:
+    app = Application(backend="uia").connect(title_re=WINDOW_TITLE_RE, timeout=timeout)
+    return app, app.top_window()
+
+
+def connect_by_handle(hwnd: int) -> UIAWrapper:
+    return Application(backend="uia").connect(handle=hwnd).window(handle=hwnd)
+
+
+# ---------------------------------------------------------------------------
+# Menu navigation
+# ---------------------------------------------------------------------------
+
+
+def open_menu(win: UIAWrapper, menu_title: str) -> UIAWrapper:
+    """Click a top-level menu and return the popup wrapper.
+
+    Caller is responsible for clicking an item in the popup; the popup
+    closes when an item is clicked or focus moves away.
+    """
+    force_foreground(win.handle)
+    time.sleep(0.3)
+    win.child_window(title=menu_title, control_type="MenuItem").click_input()
+    time.sleep(0.5)
+    popup_hwnd = find_popup(win.process_id())
+    if popup_hwnd is None:
+        raise RuntimeError(f"menu popup did not appear for {menu_title!r}")
+    return connect_by_handle(popup_hwnd)
+
+
+def click_menu_item(popup: UIAWrapper, item_title: str) -> None:
+    """Click a popup menu item. invoke() raises COMError on these — use click_input."""
+    popup.child_window(title=item_title, control_type="MenuItem").click_input()
+
+
+def menu_path(win: UIAWrapper, menu: str, item: str) -> None:
+    """Convenience: open `menu`, click `item`, done."""
+    popup = open_menu(win, menu)
+    click_menu_item(popup, item)
+
+
+# ---------------------------------------------------------------------------
+# Result-tree reading
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class GroupedRow:
+    y: int
+    cells: tuple[str, ...]   # left-to-right, only non-empty
+
+
+def read_result_rows(win: UIAWrapper, y_min: int = 600) -> list[GroupedRow]:
+    """Walk the main window's TreeView and return rows sorted by screen Y.
+
+    Each row's cells are read by clustering elements with similar y-coords.
+    Empty cells (Action column on un-decided files, etc.) are not present.
+    """
+    items = win.descendants(control_type="TreeItem")
+    by_row: dict[int, list[tuple[int, str]]] = {}
+    for it in items:
+        try:
+            txt = (it.window_text() or "").strip()
+            r = it.rectangle()
+            if not txt or r.top < y_min:
+                continue
+            key = r.top // 30 * 30   # 30px row height bucket
+            by_row.setdefault(key, []).append((r.left, txt))
+        except Exception:
+            continue
+    out: list[GroupedRow] = []
+    for y in sorted(by_row):
+        cells = tuple(t for _, t in sorted(by_row[y]))
+        out.append(GroupedRow(y=y, cells=cells))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Wait helpers
+# ---------------------------------------------------------------------------
+
+
+def wait_for_dialog(pid: int, title: str, timeout: float = 10) -> int:
+    """Block until a window with `title` appears in pid; return its hwnd."""
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for hwnd, _cls, t in list_process_windows(pid):
+            if t == title:
+                return hwnd
+        time.sleep(0.2)
+    raise TimeoutError(f"dialog {title!r} did not appear within {timeout}s")
+
+
+def wait_for_text_in(
+    edit: UIAWrapper, needles: Iterable[str], timeout: float = 30
+) -> str:
+    """Poll an Edit/QPlainTextEdit until any of `needles` appears. Returns full text."""
+    deadline = time.time() + timeout
+    last = ""
+    while time.time() < deadline:
+        try:
+            last = edit.window_text() or ""
+        except Exception:
+            pass
+        if any(n in last for n in needles):
+            return last
+        time.sleep(0.5)
+    raise TimeoutError(f"none of {list(needles)!r} appeared in edit within {timeout}s")
+
+
+# ---------------------------------------------------------------------------
+# Composed flows — used by most scenarios
+# ---------------------------------------------------------------------------
+
+
+def open_scan_dialog(win: UIAWrapper) -> tuple[UIAWrapper, int]:
+    """Open File > Scan Sources… and return (dialog_wrapper, dialog_hwnd)."""
+    pid = win.process_id()
+    menu_path(win, MENU_FILE, FILE_SCAN_SOURCES)
+    hwnd = wait_for_dialog(pid, SCAN_DIALOG_TITLE, timeout=5)
+    return connect_by_handle(hwnd), hwnd
+
+
+def read_configured_sources(dlg: UIAWrapper) -> list[str]:
+    """Return the source paths currently in the Scan dialog's table."""
+    out: list[str] = []
+    try:
+        table = dlg.child_window(
+            auto_id=SCAN_AID_SOURCE_TABLE, control_type="Table"
+        )
+        for cell in table.descendants(control_type="DataItem"):
+            t = (cell.window_text() or "").strip()
+            if "sandbox" in t:
+                out.append(t)
+    except Exception:
+        pass
+    return out
+
+
+def run_scan_and_wait(
+    dlg: UIAWrapper, timeout: float = 60
+) -> tuple[str, float]:
+    """Click Start Scan, poll log until 'Done.' or error. Returns (full_log, elapsed)."""
+    start_btn = dlg.child_window(title=SCAN_BTN_START, control_type="Button")
+    log_edit = dlg.child_window(auto_id=SCAN_AID_LOG, control_type="Edit")
+    t0 = time.time()
+    start_btn.invoke()
+    log = wait_for_text_in(log_edit, ["Done.", "Error", "Failed"], timeout=timeout)
+    return log, time.time() - t0
+
+
+def extract_summary(log: str) -> list[str]:
+    """Pull the manifest-summary block from the scan log."""
+    out: list[str] = []
+    in_summary = False
+    for line in log.splitlines():
+        if "Migration Manifest Summary" in line or "Group Summary" in line:
+            in_summary = True
+        if in_summary:
+            out.append(line.strip())
+        if in_summary and line.strip().startswith("──") and out and len(out) > 1:
+            in_summary = False
+    return out
+
+
+def close_and_load_manifest(dlg: UIAWrapper) -> None:
+    """Click 'Close  Load' (post-scan dialog button)."""
+    btn = dlg.child_window(title=SCAN_BTN_CLOSE_LOAD, control_type="Button")
+    btn.invoke()
+    time.sleep(1.0)
+
+
+def cancel_scan_dialog(dlg: UIAWrapper) -> None:
+    """Click the title-bar Close (×) to cancel a scan or close pre-scan."""
+    # Locale-named close button on the title bar
+    try:
+        for b in dlg.descendants(control_type="Button"):
+            r = b.rectangle()
+            t = b.window_text() or ""
+            if r.top < 320 and r.left > 2400 and t in ("關閉", "Close", "X"):
+                b.click_input()
+                time.sleep(0.5)
+                return
+    except Exception:
+        pass

--- a/qa/scenarios/configure.py
+++ b/qa/scenarios/configure.py
@@ -1,0 +1,32 @@
+"""CLI: write qa/settings.json for a scenario.
+
+Usage:
+    .venv/Scripts/python.exe -m qa.scenarios.configure <scenario_name>
+
+Run this BEFORE launching main.py for the scenario.
+"""
+from __future__ import annotations
+
+import sys
+
+from qa.scenarios._config import SCENARIO_SOURCES, write_settings
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print(f"usage: python -m qa.scenarios.configure <scenario>")
+        print(f"known scenarios: {sorted(SCENARIO_SOURCES)}")
+        return 2
+    name = sys.argv[1]
+    try:
+        path = write_settings(name)
+    except KeyError as e:
+        print(f"error: {e}")
+        return 1
+    print(f"wrote {path}")
+    print(f"sources={SCENARIO_SOURCES[name]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s01_happy_path.py
+++ b/qa/scenarios/s01_happy_path.py
@@ -1,0 +1,67 @@
+"""Scenario 1 — Happy path: scan + review + mark.
+
+Required sources (write before launching): qa/sandbox/huge,
+qa/sandbox/near-duplicates, qa/sandbox/unique
+PRE: PHOTO_MANAGER_HOME=qa QT_ACCESSIBILITY=1 .venv/Scripts/python.exe main.py
+"""
+from __future__ import annotations
+
+import ctypes
+import sys
+
+from qa.scenarios import _uia
+
+
+def main() -> int:
+    print("scenario: s01_happy_path")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, scan_hwnd = _uia.open_scan_dialog(win)
+    print(f"  scan_dialog_hwnd={scan_hwnd}")
+
+    print("step: read_scan_dialog")
+    output_path = dlg.child_window(
+        auto_id=_uia.SCAN_AID_OUTPUT_PATH, control_type="Edit"
+    ).window_text()
+    spinners = [s.window_text() for s in dlg.descendants(control_type="Spinner")]
+    print(f"  output_path={output_path!r}")
+    print(f"  spinner_values={spinners!r}")
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    for line in _uia.extract_summary(log):
+        if line:
+            print(f"  log: {line}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+    remaining = [t for _, _, t in _uia.list_process_windows(win.process_id())]
+    print(f"  windows_after_close={remaining!r}")
+
+    print("step: read_results")
+    _, win = _uia.connect_main()
+    rows = _uia.read_result_rows(win)
+    print(f"  total_rows={len(rows)}")
+    for r in rows:
+        print(f"  row: y={r.y} cells={list(r.cells)}")
+
+    print("step: verify_action_menu_enabled")
+    popup = _uia.open_menu(win, _uia.MENU_ACTION)
+    for it in popup.descendants(control_type="MenuItem"):
+        try:
+            print(f"  action_menu: title={it.window_text()!r} enabled={it.is_enabled()}")
+        except Exception as e:
+            print(f"  action_menu: err={e!r}")
+    ctypes.windll.user32.keybd_event(0x1B, 0, 0, 0)
+    ctypes.windll.user32.keybd_event(0x1B, 0, 2, 0)
+
+    print("scenario: s01_happy_path DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s02_empty_folder.py
+++ b/qa/scenarios/s02_empty_folder.py
@@ -1,0 +1,59 @@
+"""Scenario 2 — Empty folder: empty-state UX, no-results dialog.
+
+Required sources: qa/sandbox/empty
+Probes: how the app handles a scan that finds zero files.
+"""
+from __future__ import annotations
+
+import sys
+import time
+
+from qa.scenarios import _uia
+
+
+def main() -> int:
+    print("scenario: s02_empty_folder")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, scan_hwnd = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=20)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    for line in log.splitlines():
+        s = line.strip()
+        if s:
+            print(f"  log: {s[:160]}")
+
+    print("step: post_scan_dialog_state")
+    pid = win.process_id()
+    wins = [t for _, _, t in _uia.list_process_windows(pid)]
+    print(f"  open_windows={wins!r}")
+    # Did anything pop up? (empty-state dialog, message, etc.)
+    extra = [t for t in wins if t not in ("Photo Manager - M1", "Scan Sources")]
+    print(f"  extra_dialogs={extra!r}")
+
+    print("step: close_dialog")
+    try:
+        _uia.close_and_load_manifest(dlg)
+    except Exception as e:
+        print(f"  close_load_failed={e!r}")
+        # Fall back to title-bar close
+        _uia.cancel_scan_dialog(dlg)
+
+    print("step: read_results")
+    _, win = _uia.connect_main()
+    rows = _uia.read_result_rows(win)
+    print(f"  total_rows={len(rows)}")
+    for r in rows[:10]:
+        print(f"  row: y={r.y} cells={list(r.cells)}")
+
+    print("scenario: s02_empty_folder DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s03_cancel_scan.py
+++ b/qa/scenarios/s03_cancel_scan.py
@@ -1,0 +1,59 @@
+"""Scenario 3 — Cancel scan mid-run.
+
+Required sources: qa/sandbox/near-duplicates, huge, unique
+Probes: interrupt handling — does cancel actually stop, is cleanup clean,
+is the manifest left in a consistent state?
+
+Strategy: kick off a scan, immediately click the title-bar Close (×) — there's
+no explicit "Cancel" button on the dialog, so the close gesture IS the cancel.
+"""
+from __future__ import annotations
+
+import sys
+import time
+
+from qa.scenarios import _uia
+
+
+def main() -> int:
+    print("scenario: s03_cancel_scan")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, scan_hwnd = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: start_then_cancel")
+    start_btn = dlg.child_window(title=_uia.SCAN_BTN_START, control_type="Button")
+    log_edit = dlg.child_window(auto_id=_uia.SCAN_AID_LOG, control_type="Edit")
+    t0 = time.time()
+    start_btn.invoke()
+    # Let it get into the hashing phase, then cancel
+    time.sleep(0.8)
+    pre_log = log_edit.window_text() or ""
+    print(f"  log_at_cancel={pre_log[-300:]!r}")
+    _uia.cancel_scan_dialog(dlg)
+    elapsed = time.time() - t0
+    print(f"  cancel_elapsed_s={elapsed:.2f}")
+    time.sleep(1.0)
+
+    print("step: post_cancel_state")
+    pid = win.process_id()
+    wins = [t for _, _, t in _uia.list_process_windows(pid)]
+    print(f"  open_windows={wins!r}")
+
+    # Inspect main window for stale state
+    print("step: read_main_after_cancel")
+    _, win = _uia.connect_main()
+    rows = _uia.read_result_rows(win)
+    print(f"  total_rows_after_cancel={len(rows)}")
+    for r in rows[:10]:
+        print(f"  row: y={r.y} cells={list(r.cells)}")
+
+    print("scenario: s03_cancel_scan DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s04_corrupted.py
+++ b/qa/scenarios/s04_corrupted.py
@@ -1,0 +1,56 @@
+"""Scenario 4 — Corrupted file handling.
+
+Required sources: qa/sandbox/corrupted
+Probes: hash/EXIF error paths — does the scan tolerate a corrupted file,
+log a meaningful error, and continue?
+"""
+from __future__ import annotations
+
+import sys
+
+from qa.scenarios import _uia
+
+
+def main() -> int:
+    print("scenario: s04_corrupted")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, scan_hwnd = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    # Print every log line — corruption findings live in the log text
+    for line in log.splitlines():
+        s = line.strip()
+        if s:
+            print(f"  log: {s[:200]}")
+    # Surface error / warning lines
+    err_lines = [l for l in log.splitlines() if any(
+        k in l.lower() for k in ("error", "warning", "fail", "skip", "corrupt")
+    )]
+    print(f"  error_keyword_lines={len(err_lines)}")
+
+    print("step: close_dialog")
+    try:
+        _uia.close_and_load_manifest(dlg)
+    except Exception as e:
+        print(f"  close_load_failed={e!r}")
+        _uia.cancel_scan_dialog(dlg)
+
+    print("step: read_results")
+    _, win = _uia.connect_main()
+    rows = _uia.read_result_rows(win)
+    print(f"  total_rows={len(rows)}")
+    for r in rows[:15]:
+        print(f"  row: y={r.y} cells={list(r.cells)}")
+
+    print("scenario: s04_corrupted DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s05_huge_preview.py
+++ b/qa/scenarios/s05_huge_preview.py
@@ -1,0 +1,76 @@
+"""Scenario 5 — Heavy preview interaction.
+
+Required sources: qa/sandbox/huge
+Probes: large-image perf, keyboard nav, rapid clicks, preview rendering.
+
+Strategy: scan the huge folder (1 file), load manifest, select the row,
+hit it with rapid Enter / arrow keys, measure response.
+"""
+from __future__ import annotations
+
+import sys
+import time
+
+from qa.scenarios import _uia
+
+
+def main() -> int:
+    print("scenario: s05_huge_preview")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, scan_hwnd = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=60)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    for line in _uia.extract_summary(log):
+        if line:
+            print(f"  log: {line}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+
+    print("step: read_results")
+    _, win = _uia.connect_main()
+    rows = _uia.read_result_rows(win)
+    print(f"  total_rows={len(rows)}")
+    for r in rows[:10]:
+        print(f"  row: y={r.y} cells={list(r.cells)}")
+
+    # Probe preview perf: click the (only) file row, then rapid clicks
+    print("step: select_row_and_probe_preview")
+    items = win.descendants(control_type="TreeItem")
+    target = next((i for i in items if (i.window_text() or "").endswith(".jpg")), None)
+    if target is None:
+        print("  no file row found")
+    else:
+        print(f"  target={target.window_text()!r}")
+        t0 = time.time()
+        target.click_input()
+        time.sleep(0.5)
+        # Rapid double clicks
+        for _ in range(3):
+            target.click_input(double=True)
+            time.sleep(0.2)
+        print(f"  rapid_click_elapsed_s={time.time() - t0:.2f}")
+
+    # Read preview pane state
+    print("step: read_preview_pane")
+    for s in win.descendants(control_type="Text"):
+        try:
+            t = (s.window_text() or "").strip()
+            aid = s.element_info.automation_id or ""
+            if "PreviewPane" in aid:
+                print(f"  preview_text: {t[:80]!r}  aid={aid!r}")
+        except Exception:
+            pass
+
+    print("scenario: s05_huge_preview DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s06_formats.py
+++ b/qa/scenarios/s06_formats.py
@@ -1,0 +1,60 @@
+"""Scenario 6 — Multi-format scan: HEIC, PNG, GIF, WebP, TIFF.
+
+Required sources: qa/sandbox/formats
+Probes: thumbnails render, dates extracted, GIF graceful handling (no EXIF).
+"""
+from __future__ import annotations
+
+import sys
+
+from qa.scenarios import _uia
+
+
+def main() -> int:
+    print("scenario: s06_formats")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, scan_hwnd = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=60)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    for line in _uia.extract_summary(log):
+        if line:
+            print(f"  log: {line}")
+    # Also surface any per-file warnings about unrecognized formats
+    warns = [l for l in log.splitlines() if any(
+        k in l.lower() for k in ("warning", "error", "skip", "unrecognized", "no exif")
+    )]
+    print(f"  warning_lines={len(warns)}")
+    for w in warns[:10]:
+        print(f"  warn: {w.strip()[:200]}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+
+    print("step: read_results")
+    _, win = _uia.connect_main()
+    rows = _uia.read_result_rows(win)
+    print(f"  total_rows={len(rows)}")
+    for r in rows:
+        print(f"  row: y={r.y} cells={list(r.cells)}")
+    # Verify each format showed up
+    extensions_seen = set()
+    for r in rows:
+        for cell in r.cells:
+            if "." in cell and len(cell) < 80:
+                ext = cell.rsplit(".", 1)[-1].lower()
+                if len(ext) <= 5:
+                    extensions_seen.add(ext)
+    print(f"  extensions_in_results={sorted(extensions_seen)}")
+
+    print("scenario: s06_formats DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s07_format_dup.py
+++ b/qa/scenarios/s07_format_dup.py
@@ -1,0 +1,54 @@
+"""Scenario 7 — Format duplicate (HEIC vs JPG of same scene).
+
+Required sources: qa/sandbox/format-dup
+Probes: FORMAT_DUPLICATE classifier — HEIC should win, JPG marked as the dup.
+"""
+from __future__ import annotations
+
+import sys
+
+from qa.scenarios import _uia
+
+
+def main() -> int:
+    print("scenario: s07_format_dup")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, scan_hwnd = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    # Print the full classifier summary AND any FORMAT_DUPLICATE-tagged lines
+    for line in log.splitlines():
+        s = line.strip()
+        if s and ("FORMAT" in s.upper() or "Manifest Summary" in s
+                  or "Group" in s or "%" in s or "──" in s):
+            print(f"  log: {s[:200]}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+
+    print("step: read_results")
+    _, win = _uia.connect_main()
+    rows = _uia.read_result_rows(win)
+    print(f"  total_rows={len(rows)}")
+    for r in rows:
+        print(f"  row: y={r.y} cells={list(r.cells)}")
+    # Check which file was marked as Ref (the winner)
+    ref_file = None
+    for r in rows:
+        if r.cells and r.cells[0] == "Ref":
+            ref_file = r.cells[1] if len(r.cells) > 1 else None
+            break
+    print(f"  ref_file={ref_file!r}")
+
+    print("scenario: s07_format_dup DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s08_exif_edge.py
+++ b/qa/scenarios/s08_exif_edge.py
@@ -1,0 +1,51 @@
+"""Scenario 8 — EXIF edge cases.
+
+Required sources: qa/sandbox/exif-edge
+Probes: Date column for: timezone offset, sub-second, CreateDate-only,
+DateTime tag-only, zero sentinel, dash sentinel.
+"""
+from __future__ import annotations
+
+import sys
+
+from qa.scenarios import _uia
+
+
+def main() -> int:
+    print("scenario: s08_exif_edge")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, scan_hwnd = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=60)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    for line in _uia.extract_summary(log):
+        if line:
+            print(f"  log: {line}")
+    # UNDATED count is meaningful for this scenario
+    for line in log.splitlines():
+        if "UNDATED" in line.upper():
+            print(f"  log: {line.strip()[:200]}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+
+    print("step: read_results")
+    _, win = _uia.connect_main()
+    rows = _uia.read_result_rows(win)
+    print(f"  total_rows={len(rows)}")
+    # For each file row, surface filename + Shot Date column. Walk all so the
+    # LLM can audit per-file what the Date column is showing for each edge case.
+    for r in rows:
+        print(f"  row: y={r.y} cells={list(r.cells)}")
+
+    print("scenario: s08_exif_edge DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s09_walker_exclusions.py
+++ b/qa/scenarios/s09_walker_exclusions.py
@@ -1,0 +1,62 @@
+"""Scenario 9 — Walker exclusion rules.
+
+Required sources: qa/sandbox/walker-exclusions
+Probes: only the 2 real photos appear; sidecar.json, Thumbs.db, desktop.ini
+correctly skipped.
+"""
+from __future__ import annotations
+
+import sys
+
+from qa.scenarios import _uia
+
+
+def main() -> int:
+    print("scenario: s09_walker_exclusions")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, scan_hwnd = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    # Check the "→ N files" line — should show 2 if exclusions worked
+    for line in log.splitlines():
+        if "files" in line.lower() and "→" in line:
+            print(f"  walker_count_line: {line.strip()[:200]}")
+    for line in _uia.extract_summary(log):
+        if line:
+            print(f"  log: {line}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+
+    print("step: read_results")
+    _, win = _uia.connect_main()
+    rows = _uia.read_result_rows(win)
+    print(f"  total_rows={len(rows)}")
+    for r in rows:
+        print(f"  row: y={r.y} cells={list(r.cells)}")
+    # Surface filenames seen — these should be the 2 real photos only
+    files = []
+    for r in rows:
+        for c in r.cells:
+            if "." in c and "\\" not in c and "/" not in c and len(c) < 60:
+                if any(c.lower().endswith(e) for e in (".jpg", ".jpeg", ".png", ".heic", ".tiff", ".webp")):
+                    files.append(c)
+    print(f"  files_in_results={files}")
+    # Excluded files we DON'T want to see
+    excluded = ["sidecar.json", "Thumbs.db", "desktop.ini"]
+    for ex in excluded:
+        present = any(ex in r.cells[1] if len(r.cells) > 1 else False for r in rows)
+        print(f"  excluded_file_present: {ex}={present}")
+
+    print("scenario: s09_walker_exclusions DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s10_multi_source.py
+++ b/qa/scenarios/s10_multi_source.py
@@ -1,0 +1,54 @@
+"""Scenario 10 — Multi-source priority + cross-source dedup.
+
+Required sources: qa/sandbox/multi-source-a, qa/sandbox/multi-source-b
+Probes: EXACT_DUPLICATE across sources, near-dup grouping,
+source-order priority (multi-source-a is configured FIRST → wins ties).
+"""
+from __future__ import annotations
+
+import sys
+
+from qa.scenarios import _uia
+
+
+def main() -> int:
+    print("scenario: s10_multi_source")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, scan_hwnd = _uia.open_scan_dialog(win)
+    sources = _uia.read_configured_sources(dlg)
+    print(f"  configured_sources={sources!r}")
+    print(f"  source_order={sources!r}")  # order matters here
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    for line in _uia.extract_summary(log):
+        if line:
+            print(f"  log: {line}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+
+    print("step: read_results")
+    _, win = _uia.connect_main()
+    rows = _uia.read_result_rows(win)
+    print(f"  total_rows={len(rows)}")
+    for r in rows:
+        print(f"  row: y={r.y} cells={list(r.cells)}")
+
+    # For multi-source dedup: which source folder did the Ref come from?
+    print("step: analyze_priority")
+    for r in rows:
+        if r.cells and r.cells[0] == "Ref":
+            ref_folder = r.cells[2] if len(r.cells) > 2 else "?"
+            print(f"  ref_folder={ref_folder!r}")
+
+    print("scenario: s10_multi_source DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s11_video_live.py
+++ b/qa/scenarios/s11_video_live.py
@@ -1,0 +1,60 @@
+"""Scenario 11 — Video + Live Photo.
+
+Required sources: qa/sandbox/videos, qa/sandbox/live-photo
+Probes: MP4/MOV recognized, no pHash for video, IMG_0001 HEIC+MOV pair
+grouped, action propagation works for video pairs.
+"""
+from __future__ import annotations
+
+import sys
+
+from qa.scenarios import _uia
+
+
+def main() -> int:
+    print("scenario: s11_video_live")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, scan_hwnd = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=60)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    for line in _uia.extract_summary(log):
+        if line:
+            print(f"  log: {line}")
+    # Look for any video-specific messages (no pHash, etc.)
+    video_lines = [l for l in log.splitlines() if any(
+        k in l.lower() for k in ("video", "mp4", "mov", "live", "no phash", "skip phash")
+    )]
+    print(f"  video_log_lines={len(video_lines)}")
+    for v in video_lines[:10]:
+        print(f"  v_log: {v.strip()[:200]}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+
+    print("step: read_results")
+    _, win = _uia.connect_main()
+    rows = _uia.read_result_rows(win)
+    print(f"  total_rows={len(rows)}")
+    for r in rows:
+        print(f"  row: y={r.y} cells={list(r.cells)}")
+    # Surface .mov / .mp4 entries
+    video_files = []
+    for r in rows:
+        for c in r.cells:
+            cl = c.lower()
+            if cl.endswith(".mov") or cl.endswith(".mp4"):
+                video_files.append(c)
+    print(f"  video_files_in_results={video_files}")
+
+    print("scenario: s11_video_live DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/settings.json
+++ b/qa/settings.json
@@ -1,28 +1,30 @@
 {
-  "_comment": "Isolated config for /qa-explore. The QA agent loads this by setting PHOTO_MANAGER_HOME=<repo>/qa before launching main.py. Never references real photo folders. Schema matches scan_dialog.py:451-456 — sources.list is a list of {path, recursive} dicts.",
+  "_comment": "Auto-written by qa.scenarios.configure for s01_happy_path.",
   "thumbnail_size": 256,
   "thumbnail_mem_cache": 128,
   "thumbnail_disk_cache_dir": "qa/.thumb-cache",
   "sorting": {
     "defaults": [
-      { "field": "file_size_bytes", "asc": false }
+      {
+        "field": "file_size_bytes",
+        "asc": false
+      }
     ]
   },
   "sources": {
     "list": [
-      { "path": "qa/sandbox/unique", "recursive": true },
-      { "path": "qa/sandbox/near-duplicates", "recursive": true },
-      { "path": "qa/sandbox/empty", "recursive": true },
-      { "path": "qa/sandbox/corrupted", "recursive": true },
-      { "path": "qa/sandbox/huge", "recursive": true },
-      { "path": "qa/sandbox/formats", "recursive": true },
-      { "path": "qa/sandbox/exif-edge", "recursive": true },
-      { "path": "qa/sandbox/format-dup", "recursive": true },
-      { "path": "qa/sandbox/multi-source-a", "recursive": true },
-      { "path": "qa/sandbox/multi-source-b", "recursive": true },
-      { "path": "qa/sandbox/walker-exclusions", "recursive": true },
-      { "path": "qa/sandbox/videos", "recursive": true },
-      { "path": "qa/sandbox/live-photo", "recursive": true }
+      {
+        "path": "qa/sandbox/huge",
+        "recursive": true
+      },
+      {
+        "path": "qa/sandbox/near-duplicates",
+        "recursive": true
+      },
+      {
+        "path": "qa/sandbox/unique",
+        "recursive": true
+      }
     ],
     "output": "qa/run-manifest.sqlite"
   }


### PR DESCRIPTION
## Summary

- Replaces the screenshot-driven QA loop with deterministic per-scenario drivers that read Qt's accessibility tree via `pywinauto`. End-to-end batch of all 10 non-s01 scenarios runs in ~80–120 s versus the previous multi-minute per-scenario loop.
- 11 scenario drivers under `qa/scenarios/sNN_*.py`, plus shared helpers (`_uia.py`), per-scenario settings writer (`_config.py` + `configure.py`), and a one-process batch runner (`_batch.py`).
- Adds `pywinauto` as a QA-only dep (`qa/requirements.txt`); allowlists `qa.scenarios.*` invocations in `.claude/settings.json.example` so driver/configure calls don't prompt — launches stay gated.
- Rewrites `docs/qa/README.md` and updates `.claude/skills/qa-explore/SKILL.md` to reflect the new architecture, the required `QT_ACCESSIBILITY=1` env var, the popup-HWND pattern, the batch runner, and current runtime numbers.

## Why

The screenshot-per-step loop was slow and token-heavy. Most pixels in each frame were noise; what the agent actually needs each step (button names, dialog widgets, table rows) is already exposed by Qt's `QAccessible` bridge as structured text — a few hundred bytes versus ~100 KB per UIA snapshot. With `QT_ACCESSIBILITY=1` set on launch, every menu popup and dialog widget becomes addressable by name, so we can drive the app deterministically from a Python script.

## Findings produced by the new run

This branch was used to file 5 QA issues against the app (severity 0/0/2/3/0):

- #54 — `Close  Load` button label (double-space)
- #55 — within-group row order puts Ref last
- #56 — empty-folder scan never logs `Done.` (driver hung)
- #57 — corrupted files silently classified as `UNDATED`
- #58 — result tree hides isolated files

All five are independent of this PR; they're observations from the QA run and live as separate issues for triage.

## Test plan

- [x] All 11 drivers run end-to-end against a freshly-launched app (s01 individually + s02–s11 via `_batch.py`); 10/11 pass cleanly, 1 timeout (s02) is itself a finding (#56), not a driver bug.
- [x] `pywinauto` install lands cleanly into `.venv` from `qa/requirements.txt`.
- [x] `qa/settings.json` round-trips through `python -m qa.scenarios.configure <scenario>` for every scenario.
- [x] `QT_ACCESSIBILITY=1` verified to expose `QMenu` popup items in the UIA tree (`Scan Sources…`, `Open Manifest…`, `Save Manifest Decisions…`, `Exit`); without it, popups are invisible.
- [ ] Reviewer to spot-check: does running `/qa-explore` from scratch on a fresh checkout walk the new flow without manual intervention?
- [ ] Reviewer to spot-check: is the popup-HWND workaround in `_uia.find_popup` portable across Windows locales? (Verified on zh-TW; class name match `"Popup"` should be locale-independent but worth confirming.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)