### PR TITLE
chore: finish CSV-removal cleanup, drop dead closeEvent block

### DIFF
--- a/app/viewmodels/main_vm.py
+++ b/app/viewmodels/main_vm.py
@@ -1,4 +1,4 @@
-"""ViewModel for orchestrating CSV IO and grouping/sorting logic."""
+"""ViewModel for grouping and sorting photo records loaded from a manifest."""
 
 from __future__ import annotations
 

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -383,52 +383,6 @@ class MainWindow(QMainWindow):
         """
         self._preview.on_image_loaded(token, path, image)
 
-    # PRESERVED: Close event handler
-
-    def closeEvent(self, event) -> None:
-        """Handle application close event to prompt for source file update.
-
-        Args:
-            event: Close event
-        """
-        try:
-            # Check if there are any changes that might need saving
-            source_path = self._vm.get_source_csv_path()
-            if source_path and self._vm.groups:
-                # Ask user if they want to update the source file
-                reply = QMessageBox.question(
-                    self,
-                    "Update Source File",
-                    f"Do you want to update the source CSV file with the current list?\n\n{source_path}",
-                    QMessageBox.Yes | QMessageBox.No | QMessageBox.Cancel,
-                    QMessageBox.No,
-                )
-
-                if reply == QMessageBox.Yes:
-                    try:
-                        # Use the same export path used by the menu export (with dialogs)
-                        self.file_operations.export_csv_to_path(source_path)
-                        logger.info("Source file updated on exit: {}", source_path)
-                    except Exception as ex:
-                        logger.error("Failed to update source file on exit: {}", ex)
-                        QMessageBox.warning(
-                            self, "Update Failed", f"Failed to update source file:\n{str(ex)}"
-                        )
-                        event.ignore()
-                        return
-                elif reply == QMessageBox.Cancel:
-                    event.ignore()
-                    return
-                # If No, continue with closing without saving
-
-            # Accept the close event
-            event.accept()
-
-        except Exception as ex:
-            logger.error("Close event handler failed: {}", ex)
-            # In case of error, just accept the close event
-            event.accept()
-
     # Private methods
 
     def _remove_from_list_toolbar(self) -> None:

--- a/core/models.py
+++ b/core/models.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 @dataclass
 class PhotoRecord:
-    """A single photo row originating from CSV or other sources."""
+    """A single photo row loaded from a manifest."""
 
     group_number: int
     is_mark: bool
@@ -28,7 +28,7 @@ class PhotoRecord:
     dpi_width: int | None = None
     dpi_height: int | None = None
     orientation: int | None = None
-    # Scanner classification (populated when loaded from manifest; empty for CSV)
+    # Scanner classification (populated when loaded from manifest)
     action: str = ""
     # User's planned file operation (delete | keep | "" = undecided)
     user_decision: str = ""

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -218,7 +218,7 @@ class TestRemoveFromList:
         rec_a = _rec("/a.jpg", group=1)
         vm = MainVM(MagicMock())
         vm.groups = [PhotoGroup(group_number=1, items=[rec_a])]
-        # No manifest_path set — CSV workflow
+        # No manifest_path set — nothing to write to
         handler, _, _ = _make_handler(vm, manifest_path=None)
 
         handler.remove_items_from_list([{"type": "file", "path": "/a.jpg"}])

--- a/tests/test_scan_worker.py
+++ b/tests/test_scan_worker.py
@@ -46,7 +46,7 @@ class TestScanWorkerSkipsBadFile:
 
         monkeypatch.setattr(_hasher, "compute_hashes", fake_compute)
 
-        out = tmp_path / "manifest.csv"
+        out = tmp_path / "manifest.sqlite"
         worker = ScanWorker(
             sources={"src": str(tmp_path)},
             output_path=str(out),


### PR DESCRIPTION
## Summary

- Remove the `MainWindow.closeEvent` override — every line targeted the removed CSV API (`MainVM.get_source_csv_path`, `FileOperations.export_csv_to_path`); a bare `except` swallowed the `AttributeError`, logging ERROR on every clean exit.
- Sweep five stale CSV docstrings / comments / test filenames left over from the SQLite manifest migration.

User-visible behavior is unchanged (Qt's default close handling = the `event.accept()` the dead path always fell through to). The recurring `Close event handler failed: 'MainVM' object has no attribute 'get_source_csv_path'` log line is gone.

Closes #48.

## Test plan

- [x] `pytest -q` — full suite green (391 passed, 2 skipped)
- [x] grep confirms `get_source_csv_path` / `export_csv_to_path` / `_source_csv_path` have zero remaining references
- [ ] launch app, close window, confirm `app_<date>.log` no longer logs the AttributeError

🤖 Generated with [Claude Code](https://claude.com/claude-code)