### PR TITLE
test(walker): pin walker-exclusions fixture to expected 2-file result

### DIFF
--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -235,3 +235,32 @@ class TestFlatScan:
         labels = {r.source_label for r in records}
         assert "flat" not in labels
         assert "rec" in labels
+
+
+class TestWalkerExclusionsFixture:
+    """Pin the qa/sandbox/walker-exclusions/ fixture's expected walker output.
+
+    The fixture mixes 2 real JPEGs with the three skip patterns documented
+    on `scanner/walker.py` and `scanner/media.py`:
+
+      - real_photo_a.jpg.json   (Google Takeout sidecar — non-media extension)
+      - Thumbs.db               (Windows thumbnail cache — SKIP_FILENAMES)
+      - desktop.ini             (Windows folder config — SKIP_FILENAMES)
+
+    If any of the three skip rules regresses, the count flips from 2 to 3+
+    and this test fails immediately rather than silently letting noise
+    into hash comparisons. Companion to QA scenario s09_walker_exclusions.
+    """
+
+    def test_walker_exclusions_fixture_returns_only_real_photos(self):
+        from scanner.walker import scan_sources
+
+        fixture = Path(__file__).resolve().parent.parent / "qa" / "sandbox" / "walker-exclusions"
+        if not fixture.is_dir():
+            pytest.skip(f"fixture not present: {fixture}")
+
+        records = scan_sources({"wx": fixture}, recursive_map={"wx": True})
+        names = sorted(r.path.name for r in records)
+        assert names == ["real_photo_a.jpg", "real_photo_b.jpg"], (
+            f"walker leaked excluded files into the result set: {names}"
+        )


### PR DESCRIPTION
## Summary

Adds a regression test for the `qa/sandbox/walker-exclusions/` fixture so that any future change breaking one of the three documented skip rules (`*.json` extension filter, `Thumbs.db` / `desktop.ini` via `SKIP_FILENAMES`) fails the suite immediately instead of silently letting noise into hash comparisons.

## Context

Issue #47 reported the walker emitting `→ 3 files` for this fixture, implying one of the three skip rules was not firing. The walker today returns the correct 2 files for the committed fixture — verified with a direct `scan_sources()` call. `scanner/walker.py` and `scanner/media.py` haven't changed since long before the QA run that filed the issue, so the discrepancy isn't a regression we silently fixed; the most plausible explanation is a stray editor / OS file in the fixture directory at QA time.

This PR doesn't change walker behavior. It locks in the expected result against the committed fixture so a real regression in any of the three skip rules fails this test immediately.

Recommend closing #47 as **not reproducible against master** with a pointer to this test as the safety net.

## Test plan

- [x] `pytest -q tests/test_walker.py` — 18 passed, 2 skipped
- [x] `pytest -q` — full suite green (392 passed, 2 skipped)
- [x] Test skips gracefully when fixture is absent (verified by reading the `is_dir()` guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)