### PR TITLE
fix(scan): treat empty input as benign success, not failure

### DIFF
--- a/app/views/dialogs/scan_dialog.py
+++ b/app/views/dialogs/scan_dialog.py
@@ -542,6 +542,7 @@ class ScanDialog(QDialog):
         self._worker.progress.connect(self._log)
         self._worker.finished.connect(self._on_finished)
         self._worker.failed.connect(self._on_failed)
+        self._worker.completed_empty.connect(self._on_completed_empty)
         self._worker.start()
 
     def _log(self, msg: str) -> None:
@@ -564,6 +565,10 @@ class ScanDialog(QDialog):
         self._log(f"\nERROR: {error}")
         self._btn_scan.setEnabled(True)
         QMessageBox.critical(self, "Scan Failed", error)
+
+    def _on_completed_empty(self) -> None:
+        """Empty input is benign — re-enable Start Scan, no modal."""
+        self._btn_scan.setEnabled(True)
 
     def _load_and_close(self) -> None:
         """Call the completion callback and close the dialog."""

--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -11,14 +11,19 @@ class ScanWorker(QThread):
     """Runs scan.py pipeline in a background thread.
 
     Signals:
-        progress(str)  — one-line status update for the UI log
-        finished(str)  — emitted with manifest_path on success
-        failed(str)    — emitted with error message on failure
+        progress(str)        — one-line status update for the UI log
+        finished(str)        — emitted with manifest_path on success
+        failed(str)          — emitted with error message on real failure
+        completed_empty()    — scan ran cleanly but found 0 media files
+                               (kept distinct from `failed` so the dialog
+                               can avoid misclassifying a benign empty
+                               input as an error)
     """
 
     progress = Signal(str)
     finished = Signal(str)
     failed = Signal(str)
+    completed_empty = Signal()
 
     def __init__(
         self,
@@ -81,7 +86,11 @@ class ScanWorker(QThread):
         self._emit(f"  Total: {len(records):,} media files")
 
         if not records:
-            self.failed.emit("No media files found in the selected source folders.")
+            # Empty input is a benign success, not a failure: the user picked
+            # folders that simply have no media. Log a neutral terminator and
+            # signal the dialog to re-enable Start Scan without a red modal.
+            self._emit("Done. No media files found — nothing to scan.")
+            self.completed_empty.emit()
             return
 
         # --- 2. Hash + PIL EXIF (parallel) ---

--- a/tests/test_scan_worker.py
+++ b/tests/test_scan_worker.py
@@ -1,8 +1,13 @@
 """Tests for app/views/workers/scan_worker.py — ScanWorker pipeline behaviour.
 
-Focus: regression test for issue #46 — one bad file must never abort the whole
-scan. Verifies that a per-file ``compute_hashes`` exception is logged and
-skipped, and the pipeline still produces a manifest.
+Coverage:
+
+- issue #46 regression — one bad file must never abort the whole scan
+  (per-file ``compute_hashes`` exception is logged and skipped, manifest
+  still written).
+- issues #51 + #56 regression — an empty input folder is treated as a
+  benign success (``completed_empty`` signal, "Done." log line, no
+  ``failed`` emission, no modal).
 """
 
 from __future__ import annotations
@@ -71,3 +76,50 @@ class TestScanWorkerSkipsBadFile:
             f"skip summary missing from progress: {progress!r}"
         assert any("bad.tif" in m for m in progress), \
             f"skipped file path should appear in progress: {progress!r}"
+
+
+class TestScanWorkerEmptyInput:
+    def test_empty_folder_signals_completed_empty_not_failed(self, qapp, tmp_path):
+        """An empty source folder is a benign success, not a failure.
+
+        Regression for issues #51 (red 'Scan Failed' modal misclassified the
+        case) and #56 (QA driver polling for 'Done.' / 'Error' / 'Failed'
+        timed out because the log only contained 'ERROR:' from the failure
+        path).
+
+        Expectations:
+          - ``completed_empty`` fires exactly once.
+          - ``failed`` does NOT fire.
+          - ``finished`` does NOT fire (no manifest written).
+          - The progress log contains a 'Done.' terminator so the QA
+            driver's case-sensitive match succeeds.
+        """
+        from app.views.workers.scan_worker import ScanWorker
+
+        empty_dir = tmp_path / "empty"
+        empty_dir.mkdir()
+
+        worker = ScanWorker(
+            sources={"src": str(empty_dir)},
+            output_path=str(tmp_path / "manifest.sqlite"),
+            recursive_map={"src": False},
+            workers=2,
+        )
+
+        progress: list[str] = []
+        finished: list[str] = []
+        failed: list[str] = []
+        completed_empty_calls: list[None] = []
+        worker.progress.connect(progress.append)
+        worker.finished.connect(finished.append)
+        worker.failed.connect(failed.append)
+        worker.completed_empty.connect(lambda: completed_empty_calls.append(None))
+
+        worker.run()
+
+        assert not failed, f"Empty input must not emit `failed`; got: {failed}"
+        assert not finished, f"Empty input must not emit `finished`; got: {finished}"
+        assert len(completed_empty_calls) == 1, \
+            f"`completed_empty` should fire exactly once; got {len(completed_empty_calls)}"
+        assert any("Done." in m for m in progress), \
+            f"progress log must contain a 'Done.' terminator: {progress!r}"


### PR DESCRIPTION
## Summary

Empty source folders used to surface as a red **Scan Failed** modal — a benign case rendered as a real error. This broke two things at once:

1. **#51** — the modal misclassified "no files found" as failure, with a stressful red ❌.
2. **#56** — the QA driver polls the scan log for `[\"Done.\", \"Error\", \"Failed\"]` (case-sensitive). The failure path only ever wrote `ERROR:`, which doesn't match `Error`, so the driver timed out after 20 s.

Fix is a small split in worker semantics: real failures still fire `failed`; an empty result now fires a new `completed_empty()` signal. The dialog re-enables Start Scan without a modal, and the worker logs a neutral `Done. No media files found — nothing to scan.` so the QA driver matches its `Done.` needle on the same code path.

Closes #51, closes #56.

## Changes

- `app/views/workers/scan_worker.py` — add `completed_empty` signal; replace the `failed.emit(...)` branch in the empty-records case with a `Done.` log line + `completed_empty.emit()`.
- `app/views/dialogs/scan_dialog.py` — connect `completed_empty` to a new `_on_completed_empty` slot that re-enables Start Scan; no modal, no log error.
- `tests/test_scan_worker.py` — new `TestScanWorkerEmptyInput::test_empty_folder_signals_completed_empty_not_failed` pins the contract: `completed_empty` fires once, `failed`/`finished` do not, and the log contains `Done.`

## Test plan

- [x] `pytest -q tests/test_scan_worker.py` — 2 passed
- [x] `pytest -q tests/test_scan_dialog.py` — 34 passed (signal connection didn't break existing wiring)
- [x] `pytest -q` — full suite green (393 passed, 2 skipped)
- [ ] Manual: launch app, scan `qa/sandbox/empty/`, confirm log shows `Done. No media files found — nothing to scan.` with no modal and Start Scan re-enabled
- [ ] Manual: re-run QA scenario s02; expect no 20 s timeout

🤖 Generated with [Claude Code](https://claude.com/claude-code)