### PR TITLE
fix(scan): surface corrupt image files instead of silent UNDATED

### DIFF
--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -139,6 +139,23 @@ class ScanWorker(QThread):
         # Remove any None slots (cancelled futures that didn't run, or skipped files)
         hash_results = [r for r in hash_results if r is not None]
 
+        # Detect silent image-decode failures: compute_hashes returned without
+        # raising but PIL couldn't produce a pHash — the file is truncated or
+        # corrupt. Route to the same skip channel as exception failures so the
+        # user sees them in the log instead of getting a misleading UNDATED row.
+        _IMAGE_TYPES = frozenset(("jpeg", "heic", "raw", "png", "gif", "webp"))
+        corrupt_paths: set[Path] = set()
+        for r in hash_results:
+            if r.record.file_type in _IMAGE_TYPES and r.phash is None:
+                skipped.append((
+                    r.record.path,
+                    "ImageDecodeError",
+                    "image file could not be decoded (truncated or corrupt)",
+                ))
+                corrupt_paths.add(r.record.path)
+        if corrupt_paths:
+            hash_results = [r for r in hash_results if r.record.path not in corrupt_paths]
+
         if skipped:
             self._emit(f"  Skipped {len(skipped):,} unreadable file(s):")
             for p, exc_type, exc_msg in skipped[:10]:

--- a/tests/test_scan_worker.py
+++ b/tests/test_scan_worker.py
@@ -8,6 +8,9 @@ Coverage:
 - issues #51 + #56 regression — an empty input folder is treated as a
   benign success (``completed_empty`` signal, "Done." log line, no
   ``failed`` emission, no modal).
+- issue #57 regression — silent image-decode failures (truncated /
+  corrupt JPEGs that compute_hashes returns from without raising) are
+  routed to the skip channel instead of being misclassified as UNDATED.
 """
 
 from __future__ import annotations
@@ -123,3 +126,66 @@ class TestScanWorkerEmptyInput:
             f"`completed_empty` should fire exactly once; got {len(completed_empty_calls)}"
         assert any("Done." in m for m in progress), \
             f"progress log must contain a 'Done.' terminator: {progress!r}"
+
+
+class TestScanWorkerCorruptImage:
+    def test_truncated_jpeg_is_logged_and_excluded_from_manifest(
+        self, qapp, tmp_path
+    ):
+        """A truncated JPEG should be logged as ImageDecodeError, not silently UNDATED.
+
+        Regression for issue #57: ``compute_hashes`` returns successfully for a
+        truncated JPEG (sha256 from raw bytes works) but PIL can't extract a
+        pHash. Pre-fix, the file landed in the manifest with action=UNDATED,
+        visually indistinguishable from a JPG that simply has no EXIF date.
+        """
+        import sqlite3
+
+        from app.views.workers.scan_worker import ScanWorker
+
+        # Two files: one valid JPEG, one truncated JPEG (1 KB cut).
+        good = tmp_path / "good.jpg"
+        bad = tmp_path / "bad_truncated.jpg"
+        _write_jpeg(good, color=(0, 128, 255))
+
+        # Build a real JPEG, then truncate it so PIL.Image.load() fails.
+        full = tmp_path / "_full.jpg"
+        Image.new("RGB", (200, 150), (200, 100, 50)).save(full, "JPEG")
+        bad.write_bytes(full.read_bytes()[:1024])
+        full.unlink()
+
+        out = tmp_path / "manifest.sqlite"
+        worker = ScanWorker(
+            sources={"src": str(tmp_path)},
+            output_path=str(out),
+            recursive_map={"src": False},
+            workers=2,
+        )
+
+        progress: list[str] = []
+        finished: list[str] = []
+        failed: list[str] = []
+        worker.progress.connect(progress.append)
+        worker.finished.connect(finished.append)
+        worker.failed.connect(failed.append)
+
+        worker.run()
+
+        assert not failed, f"Scan must not have failed; got: {failed}"
+        assert finished == [str(out)], f"finished signal wrong: {finished}"
+
+        # Log surfaces the corrupt file with the synthetic exception type.
+        assert any("ImageDecodeError" in m for m in progress), \
+            f"progress should flag corrupt file as ImageDecodeError: {progress!r}"
+        assert any("bad_truncated.jpg" in m for m in progress), \
+            f"corrupt file path should appear in progress: {progress!r}"
+
+        # Manifest contains the good file, NOT the corrupt one. Query SQLite
+        # directly because ManifestRepository.load() filters to grouped rows.
+        with sqlite3.connect(out) as conn:
+            paths = [Path(p).name for (p,) in conn.execute(
+                "SELECT source_path FROM migration_manifest"
+            )]
+        assert "good.jpg" in paths, f"good file missing from manifest: {paths}"
+        assert "bad_truncated.jpg" not in paths, \
+            f"corrupt file should be excluded from manifest, but found in: {paths}"


### PR DESCRIPTION
## Summary

Truncated / corrupt image files used to silently land in the manifest as UNDATED rows: `compute_hashes` returned without raising (the SHA-256 streams from raw bytes regardless), but PIL couldn't extract a pHash. The user had no way to tell whether they were looking at a corrupt JPEG or one that just lacks EXIF `DateTimeOriginal` — both showed up identically as UNDATED.

This routes those silent decode failures to the same skip channel as exception failures (#46/#53). Detection lives in `ScanWorker._run_pipeline` after the hashing pass: any non-video `file_type` with `phash is None` gets appended to `skipped` with a synthetic `ImageDecodeError` tag, and is excluded from the manifest. The existing \"Skipped N unreadable file(s)\" log block now surfaces both kinds of failures with their paths.

Closes #57.

## Changes

- `app/views/workers/scan_worker.py` — after the None-slot filter, scan `hash_results` for image-type entries with `phash is None`, append to `skipped`, and exclude from `hash_results` before classify.
- `tests/test_scan_worker.py` — `TestScanWorkerCorruptImage::test_truncated_jpeg_is_logged_and_excluded_from_manifest` writes a real JPEG, truncates it to 1 KB, runs the scan worker, and asserts (a) the log contains `ImageDecodeError`, (b) the corrupt file's path appears in progress, (c) the manifest contains the good file but not the corrupt one.

## Test plan

- [x] `pytest -q tests/test_scan_worker.py` — 3 passed
- [x] `pytest -q` — full suite green (394 passed, 2 skipped)
- [ ] Manual: launch app, scan `qa/sandbox/corrupted/`, confirm log shows `ImageDecodeError: image file could not be decoded (truncated or corrupt)` and the manifest summary's UNDATED count no longer includes the corrupt file
- [ ] Manual: re-run QA scenario s04 (corrupted-file handling)

🤖 Generated with [Claude Code](https://claude.com/claude-code)