### PR TITLE
fix(scan): forward scan progress and errors to loguru

### DIFF
--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from PySide6.QtCore import QThread, Signal
+from loguru import logger
 
 
 class ScanWorker(QThread):
@@ -50,9 +51,16 @@ class ScanWorker(QThread):
         try:
             self._run_pipeline()
         except Exception as exc:  # pylint: disable=broad-exception-caught
+            # Log with traceback so the rotating app_<date>.log captures the
+            # full forensic context — the dialog log box clears on close.
+            logger.exception("Scan pipeline failed: {}", exc)
             self.failed.emit(str(exc))
 
     def _emit(self, msg: str) -> None:
+        # Forward every progress line to loguru so the rotating app_<date>.log
+        # has a persistent record for users reporting "the scan stopped" —
+        # the dialog log box is transient and disappears on close.
+        logger.info("scan: {}", msg)
         self.progress.emit(msg)
 
     def _run_pipeline(self) -> None:
@@ -127,6 +135,7 @@ class ScanWorker(QThread):
                 if self.isInterruptionRequested():
                     cancel_flag.set()
                     pool.shutdown(wait=False, cancel_futures=True)
+                    logger.warning("Scan cancelled by user during hashing pass")
                     self.failed.emit("Scan cancelled.")
                     return
                 idx, result = future.result()

--- a/tests/test_scan_worker.py
+++ b/tests/test_scan_worker.py
@@ -11,6 +11,9 @@ Coverage:
 - issue #57 regression — silent image-decode failures (truncated /
   corrupt JPEGs that compute_hashes returns from without raising) are
   routed to the skip channel instead of being misclassified as UNDATED.
+- issue #49 regression — scan progress and errors are forwarded to
+  loguru so the rotating ``app_<date>.log`` captures forensic context
+  (the dialog log box is transient and disappears on close).
 """
 
 from __future__ import annotations
@@ -189,3 +192,55 @@ class TestScanWorkerCorruptImage:
         assert "good.jpg" in paths, f"good file missing from manifest: {paths}"
         assert "bad_truncated.jpg" not in paths, \
             f"corrupt file should be excluded from manifest, but found in: {paths}"
+
+
+class TestScanWorkerLogging:
+    def test_scan_progress_and_errors_forwarded_to_loguru(
+        self, qapp, tmp_path
+    ):
+        """Progress lines and per-file skip records flow through loguru.
+
+        Regression for issue #49: scan errors used to live only in the
+        dialog's transient log box, so "the scan stopped" reports had no
+        artifact to attach. After the fix, every progress emission lands
+        in the rotating ``app_<date>.log`` (via loguru) — and a corrupt
+        file (#57) shows up there with its path and synthetic exception
+        type for forensics.
+        """
+        from loguru import logger
+
+        from app.views.workers.scan_worker import ScanWorker
+
+        # Same fixture shape as the corrupt-image test — one valid JPEG
+        # plus one truncated JPEG so we exercise both progress lines and
+        # per-file skip-record forwarding.
+        good = tmp_path / "good.jpg"
+        bad = tmp_path / "bad_truncated.jpg"
+        _write_jpeg(good, color=(0, 128, 255))
+        full = tmp_path / "_full.jpg"
+        Image.new("RGB", (200, 150), (200, 100, 50)).save(full, "JPEG")
+        bad.write_bytes(full.read_bytes()[:1024])
+        full.unlink()
+
+        captured: list[str] = []
+        sink_id = logger.add(lambda msg: captured.append(str(msg)), level="INFO")
+        try:
+            worker = ScanWorker(
+                sources={"src": str(tmp_path)},
+                output_path=str(tmp_path / "manifest.sqlite"),
+                recursive_map={"src": False},
+                workers=2,
+            )
+            worker.run()
+        finally:
+            logger.remove(sink_id)
+
+        joined = "\n".join(captured)
+        assert "scan: " in joined, \
+            f"scan progress should be tagged with 'scan: ' prefix in loguru: {joined!r}"
+        assert "Done." in joined, \
+            f"final 'Done.' terminator should land in loguru: {joined!r}"
+        assert "bad_truncated.jpg" in joined, \
+            f"corrupt file path should land in loguru for forensics: {joined!r}"
+        assert "ImageDecodeError" in joined, \
+            f"synthetic exception type should land in loguru: {joined!r}"


### PR DESCRIPTION
## Summary

Scan errors used to live only in the dialog's transient log box. When the user dismissed the modal or closed the app, the only forensic trace disappeared — \"the scan stopped\" reports had no artifact to attach.

Now every scan-progress emission also flows through loguru, so the rotating \`%LOCALAPPDATA%\PhotoManager\logs\app_<date>.log\` captures the same context the dialog shows: walked source paths, file counts, hashing progress, per-file skip records (path + synthetic exception type), the exiftool warning, and the final \`Done.\` / failure terminator.

Closes #49.

## Changes

- \`app/views/workers/scan_worker.py\`
  - \`_emit\` now calls \`logger.info(\"scan: {}\", msg)\` before emitting the Qt signal — every progress line is persisted automatically, including the per-file skip detail that \`_emit\`-routes through the existing skip block.
  - \`run()\` exception handler logs with \`logger.exception(...)\` so the full traceback lands in the file alongside the \`failed\` signal.
  - Cancellation path logs at \`WARNING\` before emitting \`failed.emit(\"Scan cancelled.\")\`.
- \`tests/test_scan_worker.py\` — new \`TestScanWorkerLogging::test_scan_progress_and_errors_forwarded_to_loguru\`. Adds an in-memory loguru sink, runs a scan with one good and one truncated JPEG, and asserts the captured log contains the \`scan: \` prefix, the \`Done.\` terminator, the corrupt file's path, and the \`ImageDecodeError\` tag.

## Test plan

- [x] \`pytest -q tests/test_scan_worker.py\` — 4 passed
- [x] \`pytest -q\` — full suite green (395 passed, 2 skipped)
- [ ] Manual: launch app, run a scan that hits a corrupt file, close the app, open \`app_<date>.log\` and confirm the scan: lines and the \`ImageDecodeError\` record are present
- [ ] Manual: cancel a long-running scan; confirm \`Scan cancelled by user during hashing pass\` appears in the log

🤖 Generated with [Claude Code](https://claude.com/claude-code)