### PR TITLE
fix(ux): four small dialog and main-window UX fixes

### DIFF
--- a/app/views/components/menu_controller.py
+++ b/app/views/components/menu_controller.py
@@ -39,6 +39,10 @@ class MenuController:
         # List Menu
         list_menu = menubar.addMenu("List")
         self.actions["remove_from_list"] = list_menu.addAction("Remove from List")
+        # Disabled until a manifest loads — gives the user a visible-but-greyed
+        # entry instead of a menu that appears empty / no-op before any data is
+        # present. Re-enabled in MainWindow._load_manifest_from_path.
+        self.actions["remove_from_list"].setEnabled(False)
 
         # Log Menu
         log_menu = menubar.addMenu("Log")

--- a/app/views/dialogs/scan_dialog.py
+++ b/app/views/dialogs/scan_dialog.py
@@ -66,8 +66,10 @@ def _auto_label(name: str, existing: set[str]) -> str:
 class _FolderTreePanel(QWidget):
     """Embedded filesystem tree for browsing and selecting source folders.
 
-    Emits ``folder_requested(path)`` when the user double-clicks a folder
-    or presses the "Add Selected Folder" button.
+    Emits ``folder_requested(path)`` when the user adds a folder via:
+      - double-click in the tree
+      - "Add Selected Folder" button
+      - typing/pasting a path into the path field and pressing Enter / "+ Add"
     """
 
     folder_requested = Signal(str)
@@ -76,12 +78,27 @@ class _FolderTreePanel(QWidget):
         super().__init__(parent)
         self._model: QFileSystemModel
         self._tree: QTreeView
+        self._path_field: QLineEdit
         self._build_ui()
 
     def _build_ui(self) -> None:
-        """Construct the directory tree view and add button."""
+        """Construct the directory tree view, path entry, and add button."""
         layout = QVBoxLayout(self)
         layout.setContentsMargins(0, 0, 0, 0)
+
+        # Path entry — lets the user paste / type an absolute path instead of
+        # scrolling the tree 10+ levels deep to a known fixture.
+        path_row = QHBoxLayout()
+        path_row.addWidget(QLabel("Path:"))
+        self._path_field = QLineEdit()
+        self._path_field.setPlaceholderText("Paste or type an absolute folder path…")
+        self._path_field.returnPressed.connect(self._on_add_typed)
+        path_add_btn = QPushButton("+ Add")
+        path_add_btn.setFixedWidth(80)
+        path_add_btn.clicked.connect(self._on_add_typed)
+        path_row.addWidget(self._path_field, stretch=1)
+        path_row.addWidget(path_add_btn)
+        layout.addLayout(path_row)
 
         self._model = QFileSystemModel(self)
         self._model.setFilter(QDir.AllDirs | QDir.NoDotAndDotDot)
@@ -114,6 +131,20 @@ class _FolderTreePanel(QWidget):
         if index.isValid():
             path = self._model.filePath(index)
             self.folder_requested.emit(path)
+
+    def _on_add_typed(self) -> None:
+        """Emit ``folder_requested`` for the path typed/pasted into the field.
+
+        Silently no-ops on empty input or non-existent directories so the
+        dialog doesn't bark at the user mid-typing.
+        """
+        raw = self._path_field.text().strip().strip('"')
+        if not raw:
+            return
+        if not Path(raw).is_dir():
+            return
+        self.folder_requested.emit(raw)
+        self._path_field.clear()
 
     def _on_double_click(self, index: QModelIndex) -> None:
         """Emit ``folder_requested`` on double-click."""
@@ -163,6 +194,10 @@ class _SourceListWidget(QWidget):
         self._table.setEditTriggers(QTableWidget.EditTrigger.NoEditTriggers)
         self._table.setSelectionBehavior(QTableWidget.SelectionBehavior.SelectRows)
         self._table.setAlternatingRowColors(True)
+        # Reserve enough vertical room for ~6 rows so the list isn't a 2-row
+        # sliver when many sources are configured. The QSplitter parent still
+        # lets the user grow / shrink it.
+        self._table.setMinimumHeight(180)
         layout.addWidget(self._table)
 
     # ------------------------------------------------------------------ public API
@@ -333,7 +368,9 @@ class ScanDialog(QDialog):
 
         self._source_list = _SourceListWidget(self)
         splitter.addWidget(self._source_list)
-        splitter.setSizes([320, 160])
+        # Give the source list more initial room so a multi-source config
+        # isn't squashed into a 2-row sliver. User can still drag.
+        splitter.setSizes([280, 240])
         root.addWidget(splitter, stretch=1)
 
         output_row = QHBoxLayout()

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -239,22 +239,40 @@ class MainWindow(QMainWindow):
 
     def _load_manifest_from_path(self, manifest_path: str) -> None:
         """Load a manifest directly (called after scan completes or from Open Manifest)."""
+        import sqlite3
+
         from infrastructure.manifest_repository import ManifestRepository
         try:
             self._vm.load_from_repo(ManifestRepository(), manifest_path)
             self.file_operations._manifest_path = manifest_path
             self.show_groups_summary(self._vm.groups)
             self.refresh_tree(self._vm.groups)
-            try:
-                self.menu_controller.enable_action("save_manifest", True)
-            except AttributeError:
-                pass
+            for action in ("save_manifest", "execute_action", "remove_from_list"):
+                try:
+                    self.menu_controller.enable_action(action, True)
+                except AttributeError:
+                    pass
             n = self._vm.group_count
+            # Surface isolated files in the status bar so users whose scan
+            # produced zero near-duplicate groups don't see an empty review
+            # pane with no explanation. Isolated = total manifest rows
+            # minus rows that ended up in any group.
+            isolated = 0
             try:
-                self.menu_controller.enable_action("execute_action", True)
-            except AttributeError:
+                with sqlite3.connect(manifest_path) as conn:
+                    total = conn.execute(
+                        "SELECT COUNT(*) FROM migration_manifest"
+                    ).fetchone()[0] or 0
+                grouped = sum(len(g.items) for g in self._vm.groups)
+                isolated = max(0, total - grouped)
+            except (sqlite3.Error, OSError):
                 pass
-            self.statusBar().showMessage(f"Loaded manifest: {n} group(s)", 5000)
+            parts = [f"{n} group(s)"]
+            if isolated:
+                parts.append(f"{isolated:,} isolated file(s)")
+            self.statusBar().showMessage(
+                f"Loaded manifest: {', '.join(parts)}", 10000
+            )
         except Exception as exc:
             QMessageBox.critical(self, "Load Manifest Error", str(exc))
 

--- a/tests/test_scan_dialog.py
+++ b/tests/test_scan_dialog.py
@@ -369,3 +369,75 @@ class TestBuildSources:
         assert len(sources) == 2
         assert "Photos" in sources
         assert "Photos_2" in sources
+
+
+# ---------------------------------------------------------------------------
+# Layout / picker UX (#50 + #40)
+# ---------------------------------------------------------------------------
+
+
+class TestSourceListLayout:
+    def test_source_list_has_minimum_height(self, qapp):
+        """#50 — source list table must reserve room for ~6 rows minimum."""
+        widget = _SourceListWidget()
+        assert widget._table.minimumHeight() >= 180
+
+
+class TestPathFieldEntry:
+    """#40 — typing/pasting an absolute path should add it to the source list."""
+
+    def test_empty_path_is_silently_ignored(self, qapp):
+        from app.views.dialogs.scan_dialog import _FolderTreePanel
+
+        panel = _FolderTreePanel()
+        emitted: list[str] = []
+        panel.folder_requested.connect(emitted.append)
+
+        panel._path_field.setText("")
+        panel._on_add_typed()
+        panel._path_field.setText("   ")
+        panel._on_add_typed()
+        assert emitted == []
+
+    def test_nonexistent_path_is_silently_ignored(self, qapp, tmp_path):
+        from app.views.dialogs.scan_dialog import _FolderTreePanel
+
+        panel = _FolderTreePanel()
+        emitted: list[str] = []
+        panel.folder_requested.connect(emitted.append)
+
+        panel._path_field.setText(str(tmp_path / "definitely_does_not_exist"))
+        panel._on_add_typed()
+        assert emitted == []
+
+    def test_valid_path_emits_folder_requested_and_clears_field(self, qapp, tmp_path):
+        from app.views.dialogs.scan_dialog import _FolderTreePanel
+
+        real_dir = tmp_path / "real"
+        real_dir.mkdir()
+
+        panel = _FolderTreePanel()
+        emitted: list[str] = []
+        panel.folder_requested.connect(emitted.append)
+
+        panel._path_field.setText(str(real_dir))
+        panel._on_add_typed()
+
+        assert emitted == [str(real_dir)]
+        assert panel._path_field.text() == ""
+
+    def test_quoted_path_is_stripped(self, qapp, tmp_path):
+        """Windows users often paste paths from Explorer with surrounding quotes."""
+        from app.views.dialogs.scan_dialog import _FolderTreePanel
+
+        real_dir = tmp_path / "with spaces"
+        real_dir.mkdir()
+
+        panel = _FolderTreePanel()
+        emitted: list[str] = []
+        panel.folder_requested.connect(emitted.append)
+
+        panel._path_field.setText(f'"{real_dir}"')
+        panel._on_add_typed()
+
+        assert emitted == [str(real_dir)]


### PR DESCRIPTION
## Summary

Bundles four P2 UI/UX issues from the May 2026 QA pass — each is a few lines, all touch only the main window or scan dialog. Per the triage plan these were tagged \"can be split or bundled\"; bundling keeps them as one review pass since they're all related polish.

## Changes

### #58 — Status bar reports isolated files alongside group count
A scan that produced zero near-duplicate groups left the user staring at an empty review pane with no explanation. The status bar load message now reads e.g. \`Loaded manifest: 0 group(s), 16 isolated file(s)\` so the user knows the manifest isn't broken — there's just nothing to triage. Counted via SQLite (\`total - grouped\`). Status timeout bumped 5 s → 10 s for readability. Also wired \`remove_from_list\` into the same enable-on-load loop as the existing \`save_manifest\` / \`execute_action\` actions.

### #52 — \"Remove from List\" disabled until a manifest loads
Mirrors the existing pattern for \`save_manifest\` / \`execute_action\`. The user now sees a visible-but-greyed entry when the menu is opened pre-manifest, instead of an apparent no-op.

### #50 — Source-folders list pane has a real minimum height
\`QTableWidget.setMinimumHeight(180)\` (~6 rows) plus initial splitter sizes \`[280, 240]\` (was \`[320, 160]\`) so a multi-source config isn't squashed into a 2-row sliver. User can still drag.

### #40 — Path-entry row in the source picker
A \`QLineEdit\` + \`+ Add\` button above the tree lets users paste / type an absolute folder path and hit Enter or click Add. Empty / non-existent paths are silently ignored so the dialog doesn't bark mid-typing. Surrounding quotes (from Explorer \"Copy as path\") are stripped so paste-and-go works.

## Files

- \`app/views/components/menu_controller.py\` — disable \`remove_from_list\` at setup
- \`app/views/main_window.py\` — isolated-files SQLite count + 10 s status; enable \`remove_from_list\` on load
- \`app/views/dialogs/scan_dialog.py\` — \`_FolderTreePanel\` path entry + \`_SourceListWidget\` min height + splitter sizing
- \`tests/test_scan_dialog.py\` — \`TestSourceListLayout\` + \`TestPathFieldEntry\` (5 new test methods)

## Test plan

- [x] \`pytest -q tests/test_scan_dialog.py\` — 39 passed
- [x] \`pytest -q\` — full suite green (400 passed, 2 skipped)
- [ ] Manual: launch app, open \"List\" menu pre-manifest, confirm \"Remove from List\" is greyed out
- [ ] Manual: scan a folder with no near-duplicates, confirm status bar shows isolated count
- [ ] Manual: open Scan Sources, paste a path into the new field, hit Enter, confirm it lands in the source table
- [ ] Manual: configure 6+ sources and confirm the list pane shows them all without scrolling

🤖 Generated with [Claude Code](https://claude.com/claude-code)