### PR TITLE
fix(ux): polish batch — title, button label, group order, first-run hint

### DIFF
--- a/app/views/dialogs/scan_dialog.py
+++ b/app/views/dialogs/scan_dialog.py
@@ -593,7 +593,10 @@ class ScanDialog(QDialog):
         """Handle scan completion: switch Close button to Close & Load."""
         self.manifest_path = manifest_path
         self._btn_scan.setEnabled(True)
-        self._btn_close.setText("Close & Load")
+        # `&&` escapes the ampersand so Qt doesn't interpret it as a mnemonic
+        # prefix and silently drop it on display (which produced the "Close
+        # double-space Load" bug — #54).
+        self._btn_close.setText("Close && Load")
         self._btn_close.clicked.disconnect()
         self._btn_close.clicked.connect(self._load_and_close)
 

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 from pathlib import Path
 from typing import Any
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
+    QLabel,
     QMainWindow,
     QMessageBox,
     QTreeView,
@@ -130,14 +131,26 @@ class MainWindow(QMainWindow):
 
     def _setup_ui(self) -> None:
         """Setup the main UI components and layout."""
-        self.setWindowTitle("Photo Manager - M1")
+        self.setWindowTitle("Photo Manager")
 
         # Setup tree properties
         self.tree_controller.setup_tree_properties()
 
         # Create layout sections
         center_widget, center_layout = self.layout_manager.create_tree_section()
+        # First-run hint — visible until the first manifest loads. Once a
+        # manifest is loaded (even if it produces zero groups), the user has
+        # discovered the menu and the label is hidden permanently (#42).
+        self._empty_state_label = QLabel(
+            "No manifest loaded.\n\nFile → Scan Sources… to begin."
+        )
+        self._empty_state_label.setAlignment(Qt.AlignmentFlag.AlignCenter)
+        self._empty_state_label.setStyleSheet(
+            "color: #888; font-size: 14px; padding: 40px;"
+        )
+        center_layout.addWidget(self._empty_state_label)
         center_layout.addWidget(self.tree)
+        self.tree.setVisible(False)
 
         right_widget, right_layout = self.layout_manager.create_preview_section()
 
@@ -199,6 +212,13 @@ class MainWindow(QMainWindow):
         Args:
             groups: List of group objects to display
         """
+        # First manifest load — hide the first-run hint and reveal the tree.
+        # Stays hidden afterwards even if a later load produces zero groups,
+        # because the user has clearly already discovered the entry point.
+        if self._empty_state_label.isVisible():
+            self._empty_state_label.setVisible(False)
+            self.tree.setVisible(True)
+
         self.tree_controller.refresh_model(groups)
 
         # Reconnect selection handler after model reset

--- a/app/views/tree_model_builder.py
+++ b/app/views/tree_model_builder.py
@@ -21,11 +21,13 @@ from app.views.constants import (
     SORT_ROLE,
 )
 
-# Numeric sort priorities — lower value = sorted first (ascending)
+# Numeric sort priorities — lower value = sorted first (ascending).
+# KEEP (the reference / primary file) sits at the top of its group so users
+# scanning top-down see the "winner" first (#55).
 _ACTION_SORT: dict[str, int] = {
-    "REVIEW_DUPLICATE": 1,
-    "EXACT": 2,
-    "KEEP": 3,
+    "KEEP": 1,
+    "REVIEW_DUPLICATE": 2,
+    "EXACT": 3,
     "UNDATED": 4,
     "MOVE": 5,
 }  # missing / "" → 6

--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -55,9 +55,9 @@ WHERE  executed = 0
 ORDER  BY
     group_id NULLS LAST,
     CASE action
-        WHEN 'REVIEW_DUPLICATE' THEN 1
-        WHEN 'EXACT'            THEN 2
-        WHEN 'KEEP'             THEN 3
+        WHEN 'KEEP'             THEN 1
+        WHEN 'REVIEW_DUPLICATE' THEN 2
+        WHEN 'EXACT'            THEN 3
         WHEN 'UNDATED'          THEN 4
         WHEN 'MOVE'             THEN 5
         ELSE 6
@@ -186,7 +186,9 @@ class ManifestRepository:
         e.g. MOVE / UNDATED with no near-duplicate) are not yielded — the UI
         focuses on files that need review.
 
-        Ordering within a group: REVIEW_DUPLICATE → EXACT → KEEP → UNDATED → MOVE.
+        Ordering within a group: KEEP → REVIEW_DUPLICATE → EXACT → UNDATED → MOVE.
+        Reference / primary file (KEEP) sits at the top so users scanning a
+        group top-down see the "winner" first (#55).
         """
         from collections import defaultdict
 

--- a/qa/scenarios/s02_empty_folder.py
+++ b/qa/scenarios/s02_empty_folder.py
@@ -33,7 +33,7 @@ def main() -> int:
     wins = [t for _, _, t in _uia.list_process_windows(pid)]
     print(f"  open_windows={wins!r}")
     # Did anything pop up? (empty-state dialog, message, etc.)
-    extra = [t for t in wins if t not in ("Photo Manager - M1", "Scan Sources")]
+    extra = [t for t in wins if t not in ("Photo Manager", "Scan Sources")]
     print(f"  extra_dialogs={extra!r}")
 
     print("step: close_dialog")

--- a/tests/test_manifest_repository.py
+++ b/tests/test_manifest_repository.py
@@ -1002,3 +1002,29 @@ class TestRemoveFromReviewNoVacuum:
             assert "VACUUM" not in sql.upper(), (
                 f"remove_from_review() still executes VACUUM via: {sql!r}"
             )
+
+
+class TestInGroupRowOrdering:
+    """#55 — KEEP (the reference/primary file) sits at the top of its group."""
+
+    def test_keep_appears_before_review_duplicate_and_exact(self, tmp_path):
+        ref = tmp_path / "ref" / "ref.jpg"
+        review = tmp_path / "review" / "near.jpg"
+        exact = tmp_path / "exact" / "dup.jpg"
+        for p in (ref, review, exact):
+            _make_jpeg(p)
+        gid = "/group/order-test"
+        db = _make_manifest(tmp_path, [
+            # Insert in non-priority order; SQL ordering should still put KEEP first.
+            _row({"source_path": str(review), "action": "REVIEW_DUPLICATE", "group_id": gid}),
+            _row({"source_path": str(exact), "action": "EXACT", "group_id": gid,
+                  "hamming_distance": None}),
+            _row({"source_path": str(ref), "action": "KEEP", "group_id": gid,
+                  "hamming_distance": None}),
+        ])
+        records = list(ManifestRepository().load(str(db)))
+        actions = [r.action for r in records]
+        # KEEP must be first; the rest follow per the documented order.
+        assert actions[0] == "KEEP", \
+            f"reference file should be at top of group; got order {actions}"
+        assert actions == ["KEEP", "REVIEW_DUPLICATE", "EXACT"]


### PR DESCRIPTION
## Summary

Bundles the four P3 copy / layout polish issues from the May 2026 QA pass. Each is a few lines, behavior is correct in every case — only wording or ordering changes.

## Changes

### #54 — \"Close && Load\" button label
The Qt label was \`\"Close & Load\"\` but the bare \`&\` acts as a mnemonic prefix, so Qt strips it on display and leaves the double-space artifact (\"Close  Load\") that the QA report flagged. Escaped to \`\"Close && Load\"\` so it renders as \"Close & Load\" with no mnemonic.

### #41 — Drop M1 suffix from window title
\`Photo Manager - M1\` → \`Photo Manager\`. QA scenario \`s02_empty_folder.py\`'s window-list filter is updated in the same commit so it still finds the main window.

### #55 — KEEP at top of group
Within-group row order used to put REVIEW_DUPLICATE → EXACT → KEEP, so the reference / primary file ended up below the rows the user was triaging. KEEP now sits at the top so a top-down scan sees the \"winner\" first. Updated in lockstep:
- SQL \`ORDER BY CASE action\` in [\`infrastructure/manifest_repository.py\`](infrastructure/manifest_repository.py) (initial load)
- \`_ACTION_SORT\` dict in [\`app/views/tree_model_builder.py\`](app/views/tree_model_builder.py) (proxy model sort)

### #42 — Centered first-run hint
A \`QLabel\` reading \"No manifest loaded.\n\nFile → Scan Sources… to begin.\" sits centered in the tree section until any manifest loads. Once a manifest has loaded — even one with zero groups — the hint hides permanently, because the user has clearly already discovered the entry point.

## Test plan

- [x] \`pytest -q tests/test_manifest_repository.py\` — 50 passed (includes new \`TestInGroupRowOrdering\` regression test)
- [x] \`pytest -q\` — full suite green (401 passed, 2 skipped)
- [ ] Manual: launch app, confirm window title reads \"Photo Manager\" and the centered \"No manifest loaded\" hint shows
- [ ] Manual: scan and let finish, confirm button reads \"Close & Load\" with single space
- [ ] Manual: open a manifest with a near-duplicate group, confirm the KEEP row is at the top of the group

🤖 Generated with [Claude Code](https://claude.com/claude-code)