### PR TITLE
fix(qa): align driver button title with post-#54 "Close & Load"

### DIFF
--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -52,7 +52,7 @@ ACTION_EXECUTE = "Execute Action…"
 # Scan dialog
 SCAN_DIALOG_TITLE = "Scan Sources"
 SCAN_BTN_START = "Start Scan"
-SCAN_BTN_CLOSE_LOAD = "Close  Load"   # NB: literal double-space, see finding #1
+SCAN_BTN_CLOSE_LOAD = "Close & Load"   # exact UIA accessible name; mirrors scan_dialog.setText("Close && Load")
 SCAN_BTN_BROWSE = "Browse…"
 SCAN_BTN_REMOVE_ALL = "Remove All"
 SCAN_BTN_ADD_SELECTED = "+ Add Selected Folder"
@@ -277,7 +277,7 @@ def extract_summary(log: str) -> list[str]:
 
 
 def close_and_load_manifest(dlg: UIAWrapper) -> None:
-    """Click 'Close  Load' (post-scan dialog button)."""
+    """Click 'Close & Load' (post-scan dialog button)."""
     btn = dlg.child_window(title=SCAN_BTN_CLOSE_LOAD, control_type="Button")
     btn.invoke()
     time.sleep(1.0)


### PR DESCRIPTION
## Summary

PR #66 shipped issue #54's fix by changing the Scan dialog's post-scan button text from the buggy `Close  Load` (literal double-space) to a properly-escaped `Close && Load`, which Qt renders as `Close & Load` (single space, ampersand visible). The QA driver helper [`close_and_load_manifest`](qa/scenarios/_uia.py:279) still hard-coded the old buggy form in `SCAN_BTN_CLOSE_LOAD`. Result: every batch scenario that expected to load a manifest (s05–s11) timed out at the close step with `ElementNotFoundError`; s02/s03/s04 only reported `rc=0` because their drivers happen to wrap the same lookup in try/except.

This PR updates the constant to the exact post-#54 accessible name. Going with **exact-match** rather than `title_re` so the assertion fails loudly the next time the button text drifts — that drift is a real signal worth catching, not noise to absorb.

Closes #72.

## Why exact-match (and not regex)

A regex like `r\"^Close.*Load$\"` would survive both `Close  Load` and `Close & Load`. That's a feature only if you want the driver to be label-tolerant. Here, the assertion *is* the label — if a future PR changes the button to `Load Manifest` or splits it into two buttons, the QA driver should fail and force the maintainer to update both the app and the driver in lockstep. Exact-match preserves that signal.

## Test plan

- [x] `pytest -q` — full suite green (401 passed, 2 skipped). Pytest doesn't exercise the UIA path; this confirms no Python-import regressions.
- [ ] Manual: run `.venv/Scripts/python.exe -m qa.scenarios._batch` and confirm all 10 scenarios report `rc=0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)