### PR TITLE
fix(scan): narrow corrupt-image detection to PIL-decoded formats only

### DIFF
--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -152,7 +152,16 @@ class ScanWorker(QThread):
         # raising but PIL couldn't produce a pHash — the file is truncated or
         # corrupt. Route to the same skip channel as exception failures so the
         # user sees them in the log instead of getting a misleading UNDATED row.
-        _IMAGE_TYPES = frozenset(("jpeg", "heic", "raw", "png", "gif", "webp"))
+        #
+        # Restricted to formats where PIL is the primary decoder and a missing
+        # pHash unambiguously means decode-failure:
+        #   - GIF excluded: compute_hashes always returns phash=None for GIF
+        #     (intentional early-return at scanner/hasher.py:53), so flagging
+        #     phash=None as corruption false-positives 100% of the time (#75).
+        #   - RAW excluded: rawpy is the decoder, and rawpy fails on legitimate
+        #     non-camera-RAW TIFFs (Photoshop / scanner output) — flagging
+        #     those as corrupt drops real user files from the manifest (#75).
+        _IMAGE_TYPES = frozenset(("jpeg", "heic", "png", "webp"))
         corrupt_paths: set[Path] = set()
         for r in hash_results:
             if r.record.file_type in _IMAGE_TYPES and r.phash is None:

--- a/tests/test_scan_worker.py
+++ b/tests/test_scan_worker.py
@@ -193,6 +193,88 @@ class TestScanWorkerCorruptImage:
         assert "bad_truncated.jpg" not in paths, \
             f"corrupt file should be excluded from manifest, but found in: {paths}"
 
+    def test_gif_not_flagged_as_corrupt(self, qapp, tmp_path):
+        """GIFs must NOT be flagged as ImageDecodeError.
+
+        Regression for #75: scanner/hasher.compute_hashes intentionally
+        returns ``phash=None`` for GIFs (early-return at hasher.py:53).
+        The #57 fix originally treated any non-video with phash=None as
+        corrupt, which false-positived 100% of GIF inputs and silently
+        dropped them from the manifest with a misleading error.
+        """
+        import sqlite3
+
+        from app.views.workers.scan_worker import ScanWorker
+
+        gif = tmp_path / "good.gif"
+        # Tiny valid GIF (1×1 transparent pixel).
+        Image.new("RGB", (8, 8), (200, 0, 0)).save(gif, "GIF")
+
+        out = tmp_path / "manifest.sqlite"
+        worker = ScanWorker(
+            sources={"src": str(tmp_path)},
+            output_path=str(out),
+            recursive_map={"src": False},
+            workers=1,
+        )
+        progress: list[str] = []
+        worker.progress.connect(progress.append)
+        worker.run()
+
+        # The GIF should NOT appear in any "Skipped … unreadable" log line
+        # nor be tagged with the synthetic ImageDecodeError marker.
+        for line in progress:
+            assert "good.gif" not in line or "ImageDecodeError" not in line, (
+                f"GIF should not be flagged as corrupt: {line!r}"
+            )
+
+        # And it must reach the manifest.
+        with sqlite3.connect(out) as conn:
+            paths = [Path(p).name for (p,) in conn.execute(
+                "SELECT source_path FROM migration_manifest"
+            )]
+        assert "good.gif" in paths, \
+            f"GIF should be in manifest, not excluded as corrupt: {paths}"
+
+    def test_non_camera_tiff_not_flagged_as_corrupt(self, qapp, tmp_path):
+        """Non-camera-RAW TIFFs (Photoshop / scanner output) must NOT be flagged.
+
+        Regression for #75: TIFF maps to file_type='raw' (scanner/media.py),
+        and rawpy fails on synthetic / non-camera TIFFs — so phash ends up
+        None. The #57 fix originally treated that as corruption, which
+        silently dropped legitimate non-RAW TIFFs from real user libraries.
+        """
+        import sqlite3
+
+        from app.views.workers.scan_worker import ScanWorker
+
+        tiff = tmp_path / "scan_output.tif"
+        # Synthetic TIFF — PIL writes it cleanly but rawpy can't parse it.
+        Image.new("RGB", (32, 32), (50, 100, 150)).save(tiff, "TIFF")
+
+        out = tmp_path / "manifest.sqlite"
+        worker = ScanWorker(
+            sources={"src": str(tmp_path)},
+            output_path=str(out),
+            recursive_map={"src": False},
+            workers=1,
+        )
+        progress: list[str] = []
+        worker.progress.connect(progress.append)
+        worker.run()
+
+        for line in progress:
+            assert "scan_output.tif" not in line or "ImageDecodeError" not in line, (
+                f"non-camera-RAW TIFF should not be flagged as corrupt: {line!r}"
+            )
+
+        with sqlite3.connect(out) as conn:
+            paths = [Path(p).name for (p,) in conn.execute(
+                "SELECT source_path FROM migration_manifest"
+            )]
+        assert "scan_output.tif" in paths, \
+            f"TIFF should be in manifest, not excluded as corrupt: {paths}"
+
 
 class TestScanWorkerLogging:
     def test_scan_progress_and_errors_forwarded_to_loguru(


### PR DESCRIPTION
## Summary

PR #63 (closing #57) added a check that flags any non-video file with `phash=None` as `ImageDecodeError`. The check covered too many formats — for GIF and RAW, `phash=None` is the **expected** state, not a corruption signal:

- **GIF:** [`scanner/hasher.compute_hashes`](scanner/hasher.py) early-returns `(sha, None, None, None, None, None)` for any file with `file_type='gif'`. So `phash` is always `None` for GIFs, and the #57 detection false-positived 100% of the time — dropping legitimate GIFs from the manifest with a misleading "truncated or corrupt" tag.
- **RAW (incl. TIFF):** TIFFs map to `file_type='raw'` (via `scanner/media.py`) so they go through `rawpy`. `rawpy` fails on legitimate non-camera-RAW TIFFs (Photoshop / scanner / flatbed output), which silently excluded those user files too.

Closes #75.

## Change

Narrow `_IMAGE_TYPES` in [`app/views/workers/scan_worker.py`](app/views/workers/scan_worker.py) from `{jpeg, heic, raw, png, gif, webp}` to **`{jpeg, heic, png, webp}`** — the four formats where PIL is the primary decoder and a missing `phash` unambiguously means "`PIL.Image.load()` failed".

**Trade-off:** genuinely corrupt camera-RAW files no longer get the dedicated `ImageDecodeError` tag. They still appear in the manifest with their sha256 (so the user doesn't lose them). Acceptable given the false-positive blast radius this fix removes — every GIF and non-camera-RAW TIFF in a real user library was being silently dropped.

A more thorough fix would distinguish "corrupt camera RAW" from "legitimate non-camera TIFF" — that's a deeper change in `compute_hashes` (try PIL after `rawpy` fails for TIFFs, since PIL can decode most non-RAW TIFFs). Out of scope for this PR; can be a follow-up if camera-RAW corruption needs explicit handling.

## Test plan

- [x] Existing `test_truncated_jpeg_is_logged_and_excluded_from_manifest` — still passes (JPEG path unchanged)
- [x] New `test_gif_not_flagged_as_corrupt` — writes a tiny valid GIF, asserts it appears in the manifest and never appears in any `Skipped … unreadable` log line
- [x] New `test_non_camera_tiff_not_flagged_as_corrupt` — writes a synthetic TIFF (PIL writes it cleanly, rawpy fails), asserts it survives the corrupt-detection filter and lands in the manifest
- [x] `pytest -q` — full suite green (403 passed, 2 skipped)
- [ ] Manual: re-run `/qa-explore` (s06_formats specifically) and confirm `extensions_in_results=['heic', 'png', 'webp', 'gif', 'tiff']` instead of just `['heic', 'png', 'webp']`

🤖 Generated with [Claude Code](https://claude.com/claude-code)