### PR TITLE
fix(ui): put every Ref-tier action at top of group, not just KEEP

### DIFF
--- a/app/views/tree_model_builder.py
+++ b/app/views/tree_model_builder.py
@@ -22,15 +22,20 @@ from app.views.constants import (
 )
 
 # Numeric sort priorities — lower value = sorted first (ascending).
-# KEEP (the reference / primary file) sits at the top of its group so users
-# scanning top-down see the "winner" first (#55).
+#
+# "Ref tier" — every action whose `_file_similarity` renders as "Ref" (KEEP /
+# MOVE / UNDATED / unset) shares position 1 so the reference / primary file
+# of a group always lands at the top, regardless of which classifier branch
+# assigned its action. This is what users mean by "winner first" (#55, #76).
+# REVIEW_DUPLICATE and EXACT follow, sorted by closeness to the reference.
 _ACTION_SORT: dict[str, int] = {
     "KEEP": 1,
+    "MOVE": 1,
+    "UNDATED": 1,
+    "": 1,
     "REVIEW_DUPLICATE": 2,
     "EXACT": 3,
-    "UNDATED": 4,
-    "MOVE": 5,
-}  # missing / "" → 6
+}  # missing key → 1 (treated as Ref tier, matching `_file_similarity`)
 
 _DECISION_SORT: dict[str, int] = {
     "delete": 1,
@@ -196,7 +201,7 @@ def build_model(
             ]
 
             try:
-                child_row[COL_GROUP].setData(_ACTION_SORT.get(file_action, 6), SORT_ROLE)
+                child_row[COL_GROUP].setData(_ACTION_SORT.get(file_action, 1), SORT_ROLE)
             except Exception:
                 pass
             try:

--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -54,13 +54,21 @@ FROM   migration_manifest
 WHERE  executed = 0
 ORDER  BY
     group_id NULLS LAST,
+    -- "Ref tier" first (KEEP / MOVE / UNDATED / unset all render as "Ref"
+    -- in the tree per app/views/tree_model_builder._file_similarity), then
+    -- duplicates by similarity. Putting the reference / primary file at the
+    -- top of its group is what users mean when they say "winner first" (#55,
+    -- #76). Earlier we moved only KEEP to position 1, but real-world primaries
+    -- in dedup groups are almost always MOVE — so KEEP-only didn't move the
+    -- displayed Ref to the top.
     CASE action
         WHEN 'KEEP'             THEN 1
+        WHEN 'MOVE'             THEN 1
+        WHEN 'UNDATED'          THEN 1
+        WHEN ''                 THEN 1
         WHEN 'REVIEW_DUPLICATE' THEN 2
         WHEN 'EXACT'            THEN 3
-        WHEN 'UNDATED'          THEN 4
-        WHEN 'MOVE'             THEN 5
-        ELSE 6
+        ELSE 4
     END,
     id
 """
@@ -186,9 +194,10 @@ class ManifestRepository:
         e.g. MOVE / UNDATED with no near-duplicate) are not yielded — the UI
         focuses on files that need review.
 
-        Ordering within a group: KEEP → REVIEW_DUPLICATE → EXACT → UNDATED → MOVE.
-        Reference / primary file (KEEP) sits at the top so users scanning a
-        group top-down see the "winner" first (#55).
+        Ordering within a group: any action that renders as "Ref" in the
+        tree (KEEP / MOVE / UNDATED / unset) → REVIEW_DUPLICATE → EXACT.
+        Reference / primary file sits at the top so users scanning a group
+        top-down see the "winner" first (#55, #76).
         """
         from collections import defaultdict
 

--- a/tests/test_manifest_repository.py
+++ b/tests/test_manifest_repository.py
@@ -1005,17 +1005,50 @@ class TestRemoveFromReviewNoVacuum:
 
 
 class TestInGroupRowOrdering:
-    """#55 — KEEP (the reference/primary file) sits at the top of its group."""
+    """#55 + #76 — the file rendered as "Ref" sits at the top of its group.
 
-    def test_keep_appears_before_review_duplicate_and_exact(self, tmp_path):
+    `_file_similarity` (in `app/views/tree_model_builder.py`) renders any
+    action other than EXACT and REVIEW_DUPLICATE as "Ref". So the SQL
+    ordering puts every "Ref tier" action (KEEP / MOVE / UNDATED / unset)
+    at position 1, ahead of REVIEW_DUPLICATE (2) and EXACT (3).
+    """
+
+    def test_move_primary_appears_before_review_duplicate_and_exact(self, tmp_path):
+        """The s07/s10 case: dedup classifier labels the primary as MOVE.
+
+        Regression for #76. The original #55 fix moved only KEEP to position 1,
+        but `dedup.classify` actually assigns MOVE to most real-world primaries
+        — so KEEP-only didn't move the displayed Ref to the top in practice.
+        """
+        ref = tmp_path / "ref" / "primary.jpg"
+        review = tmp_path / "review" / "near.jpg"
+        exact = tmp_path / "exact" / "dup.jpg"
+        for p in (ref, review, exact):
+            _make_jpeg(p)
+        gid = "/group/move-primary"
+        db = _make_manifest(tmp_path, [
+            # Insert in non-priority order; SQL ordering must still put MOVE first.
+            _row({"source_path": str(review), "action": "REVIEW_DUPLICATE", "group_id": gid}),
+            _row({"source_path": str(exact), "action": "EXACT", "group_id": gid,
+                  "hamming_distance": None}),
+            _row({"source_path": str(ref), "action": "MOVE", "group_id": gid,
+                  "hamming_distance": None}),
+        ])
+        records = list(ManifestRepository().load(str(db)))
+        actions = [r.action for r in records]
+        assert actions[0] == "MOVE", \
+            f"MOVE primary (rendered as Ref) should be at top of group; got order {actions}"
+        assert actions == ["MOVE", "REVIEW_DUPLICATE", "EXACT"]
+
+    def test_keep_primary_appears_before_review_duplicate_and_exact(self, tmp_path):
+        """KEEP primary case (rarer in practice) — also a Ref tier action."""
         ref = tmp_path / "ref" / "ref.jpg"
         review = tmp_path / "review" / "near.jpg"
         exact = tmp_path / "exact" / "dup.jpg"
         for p in (ref, review, exact):
             _make_jpeg(p)
-        gid = "/group/order-test"
+        gid = "/group/keep-primary"
         db = _make_manifest(tmp_path, [
-            # Insert in non-priority order; SQL ordering should still put KEEP first.
             _row({"source_path": str(review), "action": "REVIEW_DUPLICATE", "group_id": gid}),
             _row({"source_path": str(exact), "action": "EXACT", "group_id": gid,
                   "hamming_distance": None}),
@@ -1024,7 +1057,6 @@ class TestInGroupRowOrdering:
         ])
         records = list(ManifestRepository().load(str(db)))
         actions = [r.action for r in records]
-        # KEEP must be first; the rest follow per the documented order.
         assert actions[0] == "KEEP", \
-            f"reference file should be at top of group; got order {actions}"
+            f"KEEP primary (rendered as Ref) should be at top of group; got order {actions}"
         assert actions == ["KEEP", "REVIEW_DUPLICATE", "EXACT"]


### PR DESCRIPTION
## Summary

PR #66 (closing #55) tried to move the reference / primary file to the top of its group by sorting `KEEP` at position 1. But `scanner/dedup.classify` labels most real-world primaries as `MOVE`, not `KEEP` — `KEEP` is only the action assigned to the lower-priority survivor of an EXACT-duplicate set, which is rare in typical scans. The /qa-explore pass after #66 landed surfaced `Ref` still at the bottom in scenarios s07 and s10:

```
s07_format_dup:
  y=660 cells=['84%',  'scene_a.jpg',  ...]   ← REVIEW_DUPLICATE  (top)
  y=690 cells=['Ref',  'scene_a.heic', ...]   ← Ref               (bottom)

s10_multi_source:
  y=660 cells=['97%',  'shared_neardup.jpg', ...]
  y=690 cells=['100%', 'shared.jpg',         ...]
  y=720 cells=['Ref',  'shared.jpg',         ...]   ← Ref still last
```

Closes #76.

## Why this happened

The "Ref" label users see is computed by [`tree_model_builder._file_similarity`](app/views/tree_model_builder.py), which renders **any action other than EXACT and REVIEW_DUPLICATE** as "Ref":

```python
def _file_similarity(action: str, record) -> str:
    if action == "EXACT":            return "100%"
    if action == "REVIEW_DUPLICATE": return _hamming_to_pct(...)
    return "Ref"   # ← KEEP / MOVE / UNDATED / "" all collapse here
```

The classifier-side distinction between `KEEP / MOVE / UNDATED / unset` is meaningful for execution time, but invisible in the review pane — they all look like the group's primary to the user. Only sorting `KEEP` to the top doesn't change what the user actually sees.

## Change

Collapse all four "Ref-tier" actions to position 1 in both ordering sources:

- SQL `ORDER BY` in `infrastructure/manifest_repository.py`:
  ```sql
  WHEN 'KEEP'             THEN 1
  WHEN 'MOVE'             THEN 1
  WHEN 'UNDATED'          THEN 1
  WHEN ''                 THEN 1
  WHEN 'REVIEW_DUPLICATE' THEN 2
  WHEN 'EXACT'            THEN 3
  ```
- `_ACTION_SORT` dict in `app/views/tree_model_builder.py` matched in lockstep.
- The `_ACTION_SORT.get(file_action, ...)` fallback for unknown actions moves from `6` to `1` so the Ref tier is the safe default.

## Why the original test didn't catch this

The PR #66 regression test [`test_keep_appears_before_review_duplicate_and_exact`](tests/test_manifest_repository.py) constructed a synthetic group with `action="KEEP"` for the primary, which validated the SQL change in isolation but didn't reflect how `dedup.classify` actually labels primaries — exactly the gap that let the regression ship.

This PR renames it to `test_move_primary_appears_before_review_duplicate_and_exact` (the real user-facing case) and adds a parallel `test_keep_primary_*` so both branches stay covered.

## Test plan

- [x] `pytest -q tests/test_manifest_repository.py` — 51 passed (was 50; renamed 1, added 1)
- [x] `pytest -q` — full suite green (402 passed, 2 skipped)
- [ ] Manual: re-run `/qa-explore` and confirm s07 / s10 show `Ref` at the **top** of their groups (y-coordinate smallest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)