### PR TITLE
qa(s01): probe first-run hint, menu-enabled state, and status bar text

### DIFF
--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -23,6 +23,7 @@ REPO = Path(__file__).resolve().parents[2]
 PY = str(REPO / ".venv" / "Scripts" / "python.exe")
 
 ALL_SCENARIOS = [
+    "s01_happy_path",
     "s02_empty_folder",
     "s03_cancel_scan",
     "s04_corrupted",

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -189,6 +189,95 @@ def read_result_rows(win: UIAWrapper, y_min: int = 600) -> list[GroupedRow]:
 
 
 # ---------------------------------------------------------------------------
+# Main-window state probes (first-run hint #42, status bar #58, menu #52)
+# ---------------------------------------------------------------------------
+
+
+def read_status_bar_text(win: UIAWrapper) -> str:
+    """Return the main window's QStatusBar message, or '' if empty/absent.
+
+    QMainWindow.statusBar().showMessage(text, timeout) shows text for
+    timeout ms then clears. Probes immediately after a state transition
+    typically still see the message; probes long after see ''.
+    """
+    try:
+        sb = win.child_window(control_type="StatusBar")
+        direct = (sb.window_text() or "").strip()
+        if direct:
+            return direct
+        for child in sb.descendants():
+            try:
+                t = (child.window_text() or "").strip()
+                if t:
+                    return t
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return ""
+
+
+def read_main_window_state(win: UIAWrapper) -> dict:
+    """Probe state used by gap-fill checks (#42 first-run, #58 status bar).
+
+    Returns:
+        empty_state_visible: True if the "No manifest loaded" hint label
+            is in the UIA tree and visible (#42).
+        tree_visible: True if the result-tree QTreeView is visible.
+        status_bar_text: current QStatusBar message (#58).
+    """
+    state = {
+        "empty_state_visible": False,
+        "tree_visible": False,
+        "status_bar_text": read_status_bar_text(win),
+    }
+    for it in win.descendants():
+        try:
+            t = it.window_text() or ""
+            if "No manifest loaded" in t:
+                try:
+                    state["empty_state_visible"] = bool(it.is_visible())
+                except Exception:
+                    state["empty_state_visible"] = True
+                break
+        except Exception:
+            continue
+    try:
+        for tree in win.descendants(control_type="Tree"):
+            try:
+                if tree.is_visible():
+                    state["tree_visible"] = True
+                    break
+            except Exception:
+                continue
+    except Exception:
+        pass
+    return state
+
+
+def probe_menu_items(win: UIAWrapper, menu_title: str) -> list[tuple[str, bool]]:
+    """Open `menu_title`, return [(item_title, enabled)], dismiss popup.
+
+    Used to verify menu enable/disable transitions like #52 ("Remove from
+    List" greyed pre-manifest, enabled after manifest loads).
+    """
+    popup = open_menu(win, menu_title)
+    out: list[tuple[str, bool]] = []
+    for it in popup.descendants(control_type="MenuItem"):
+        try:
+            title = (it.window_text() or "").strip()
+            if title:
+                out.append((title, bool(it.is_enabled())))
+        except Exception:
+            continue
+    # Dismiss popup with Esc — same pattern s01 already uses inline.
+    _user32.keybd_event(0x1B, 0, 0, 0)
+    _user32.keybd_event(0x1B, 0, 2, 0)
+    time.sleep(0.2)
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Wait helpers
 # ---------------------------------------------------------------------------
 

--- a/qa/scenarios/s01_happy_path.py
+++ b/qa/scenarios/s01_happy_path.py
@@ -3,6 +3,16 @@
 Required sources (write before launching): qa/sandbox/huge,
 qa/sandbox/near-duplicates, qa/sandbox/unique
 PRE: PHOTO_MANAGER_HOME=qa QT_ACCESSIBILITY=1 .venv/Scripts/python.exe main.py
+
+Also probes the three "post-load UI state" behaviors that earlier batch
+runs couldn't verify:
+
+  - #42 — first-run hint label visible at startup, hidden after a
+    manifest loads.
+  - #52 — "Remove from List" menu item disabled pre-manifest,
+    enabled after.
+  - #58 — status bar shows "Loaded manifest: N group(s), M isolated
+    file(s)" for the just-loaded manifest.
 """
 from __future__ import annotations
 
@@ -16,6 +26,17 @@ def main() -> int:
     print("scenario: s01_happy_path")
     app, win = _uia.connect_main()
     print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    # --- Pre-scan state probes (gaps closed by this scenario) -----------
+    print("step: probe_first_run_state")
+    pre = _uia.read_main_window_state(win)
+    print(f"  empty_state_visible={pre['empty_state_visible']}")
+    print(f"  tree_visible={pre['tree_visible']}")
+    print(f"  status_bar_text={pre['status_bar_text']!r}")
+
+    print("step: probe_list_menu_pre_load")
+    for title, enabled in _uia.probe_menu_items(win, _uia.MENU_LIST):
+        print(f"  list_menu: title={title!r} enabled={enabled}")
 
     print("step: open_scan_dialog")
     dlg, scan_hwnd = _uia.open_scan_dialog(win)
@@ -49,15 +70,20 @@ def main() -> int:
     for r in rows:
         print(f"  row: y={r.y} cells={list(r.cells)}")
 
+    # --- Post-load state probes (verify the transitions fired) ----------
+    print("step: probe_post_load_state")
+    post = _uia.read_main_window_state(win)
+    print(f"  empty_state_visible={post['empty_state_visible']}")
+    print(f"  tree_visible={post['tree_visible']}")
+    print(f"  status_bar_text={post['status_bar_text']!r}")
+
+    print("step: probe_list_menu_post_load")
+    for title, enabled in _uia.probe_menu_items(win, _uia.MENU_LIST):
+        print(f"  list_menu: title={title!r} enabled={enabled}")
+
     print("step: verify_action_menu_enabled")
-    popup = _uia.open_menu(win, _uia.MENU_ACTION)
-    for it in popup.descendants(control_type="MenuItem"):
-        try:
-            print(f"  action_menu: title={it.window_text()!r} enabled={it.is_enabled()}")
-        except Exception as e:
-            print(f"  action_menu: err={e!r}")
-    ctypes.windll.user32.keybd_event(0x1B, 0, 0, 0)
-    ctypes.windll.user32.keybd_event(0x1B, 0, 2, 0)
+    for title, enabled in _uia.probe_menu_items(win, _uia.MENU_ACTION):
+        print(f"  action_menu: title={title!r} enabled={enabled}")
 
     print("scenario: s01_happy_path DONE")
     return 0


### PR DESCRIPTION
## Summary

Three behaviors shipped this session were not reachable from the existing scenario drivers, so every /qa-explore batch had to flag them as \"no signal either way\":

- **#42** first-run hint visible at startup, hidden after manifest load
- **#52** \"Remove from List\" disabled pre-manifest, enabled after
- **#58** status bar shows \`Loaded manifest: N group(s), M isolated file(s)\` after load

This PR adds three small UIA helpers and wires them into the s01 (happy-path) driver as pre-scan and post-load probes. Also fixes the missing s01 entry in the batch runner's default scenario list.

## What this is, and what it isn't

This is **driver instrumentation** — strictly extending what /qa-explore can observe. It doesn't change any app behavior, doesn't add new test fixtures, and doesn't require its own pytest assertions (the LLM reading the batch output triages each probe value).

It's NOT yet a CI-grade automated regression check — that's separately tracked in [#74](https://github.com/jackal998/photo-manager/issues/74). With these probes in place, that future CI workflow gets meaningfully more useful coverage on each run.

## Changes

- **\`qa/scenarios/_uia.py\`** — three new helpers:
  - \`read_status_bar_text(win)\` — read QStatusBar message; \`''\` if empty/absent
  - \`read_main_window_state(win)\` — returns \`{empty_state_visible, tree_visible, status_bar_text}\` in one call
  - \`probe_menu_items(win, menu_title)\` — opens menu, returns \`[(item_title, enabled), ...]\`, dismisses popup
- **\`qa/scenarios/s01_happy_path.py\`** — calls them as pre-scan and post-load snapshots, refactors the existing inline Action-menu probe to use \`probe_menu_items\`
- **\`qa/scenarios/_batch.py\`** — adds \`s01_happy_path\` to \`ALL_SCENARIOS\` so it runs in the default \`python -m qa.scenarios._batch\` (it was previously absent)

## Verified output

From a clean batch run:

\`\`\`
step: probe_first_run_state
  empty_state_visible=True
  tree_visible=False
  status_bar_text=''
step: probe_list_menu_pre_load
  list_menu: title='Remove from List' enabled=False
...
step: probe_post_load_state
  empty_state_visible=False
  tree_visible=True
  status_bar_text='Loaded manifest: 1 group(s), 11 isolated file(s)'
step: probe_list_menu_post_load
  list_menu: title='Remove from List' enabled=True
\`\`\`

All four state transitions match the intent of the original PRs.

## Test plan

- [x] \`pytest -q\` — full suite green (no Python-import regressions)
- [x] \`python -m qa.scenarios._batch s01_happy_path\` — single-scenario run prints all 5 new probe outputs cleanly, \`rc=0\`
- [x] \`python -m qa.scenarios._batch\` — full sweep, **11/11 \`rc=0\`** (batch now includes s01)

🤖 Generated with [Claude Code](https://claude.com/claude-code)