### PR TITLE
fix(ui): order EXACT before REVIEW_DUPLICATE within a group

### DIFF
--- a/app/views/tree_model_builder.py
+++ b/app/views/tree_model_builder.py
@@ -27,14 +27,17 @@ from app.views.constants import (
 # MOVE / UNDATED / unset) shares position 1 so the reference / primary file
 # of a group always lands at the top, regardless of which classifier branch
 # assigned its action. This is what users mean by "winner first" (#55, #76).
-# REVIEW_DUPLICATE and EXACT follow, sorted by closeness to the reference.
+#
+# Duplicates follow in descending similarity: EXACT (100%) before
+# REVIEW_DUPLICATE (near-match), so a group reads top-down as
+# Ref → strongest match → weaker matches.
 _ACTION_SORT: dict[str, int] = {
     "KEEP": 1,
     "MOVE": 1,
     "UNDATED": 1,
     "": 1,
-    "REVIEW_DUPLICATE": 2,
-    "EXACT": 3,
+    "EXACT": 2,
+    "REVIEW_DUPLICATE": 3,
 }  # missing key → 1 (treated as Ref tier, matching `_file_similarity`)
 
 _DECISION_SORT: dict[str, int] = {

--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -56,18 +56,16 @@ ORDER  BY
     group_id NULLS LAST,
     -- "Ref tier" first (KEEP / MOVE / UNDATED / unset all render as "Ref"
     -- in the tree per app/views/tree_model_builder._file_similarity), then
-    -- duplicates by similarity. Putting the reference / primary file at the
-    -- top of its group is what users mean when they say "winner first" (#55,
-    -- #76). Earlier we moved only KEEP to position 1, but real-world primaries
-    -- in dedup groups are almost always MOVE — so KEEP-only didn't move the
-    -- displayed Ref to the top.
+    -- duplicates in descending similarity: EXACT (100%) before
+    -- REVIEW_DUPLICATE (near-match). Top-down a group reads as "winner"
+    -- → strongest match → weaker matches (#55, #76).
     CASE action
         WHEN 'KEEP'             THEN 1
         WHEN 'MOVE'             THEN 1
         WHEN 'UNDATED'          THEN 1
         WHEN ''                 THEN 1
-        WHEN 'REVIEW_DUPLICATE' THEN 2
-        WHEN 'EXACT'            THEN 3
+        WHEN 'EXACT'            THEN 2
+        WHEN 'REVIEW_DUPLICATE' THEN 3
         ELSE 4
     END,
     id
@@ -195,9 +193,9 @@ class ManifestRepository:
         focuses on files that need review.
 
         Ordering within a group: any action that renders as "Ref" in the
-        tree (KEEP / MOVE / UNDATED / unset) → REVIEW_DUPLICATE → EXACT.
+        tree (KEEP / MOVE / UNDATED / unset) → EXACT → REVIEW_DUPLICATE.
         Reference / primary file sits at the top so users scanning a group
-        top-down see the "winner" first (#55, #76).
+        top-down see the "winner" first, then strongest match (#55, #76).
         """
         from collections import defaultdict
 

--- a/tests/test_manifest_repository.py
+++ b/tests/test_manifest_repository.py
@@ -1010,7 +1010,8 @@ class TestInGroupRowOrdering:
     `_file_similarity` (in `app/views/tree_model_builder.py`) renders any
     action other than EXACT and REVIEW_DUPLICATE as "Ref". So the SQL
     ordering puts every "Ref tier" action (KEEP / MOVE / UNDATED / unset)
-    at position 1, ahead of REVIEW_DUPLICATE (2) and EXACT (3).
+    at position 1, then EXACT (2 — strongest match), then REVIEW_DUPLICATE
+    (3 — weaker), so a group reads top-down as Ref → 100% → near-matches.
     """
 
     def test_move_primary_appears_before_review_duplicate_and_exact(self, tmp_path):
@@ -1038,7 +1039,7 @@ class TestInGroupRowOrdering:
         actions = [r.action for r in records]
         assert actions[0] == "MOVE", \
             f"MOVE primary (rendered as Ref) should be at top of group; got order {actions}"
-        assert actions == ["MOVE", "REVIEW_DUPLICATE", "EXACT"]
+        assert actions == ["MOVE", "EXACT", "REVIEW_DUPLICATE"]
 
     def test_keep_primary_appears_before_review_duplicate_and_exact(self, tmp_path):
         """KEEP primary case (rarer in practice) — also a Ref tier action."""
@@ -1059,4 +1060,4 @@ class TestInGroupRowOrdering:
         actions = [r.action for r in records]
         assert actions[0] == "KEEP", \
             f"KEEP primary (rendered as Ref) should be at top of group; got order {actions}"
-        assert actions == ["KEEP", "REVIEW_DUPLICATE", "EXACT"]
+        assert actions == ["KEEP", "EXACT", "REVIEW_DUPLICATE"]


### PR DESCRIPTION
## Summary

Within a group, EXACT (100% byte-identical match) used to sort *below* REVIEW_DUPLICATE (near-match). After [#78](https://github.com/jackal998/photo-manager/pull/78) put the Ref/primary at the top, the s01 batch output read top-down as:

\`\`\`
Ref     neardup_00.jpg
97%     neardup_02.jpg   ← REVIEW_DUPLICATE
94%     neardup_03.jpg
91%     neardup_04.jpg
100%    neardup_01.jpg   ← EXACT (below the 91% near-match)
\`\`\`

Numerically jarring: a top-down scan of a group should read as "winner → strongest match → weaker matches", which means descending similarity. EXACT is the strongest possible match, so it belongs right after the Ref.

Swap EXACT to position 2 and REVIEW_DUPLICATE to position 3 in both ordering sources:

- SQL \`ORDER BY\` in [\`infrastructure/manifest_repository.py\`](infrastructure/manifest_repository.py)
- \`_ACTION_SORT\` dict in [\`app/views/tree_model_builder.py\`](app/views/tree_model_builder.py)

## Pre-existing, not a regression

The REVIEW-before-EXACT order has been the behavior since at least PR #66 (probably earlier). It was just invisible in batch output until [#79](https://github.com/jackal998/photo-manager/pull/79) added state probes that made group order visible top-down. Surfaced as a side note in the round-3 /qa-explore wrap-up; the user signed off as worth fixing.

## Test plan

- [x] \`pytest -q tests/test_manifest_repository.py\` — 51 passed (assertions updated to new order)
- [x] \`pytest -q\` — full suite green (404 passed, 2 skipped)
- [ ] Manual: re-run \`/qa-explore\` and confirm s01 reads as: \`Ref → 100% (EXACT) → 97% / 94% / 91% (REVIEW_DUPLICATE)\` top-down

🤖 Generated with [Claude Code](https://claude.com/claude-code)