### PR TITLE
chore: bump coverage fail_under from 75 to 80

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,4 +75,4 @@ exclude_lines = [
   "raise NotImplementedError",
   "if __name__ == .__main__.:",
 ]
-fail_under = 75
+fail_under = 80


### PR DESCRIPTION
## Summary

Total branch coverage is now **81.24 %** — the test additions shipped during this session passively lifted the codebase past the 80 % threshold:

- `tests/test_scan_worker.py` — corrupt-JPEG (#57), GIF / non-camera-TIFF (#75), empty-folder benign-completion (#51 + #56), loguru forwarding (#49)
- `tests/test_manifest_repository.py` — KEEP-primary and MOVE-primary in-group ordering (#76)
- `tests/test_scan_dialog.py` — source-list min-height (#50), path-entry typed-add (#40)
- `tests/test_walker.py` — pin `qa/sandbox/walker-exclusions/` to expected 2-file result (#47)

No further new tests needed for this PR. Closes #71.

## What changes

One line in `pyproject.toml`:

\`\`\`diff
-fail_under = 75
+fail_under = 80
\`\`\`

The omit list still hides intentionally-untested Qt glue and bootstrap modules (\`main.py\`, \`scan.py\`, \`infrastructure/image_service.py\`, \`infrastructure/logging.py\`, \`app/views/workers/scan_worker.py\`, \`app/views/media_utils.py\`); this PR only raises the threshold that the remaining 80 % must clear.

## Coverage by module (post-session, with 81.24 % overall)

| Module | Coverage | Notes |
|---|---|---|
| \`app/views/workers/manifest_load_worker.py\` | 37 % | No tests yet — likely the next target if the gate moves higher |
| \`app/views/handlers/context_menu.py\` | 47 % | Limited tests |
| \`infrastructure/utils.py\` | 59 % | EXIF/date helpers — gap noted in #71 |
| \`app/views/handlers/file_operations.py\` | 68 % | Decision-flow handler — gap noted in #71 |
| \`app/views/tree_model_builder.py\` | 69 % | UI builder, hard to test without Qt |
| \`scanner/hasher.py\` | 72 % | Was 58 % per #71; lifted by #75's GIF / TIFF tests |

The 1.24 % headroom above the new 80 % gate is intentionally tight — that's the gate doing its job. If a future change pushes total below 80 %, CI fails and the contributor gets the signal.

## Test plan

- [x] \`pytest\` (default addopts include \`--cov\` and the new gate) — `Required test coverage of 80.0% reached. Total coverage: 81.24%`. 404 passed, 2 skipped.
- [ ] Manual: confirm CI on master uses the same `pytest` invocation (it does — \`.github/workflows/tests.yml\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)