### PR TITLE
tests: lift coverage on the lowest-coverage modules

### DIFF
--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -507,3 +507,113 @@ class TestConstructor:
         )
         assert handler is not None
         assert not hasattr(handler, "deleter")
+
+
+# ── manifest-load callbacks ────────────────────────────────────────────────
+
+
+class TestManifestLoadCallbacks:
+    """Cover _on_manifest_loaded / _on_manifest_failed / _set_manifest_actions_enabled.
+
+    These run as the worker's signals fire on the GUI thread; they're plain
+    callables with simple signatures, so unit-test them directly with mocks.
+    """
+
+    def test_on_manifest_loaded_updates_vm_and_ui(self, tmp_path):
+        from app.views.handlers.file_operations import FileOperationsHandler
+        from types import SimpleNamespace
+
+        vm = SimpleNamespace(groups=[], group_count=0)
+        ui = MagicMock()
+        status = MagicMock()
+        parent = MagicMock()
+        parent.menu_controller = MagicMock()
+        handler = FileOperationsHandler(
+            vm=vm, settings=MagicMock(),
+            parent_widget=parent, ui_updater=ui, status_reporter=status,
+        )
+
+        groups = [
+            PhotoGroup(group_number=1, items=[_rec("/a.jpg"), _rec("/b.jpg")]),
+            PhotoGroup(group_number=2, items=[_rec("/c.jpg")]),
+        ]
+        # Stand in for the path the worker reports back.
+        path = str(tmp_path / "m.sqlite")
+        # group_count is read off the VM, not derived — wire it.
+        vm.group_count = len(groups)
+
+        handler._on_manifest_loaded(groups, path)
+
+        assert vm.groups is groups
+        assert handler._manifest_path == path
+        ui.refresh_tree.assert_called_once_with(groups)
+        ui.show_group_counts.assert_called_once_with(2)
+        ui.show_groups_summary.assert_called_once_with(groups)
+        # Status text mentions group count and total file count (3).
+        status.show_status.assert_called_once()
+        status_msg = status.show_status.call_args[0][0]
+        assert "2" in status_msg and "3" in status_msg
+
+    def test_on_manifest_failed_logs_and_disables_actions(self):
+        from app.views.handlers.file_operations import FileOperationsHandler
+        from types import SimpleNamespace
+
+        vm = SimpleNamespace(groups=[])
+        status = MagicMock()
+        parent = MagicMock()
+        parent.menu_controller = MagicMock()
+        handler = FileOperationsHandler(
+            vm=vm, settings=MagicMock(),
+            parent_widget=parent, ui_updater=MagicMock(), status_reporter=status,
+        )
+
+        with patch("PySide6.QtWidgets.QMessageBox.critical") as crit:
+            handler._on_manifest_failed("disk on fire")
+
+        crit.assert_called_once()
+        # Critical dialog body carries the error text.
+        assert "disk on fire" in crit.call_args[0][2]
+        # Status updated to a failure message.
+        status.show_status.assert_called_once()
+        # Manifest-dependent actions disabled.
+        assert parent.menu_controller.enable_action.called
+        for call in parent.menu_controller.enable_action.call_args_list:
+            assert call[0][1] is False
+
+    def test_set_manifest_actions_enabled_toggles_each_action(self):
+        from app.views.handlers.file_operations import FileOperationsHandler
+        from types import SimpleNamespace
+
+        vm = SimpleNamespace(groups=[])
+        parent = MagicMock()
+        parent.menu_controller = MagicMock()
+        handler = FileOperationsHandler(
+            vm=vm, settings=MagicMock(), parent_widget=parent,
+            ui_updater=MagicMock(), status_reporter=MagicMock(),
+        )
+
+        handler._set_manifest_actions_enabled(True)
+        called = {c[0][0] for c in parent.menu_controller.enable_action.call_args_list}
+        assert called == {
+            "save_manifest", "execute_action",
+            "set_action_hl_delete", "set_action_hl_keep",
+        }
+        for c in parent.menu_controller.enable_action.call_args_list:
+            assert c[0][1] is True
+
+    def test_set_manifest_actions_enabled_swallows_attribute_error(self):
+        """The except AttributeError branch — parent without menu_controller still works."""
+        from app.views.handlers.file_operations import FileOperationsHandler
+        from types import SimpleNamespace
+
+        vm = SimpleNamespace(groups=[])
+        parent = MagicMock()
+        # Make every enable_action call raise AttributeError so the except catches.
+        parent.menu_controller.enable_action.side_effect = AttributeError("no such action")
+        handler = FileOperationsHandler(
+            vm=vm, settings=MagicMock(), parent_widget=parent,
+            ui_updater=MagicMock(), status_reporter=MagicMock(),
+        )
+
+        # Must not raise.
+        handler._set_manifest_actions_enabled(True)

--- a/tests/test_manifest_load_worker.py
+++ b/tests/test_manifest_load_worker.py
@@ -1,93 +1,157 @@
-"""Tests for ManifestLoadWorker — background manifest loading via QThread."""
+"""Tests for ManifestLoadWorker — background manifest loading via QThread.
+
+Pattern: invoke ``worker.run()`` directly (same-thread, DirectConnection)
+instead of ``worker.start()`` + ``worker.wait()``. coverage.py only tracks
+the calling thread by default, so synchronous execution is what makes the
+``_load()`` body actually count toward coverage. test_scan_worker.py uses
+the same idiom for the same reason.
+"""
 
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
-import pytest
-
-from scanner.dedup import ManifestRow
-from scanner.manifest import write_manifest
+from PIL import Image
 
 
-def _make_row(path: str, group_id: str | None = None) -> ManifestRow:
-    return ManifestRow(
-        source_path=path,
-        source_label="jdrive",
-        dest_path=None,
-        action="MOVE",
-        source_hash="abc123",
-        phash=None,
-        hamming_distance=None,
-        duplicate_of=None,
-        reason="unique",
-        group_id=group_id,
-    )
+_DDL = """
+CREATE TABLE migration_manifest (
+    id               INTEGER PRIMARY KEY,
+    source_path      TEXT NOT NULL,
+    source_label     TEXT NOT NULL,
+    dest_path        TEXT,
+    action           TEXT NOT NULL,
+    source_hash      TEXT,
+    phash            TEXT,
+    hamming_distance INTEGER,
+    group_id         TEXT,
+    reason           TEXT,
+    executed         INTEGER NOT NULL DEFAULT 0,
+    user_decision    TEXT    NOT NULL DEFAULT '',
+    file_size_bytes  INTEGER,
+    shot_date        TEXT,
+    creation_date    TEXT,
+    mtime            TEXT,
+    pixel_width      INTEGER,
+    pixel_height     INTEGER
+);
+"""
 
 
-class TestManifestLoadWorker:
-    def _run_worker(self, qapp, worker, timeout_ms: int = 10_000) -> None:
-        """Start worker, wait for it, then flush any queued cross-thread signals."""
-        worker.start()
-        assert worker.wait(timeout_ms), "Worker did not finish within timeout"
-        qapp.processEvents()  # deliver queued signals from worker thread → main thread
+def _make_jpeg(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    Image.new("RGB", (16, 16), (128, 64, 32)).save(path, "JPEG")
 
-    def test_worker_emits_finished_with_groups(self, qapp, tmp_path):
-        """Worker yields PhotoGroups via finished signal for a valid manifest."""
+
+def _seed_grouped_manifest(tmp_path: Path) -> Path:
+    """Return a manifest with one near-duplicate pair (survives load filter)."""
+    cand = tmp_path / "cand.jpg"
+    ref = tmp_path / "ref.jpg"
+    _make_jpeg(cand)
+    _make_jpeg(ref)
+    db = tmp_path / "manifest.sqlite"
+    with sqlite3.connect(db) as conn:
+        conn.executescript(_DDL)
+        gid = "/group/a"
+        conn.execute(
+            "INSERT INTO migration_manifest (source_path, source_label, action, "
+            "hamming_distance, group_id, reason) VALUES (?, ?, ?, ?, ?, ?)",
+            (str(cand), "src", "REVIEW_DUPLICATE", 5, gid, "near-duplicate"),
+        )
+        conn.execute(
+            "INSERT INTO migration_manifest (source_path, source_label, action, "
+            "group_id, reason) VALUES (?, ?, ?, ?, ?)",
+            (str(ref), "src", "MOVE", gid, "unique"),
+        )
+        conn.commit()
+    return db
+
+
+class TestManifestLoadWorkerSuccess:
+    def test_emits_progress_then_finished_for_valid_manifest(self, qapp, tmp_path):
         from app.views.workers.manifest_load_worker import ManifestLoadWorker
 
-        f = tmp_path / "photo.jpg"
-        f2 = tmp_path / "photo2.jpg"
-        f.write_bytes(b"fake")
-        f2.write_bytes(b"fake2")
-        db = tmp_path / "manifest.sqlite"
-        gid = str(f)
-        write_manifest([_make_row(str(f), group_id=gid), _make_row(str(f2), group_id=gid)], db)
+        db = _seed_grouped_manifest(tmp_path)
+        worker = ManifestLoadWorker(str(db), default_sort=[])
 
-        finished_groups: list = []
-        worker = ManifestLoadWorker(str(db), [], parent=None)
-        worker.finished.connect(lambda groups: finished_groups.extend(groups))
-        self._run_worker(qapp, worker)
+        progress: list[str] = []
+        finished: list[list] = []
+        failed: list[str] = []
+        worker.progress.connect(progress.append)
+        worker.finished.connect(finished.append)
+        worker.failed.connect(failed.append)
 
-        assert len(finished_groups) == 1
-        paths = {r.file_path for r in finished_groups[0].items}
-        assert str(f) in paths
+        worker.run()
 
-    def test_worker_emits_failed_on_bad_path(self, qapp):
-        """Worker emits failed signal when the manifest path does not exist."""
+        assert not failed, f"valid load must not emit failed; got: {failed}"
+        assert len(finished) == 1, f"finished should fire once; got {len(finished)}"
+        groups = finished[0]
+        assert len(groups) == 1
+        assert len(groups[0].items) == 2
+
+        # Progress narrates the three pipeline stages.
+        assert any("Loading manifest" in p for p in progress)
+        assert any("Grouping" in p for p in progress)
+        assert any("Loaded" in p and "group" in p for p in progress)
+
+    def test_default_sort_branch_executes_when_provided(self, qapp, tmp_path):
+        """default_sort=[(field, asc)] triggers the SortService.sort branch."""
         from app.views.workers.manifest_load_worker import ManifestLoadWorker
 
-        errors: list[str] = []
-        worker = ManifestLoadWorker("/nonexistent/manifest.sqlite", [], parent=None)
-        worker.failed.connect(errors.append)
-        self._run_worker(qapp, worker)
+        db = _seed_grouped_manifest(tmp_path)
+        worker = ManifestLoadWorker(
+            str(db), default_sort=[("file_size_bytes", False)]
+        )
+        finished: list[list] = []
+        worker.finished.connect(finished.append)
+        worker.failed.connect(lambda _: None)
 
-        assert len(errors) == 1
+        worker.run()
 
-    def test_worker_emits_progress_strings(self, qapp, tmp_path):
-        """Worker emits at least one progress message before finishing."""
+        assert finished
+        assert len(finished[0]) == 1
+
+    def test_empty_manifest_yields_zero_groups(self, qapp, tmp_path):
         from app.views.workers.manifest_load_worker import ManifestLoadWorker
 
         db = tmp_path / "empty.sqlite"
-        write_manifest([], db)
+        with sqlite3.connect(db) as conn:
+            conn.executescript(_DDL)
+            conn.commit()
 
-        messages: list[str] = []
-        worker = ManifestLoadWorker(str(db), [], parent=None)
-        worker.progress.connect(messages.append)
-        self._run_worker(qapp, worker)
+        worker = ManifestLoadWorker(str(db), default_sort=[])
+        finished: list[list] = []
+        worker.finished.connect(finished.append)
+        worker.failed.connect(lambda _: None)
 
-        assert len(messages) >= 1
+        worker.run()
 
-    def test_worker_empty_manifest_yields_no_groups(self, qapp, tmp_path):
-        """Empty manifest produces an empty groups list (no crash)."""
+        assert finished == [[]], f"empty manifest should finish with []; got {finished!r}"
+
+
+class TestManifestLoadWorkerFailure:
+    def test_missing_manifest_emits_failed_with_message(self, qapp, tmp_path):
+        """Non-existent path → ManifestRepository.load raises → run() catches → failed.
+
+        Exercises the run() exception handler at line 50-52, which the
+        original test file's threaded approach didn't reach in the
+        coverage tracker (coverage.py is per-thread by default).
+        """
         from app.views.workers.manifest_load_worker import ManifestLoadWorker
 
-        db = tmp_path / "empty.sqlite"
-        write_manifest([], db)
+        worker = ManifestLoadWorker(
+            str(tmp_path / "does_not_exist.sqlite"), default_sort=[]
+        )
+        progress: list[str] = []
+        finished: list[list] = []
+        failed: list[str] = []
+        worker.progress.connect(progress.append)
+        worker.finished.connect(finished.append)
+        worker.failed.connect(failed.append)
 
-        finished_groups: list = []
-        worker = ManifestLoadWorker(str(db), [], parent=None)
-        worker.finished.connect(lambda groups: finished_groups.extend(groups))
-        self._run_worker(qapp, worker)
+        worker.run()
 
-        assert finished_groups == []
+        assert not finished, "no finished signal expected on failure"
+        assert len(failed) == 1, f"failed should fire once; got {failed!r}"
+        assert "Manifest not found" in failed[0] or "does_not_exist" in failed[0]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -57,3 +57,54 @@ class TestGetExifDatetimeOriginal:
 
         result = get_exif_datetime_original(str(f))
         assert result == datetime(2023, 7, 4, 14, 0, 0)
+
+    def test_falls_back_to_datetime_tag_306_when_36867_absent(self, tmp_path):
+        """When DateTimeOriginal (36867) is missing but DateTime (306) is present, use 306."""
+        f = tmp_path / "datetime_only.jpg"
+        img = Image.new("RGB", (10, 10), color=(200, 100, 50))
+        exif = img.getexif()
+        exif[306] = "2024:02:14 09:30:00"   # DateTime, not DateTimeOriginal
+        img.save(str(f), "JPEG", exif=exif.tobytes())
+
+        result = get_exif_datetime_original(str(f))
+        assert result == datetime(2024, 2, 14, 9, 30, 0)
+
+    def test_returns_none_when_exif_value_is_empty_string(self, tmp_path):
+        """An EXIF tag set to '' should not crash; return None gracefully."""
+        f = tmp_path / "empty_exif.jpg"
+        img = Image.new("RGB", (10, 10), color=(200, 100, 50))
+        exif = img.getexif()
+        exif[36867] = ""   # explicitly empty — `if not val` branch
+        img.save(str(f), "JPEG", exif=exif.tobytes())
+
+        result = get_exif_datetime_original(str(f))
+        assert result is None
+
+    def test_returns_none_when_exif_value_is_unparseable(self, tmp_path):
+        """An EXIF date in a totally unparseable format → None, not exception."""
+        f = tmp_path / "garbled.jpg"
+        img = Image.new("RGB", (10, 10), color=(200, 100, 50))
+        exif = img.getexif()
+        # Not the canonical "YYYY:MM:DD HH:MM:SS"; not a valid ISO format either
+        exif[36867] = "some garbage string"
+        img.save(str(f), "JPEG", exif=exif.tobytes())
+
+        result = get_exif_datetime_original(str(f))
+        assert result is None
+
+    def test_parses_iso_format_when_canonical_format_does_not_match(self, tmp_path):
+        """A non-EXIF date string that ISO-parses (after / and . normalization) is accepted.
+
+        The fallback `datetime.fromisoformat(val_str.replace("/", "-").replace(".", ":"))`
+        path covers files where some other tool wrote a non-canonical date.
+        """
+        f = tmp_path / "iso_format.jpg"
+        img = Image.new("RGB", (10, 10), color=(200, 100, 50))
+        exif = img.getexif()
+        # 19 chars but with `-` separators in date portion → fails the
+        # `val_str[4] == ":"` check, so falls through to fromisoformat.
+        exif[36867] = "2025-03-21T11:22:33"
+        img.save(str(f), "JPEG", exif=exif.tobytes())
+
+        result = get_exif_datetime_original(str(f))
+        assert result == datetime(2025, 3, 21, 11, 22, 33)


### PR DESCRIPTION
## Summary

Per-file coverage matters more than overall percentage — the \`fail_under=80\` bump in [#82](https://github.com/jackal998/photo-manager/pull/82) doesn't prevent a single module sitting at 0%. This PR pushes the worst offenders up so the codebase has no module under ~70% (apart from Qt-glue / hard-to-mock outliers explicitly omitted in pyproject).

## Per-module changes

### \`app/views/workers/manifest_load_worker.py\` — 37% → **100%**

The previous test file used \`worker.start() + worker.wait()\`, which runs \`_load()\` in a separate thread. \`coverage.py\` only tracks the calling thread by default, so the body of \`_load()\` never counted toward coverage even though the tests passed.

Rewrote to call \`worker.run()\` synchronously (DirectConnection signal delivery in the same thread). Same idiom \`test_scan_worker.py\` uses for the same reason. Four cases:
- happy path with one near-duplicate group
- \`default_sort\` branch when caller passes a sort spec
- empty manifest → \`finished\` with \`[]\`
- missing path → \`failed\` signal with error message

### \`app/views/handlers/file_operations.py\` — 68% → **75%**

New \`TestManifestLoadCallbacks\` class covers \`_on_manifest_loaded\`, \`_on_manifest_failed\`, \`_set_manifest_actions_enabled\` (both happy path and the \`AttributeError\` swallow branch). All four are plain callables triggered by \`ManifestLoadWorker\` signals on the GUI thread; unit-tested directly with mocked \`ui_updater\` / \`status_reporter\` / parent.

### \`infrastructure/utils.py\` — 59% → **64%**

Edge cases for \`get_exif_datetime_original\`:
- DateTime tag (306) fallback when DateTimeOriginal (36867) is absent
- empty-string EXIF value → \`None\` (the \`if not val\` branch)
- unparseable garbage value → \`None\` (caught exception)
- ISO-format datetime (post-\`/\` and \`.\` normalization) → \`fromisoformat\` path

Remaining 16 missed lines are hard-to-test fallback paths:
- PIL import failure (19-20, 53)
- the \`if not exif\` branch where \`getattr\` returns falsy
- rawpy DNG fallback (80-96 — needs a real DNG file or extensive mocking)

## Total branch coverage: 81.24% → **83.09%**

## Worst remaining gaps (post-PR)

| Module | Coverage | Why deferred |
|---|---|---|
| \`app/views/handlers/context_menu.py\` | 47% | Right-click menu + dialog wiring; needs Qt mocking infrastructure |
| \`infrastructure/utils.py\` | 64% | rawpy DNG fallback + PIL ImportError — would need real fixtures or import-time monkeypatching |
| \`app/views/tree_model_builder.py\` | 69% | QStandardItemModel building; testable but every assertion needs Qt scaffolding |
| \`scanner/hasher.py\` | 72% | RAW + HEIC fallback paths; some need real RAW fixtures |
| \`app/views/handlers/file_operations.py\` | 75% | Remaining 25% is heavy QFileDialog / QMessageBox interaction |

Each is a candidate for its own follow-up. None are blockers.

## Test plan

- [x] \`pytest -q tests/test_manifest_load_worker.py\` — 4 passed
- [x] \`pytest -q tests/test_file_operations.py\` — 33 passed (was 29; added 4)
- [x] \`pytest -q tests/test_utils.py\` — 9 passed (was 5; added 4)
- [x] \`pytest -q\` — full suite green; \`Required test coverage of 75.0% reached. Total coverage: 83.09%\`
- [x] Compatible with [#82](https://github.com/jackal998/photo-manager/pull/82) (\`fail_under=80\`) — once that lands, \`83.09% > 80%\` keeps CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)