### PR TITLE
chore: bake the 3-layer testing model into every doc/skill that mentions tests

### DIFF
--- a/.claude/skills/impact-map/SKILL.md
+++ b/.claude/skills/impact-map/SKILL.md
@@ -30,17 +30,39 @@ covered by an existing test.
 
 1. **Upstream callers** — `Grep` the symbol name across `app/`, `scanner/`,
    `core/`, `infrastructure/`, and `tests/`. List every call site with
-   `file:line`.
+   `file:line`. **Don't forget non-source consumers**: QA driver scripts
+   under `qa/scenarios/`, doc tables in `docs/testing.md`, and string
+   references in `app/views/` (button labels, menu titles, accessibility
+   names) all break the same way #72 broke when we renamed the scan
+   button without grepping.
 2. **Downstream dependencies** — what does the function call into? Note any
    I/O (DB, FS, subprocess, Qt) it relies on, since changes there cascade.
-3. **Tests covering each call site** — for every caller in (1), identify
-   which test file exercises that path. Flag callers with NO test coverage.
+   Boundary calls (subprocess to `exiftool`, `send2trash`, `rawpy`,
+   `pillow-heif`, `Image.open` on edge formats) need *layer-2* tests, not
+   just unit-level mocks. See [`docs/testing.md`](../../../docs/testing.md).
+3. **Tests covering each call site, by layer** — for every caller in (1),
+   identify which test exercises that path AND at which layer:
+     - Layer 1 (`tests/test_*.py` — unit + mock)
+     - Layer 2 (`tests/integration/` — real binaries, when present)
+     - Layer 3 (`qa/scenarios/sNN_*.py` — qa-explore E2E)
+   Flag callers with NO coverage at the layer that matters for the
+   change. Boundary changes need layer 2; UI-touching changes need
+   layer 3.
 4. **Behavior contract** — write down (in chat, not a file) the inputs,
    outputs, raised exceptions, and side-effects you intend to *preserve*
    versus *change*.
 5. **Plan test updates** — if behavior is changing, list the existing tests
    that must be updated. If a caller has NO test and your change could
    break it, add a test before editing the symbol.
+
+   **What a real test looks like** (per [`CLAUDE.md`](../../../CLAUDE.md)
+   testing rules): it triggers the failure mode with a *real* input — a
+   truncated file, a missing optional dep, a malformed payload — and
+   asserts the user-visible outcome. A test that mocks
+   `QStandardItem.setData` to raise just so the wrapped `except: pass`
+   runs is metric gaming, not bug-catching. If a defensive branch can't
+   be triggered with a real input, leave it covered by a comment in the
+   source, not by a synthetic assertion.
 
 ## Output format
 
@@ -49,18 +71,23 @@ A short table in chat, then proceed:
 ```
 | Caller                                          | Test                                              | Action needed                              |
 |-------------------------------------------------|---------------------------------------------------|--------------------------------------------|
-| app/views/handlers/file_operations.py:127       | tests/test_file_operations.py::test_batch_update  | none                                       |
-| scanner/dedup.py:88                             | (no test)                                         | add test before changing signature         |
-| infrastructure/manifest_repository.py:204       | tests/test_manifest_repository.py::test_save      | update assertion for new return shape      |
+| app/views/handlers/file_operations.py:127       | tests/test_file_operations.py::test_batch_update (L1)              | none                                       |
+| scanner/dedup.py:88                             | (no L1)                                                            | add test before changing signature         |
+| infrastructure/manifest_repository.py:204       | tests/test_manifest_repository.py::test_save (L1)                  | update assertion for new return shape      |
+| infrastructure/delete_service.py:67             | tests/test_delete_service.py (L1, mocked)  +  no L2                | add layer-2 integration test if behavior at the send2trash boundary is changing |
+| qa/scenarios/_uia.py:55 (button title constant) | qa/scenarios/sNN_*.py drivers (L3)                                 | update constant + commit message; layer-3 batch will catch drift on next run |
 ```
 
-After the edit, switch to the `update-docs` skill to keep `README.md` and
-`pyproject.toml` in sync.
+After the edit, switch to the `update-docs` skill to keep `README.md`,
+`pyproject.toml`, and the per-module residual-risk table in
+`docs/testing.md` in sync.
 
 ## Why this exists
 
-The project has 416 unit tests but they only protect what they cover. A
-change to a function used in five places is only safe if all five places
-are tested — or if you confirm in advance that the change preserves the
-behavior the untested callers depend on. This skill makes that confirmation
-explicit instead of assumed.
+The project's unit suite only protects what it covers. A change to a
+function used in five places is only safe if all five places are tested
+— or if you confirm in advance that the change preserves the behavior
+the untested callers depend on. And "tested at the right layer": a
+boundary change (subprocess, third-party lib) won't fail layer-1 mocks
+even when the real boundary is broken. This skill makes the
+caller-and-layer mapping explicit instead of assumed.

--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -8,6 +8,14 @@ description: Run the photo-manager QA agent — launches the app, explores it li
 You are the QA agent for photo-manager. Run this end-to-end without
 asking the user to fill in steps. Five phases, in order. Do not skip.
 
+This is **layer 3 of the project's testing strategy** (see
+[`docs/testing.md`](../../../docs/testing.md) and [`CLAUDE.md`](../../../CLAUDE.md)
+"Testing ground rules"). Layer 1 (`pytest`) catches refactoring bugs;
+this skill catches what tests can't — label drift, state-transition
+regressions, dialog dismissal weirdness, classifier-output sanity.
+Findings here typically become P0/P1 work; they're the bugs a real
+user would file.
+
 ## Mission
 
 Drive the app like a curious human tester. File what you observe. Do

--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -18,6 +18,11 @@ Activate this skill after implementing any non-trivial change to photo-manager s
 - After bumping the Python version
 - After adding or removing a `settings.json` key
 - After deprecating or deleting code
+- After **any change that shifts what each test layer covers**:
+  - Adding or removing an entry in `[tool.coverage.run] omit`
+  - Adding a `tests/integration/` test (layer 2)
+  - Adding or modifying a `qa/scenarios/sNN_*.py` driver (layer 3)
+  - A module's layer-1 coverage changes by ≥5pp (e.g. lifted from 73 → 90)
 
 ---
 
@@ -25,8 +30,10 @@ Activate this skill after implementing any non-trivial change to photo-manager s
 
 | File | What it tracks | Sections / spots to check |
 |------|---------------|--------------------------|
-| `README.md` | Project structure tree, test list, test count | `## Project structure` block; `tests/` subtree; `# NNN tests` comment |
-| `pyproject.toml` | Python version for Black / Ruff / Pylint | `target-version = ["py3XX"]`, `target-version = "py3XX"`, `py-version = "3.XX"` |
+| `README.md` | Project structure tree, test list, test count, "Run tests" section | `## Project structure` block; `tests/` subtree; `# NNN tests` comment; layer-summary table in "Run tests" |
+| `pyproject.toml` | Python version for Black / Ruff / Pylint; coverage `omit` list (each entry needs a justification + cross-layer pointer) | `target-version = ["py3XX"]`, `target-version = "py3XX"`, `py-version = "3.XX"`; `[tool.coverage.run] omit = [...]` comments |
+| `docs/testing.md` | The 3-layer model + per-module residual-risk table — canonical answer to "what's covered, what's not, what's the risk" | Per-module rows under each section (`scanner/`, `core/`, `infrastructure/`, `app/`); "Open work" list at the end |
+| `CLAUDE.md` | Hard testing rules (no padding, 3 layers, 70% per-file floor, 3-trigger rule for new features) | "Testing ground rules" section — only update if the policy itself changes |
 
 ---
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,100 @@ If a gate fires mid-task:
 3. Wait for "yes" before continuing
 4. Don't roll back unless I ask
 
+## Testing ground rules — non-negotiable
+
+The full testing strategy lives in [`docs/testing.md`](docs/testing.md);
+the rules below are the hard floor that applies in every session.
+
+**Precedence note:** if a global skill (e.g. `tdd-workflow`,
+`python-testing`) recommends a higher coverage percentage or a
+different testing posture, this section wins for this project. The
+70% per-file floor here is the considered choice — see the rationale
+below.
+
+### What a test exists to do
+
+A test catches bugs a real user would hit. If a test exercises code only
+to make the coverage number larger, it is **not a test** — it is metric
+gaming. Examples of metric gaming you must NOT do:
+
+- Monkeypatching `QStandardItem.setData` to raise so the wrapped
+  `except: pass` branches run.
+- Forcing `_HASH_AVAILABLE = False` to cover the ImportError fallback
+  when PIL is in fact a hard dependency.
+- Stubbing an `Image` object without `getexif` to cover the
+  defensive `if not exif: return None` guard.
+- Any test whose only assertion is "this branch was reached".
+
+If you find yourself writing one of these, stop. Either the branch
+catches a real failure mode (in which case test it with a *real* failure
+mode — a truncated file, a missing optional dep installed in CI, etc.)
+or it is dead defense and the right move is a comment in the source,
+not a synthetic test.
+
+### Three layers, three homes
+
+| Layer | What | Where it runs | Catches |
+|---|---|---|---|
+| 1 — Unit + mocks | `tests/test_*.py` | CI (`pytest`) + local | Refactoring bugs, parser logic, dispatch errors |
+| 2 — Integration with real binaries | `tests/integration/test_*.py` (`@pytest.mark.integration`, skip-if-missing) | Local only — CI doesn't have `exiftool` / RAW codecs / etc. | Boundary drift between our mocks and the real third-party tool |
+| 3 — End-to-end via `/qa-explore` | `qa/scenarios/sNN_*.py` | Local via `python -m qa.scenarios._batch` | Label drift, state-transition bugs, UX regressions |
+
+CI covers layer 1 only. Knowing which layer you're skimping on matters
+more than the headline coverage number.
+
+### When you write code
+
+Three triggers, three test homes:
+
+1. **Pure logic, no external deps** → unit test. Must clear the per-file
+   70% floor.
+2. **Touches a boundary** (subprocess, filesystem semantics,
+   third-party lib whose behavior varies by version — `exiftool`,
+   `rawpy`, `pillow-heif`, `send2trash`) → unit test for our side AND a
+   layer-2 integration test (`@pytest.mark.skipif(not <tool>_available)`).
+3. **User-facing flow** (button, dialog, menu, status bar) → extend or
+   add a `qa/scenarios/sNN_*.py` driver.
+
+### Coverage policy
+
+- Per-file floor: **70%** on layer 1, enforced by
+  `scripts/check_coverage_per_file.py`. The threshold sits at 70 (not
+  80) precisely so honest tests can clear it without padding the
+  defensive tail.
+- Global floor: 80% in `pyproject.toml`. Headroom over 70-per-file is
+  intentional.
+- The only escape is `[tool.coverage.run] omit` in `pyproject.toml`.
+  Each `omit` entry MUST carry a one-line comment naming (a) why it
+  cannot run in unit tests and (b) where it IS covered (qa-explore
+  scenario, integration test, manual smoke). Adding to omit is a
+  deliberate, reviewable change — not a per-file slip.
+
+### When you change a test
+
+- If you remove an assertion, justify it in the commit message.
+- If you wrap a flaky test in `@pytest.mark.skip`, explain why and
+  link an issue to fix it.
+- If you mark a test `@pytest.mark.skipif(...)`, state the condition
+  and what gets lost when it skips.
+- Never add a `pytest.skip()` inside a test body to make it pass — fix
+  the test or delete it.
+
+### When you remove tests
+
+A test that doesn't catch bugs is worse than no test (it costs maintenance
+and creates false confidence). If a test is genuine padding, deleting
+it is correct — but say so in the commit message and explain what
+*real* coverage gap remains afterward.
+
+### Documentation duty
+
+When you change anything that shifts what each layer covers (new module,
+new omit entry, new integration test, new qa-explore scenario), update
+the per-module table in [`docs/testing.md`](docs/testing.md). The doc
+is the canonical answer to "what's covered, what's not, what's the
+residual risk" — keep it honest.
+
 ## Setup (one-time, per machine)
 
 `.claude/settings.json` is gitignored because it contains a machine-specific

--- a/README.md
+++ b/README.md
@@ -77,9 +77,39 @@ run.bat          # activates .venv and starts main.py
 .venv\Scripts\python -m pytest
 ```
 
-The default `pytest` invocation runs with coverage (configured in `pyproject.toml`)
-and fails if branch coverage drops below the `fail_under` threshold. CI runs the
-same command on every push and pull request to `master` via `.github/workflows/tests.yml`.
+This runs **layer 1** (unit + mock-based). Coverage is configured in
+`pyproject.toml`; the build fails if global branch coverage drops below
+80% **or** any single tracked module drops below 70% (per-file gate
+enforced by `scripts/check_coverage_per_file.py`, run as a CI step
+right after `pytest`). CI runs this on every push and pull request to
+`master` via `.github/workflows/tests.yml`.
+
+Two more test layers exist locally:
+
+```powershell
+# Layer 2 — real binaries (exiftool, send2trash, rawpy / pillow-heif).
+# Skip-if-missing, so safe to run anywhere; gives real value only when
+# the binaries are installed (typically your dev box, not CI runners).
+.venv\Scripts\python -m pytest -m integration
+
+# Layer 3 — full GUI exercise via /qa-explore. Drives main.py through
+# scripted scenarios to catch UI / state-transition / copy regressions.
+.venv\Scripts\python -m qa.scenarios._batch
+```
+
+**The full strategy — what each layer catches, what it misses, and the
+per-module residual risk — lives in [`docs/testing.md`](docs/testing.md).**
+Read that before adding tests for a new feature. Short version:
+
+| Layer | Catches | Misses |
+|---|---|---|
+| 1 — Unit + mocks (CI) | Refactoring bugs, parser logic | Real third-party behavior |
+| 2 — Integration (local) | Boundary drift with real `exiftool` / `send2trash` / `rawpy` | GUI behavior |
+| 3 — `/qa-explore` (local) | Label drift, dialog regressions, state-transition bugs | Anything off the scripted path |
+
+**No test padding.** A test that exists only to clear a coverage gate
+is metric gaming, not engineering — see the testing rules in
+[`CLAUDE.md`](CLAUDE.md) for the explicit list of patterns to avoid.
 
 ---
 

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -2,6 +2,25 @@
 
 A Claude-driven exploratory tester for the PySide6 desktop app.
 
+## Where this fits
+
+The project's testing strategy has three layers (full detail in
+[`../testing.md`](../testing.md)):
+
+| Layer | What | Where it runs |
+|---|---|---|
+| 1 — Unit + mocks | `pytest` | CI + local |
+| 2 — Real binaries | `pytest -m integration` | Local only |
+| **3 — `/qa-explore`** (this) | full-GUI exploratory testing | Local only; CI possible per [#74](https://github.com/jackal998/photo-manager/issues/74) |
+
+Layer 1 verifies our parsers, dispatch, and pure logic against mocked
+boundaries. Layer 2 (when built — see #74's prerequisites) verifies the
+boundaries themselves. **Layer 3 is the only layer that exercises what
+a user actually does** — clicking menus, reading dialog text, watching
+state transitions. Bugs that only surface here (label drift, dead
+buttons, status bar regressions, dialog dismissal weirdness) are
+exactly what `pytest` cannot catch by construction.
+
 ## What it is
 
 `/qa-explore` launches `main.py`, drives the UI via the **Windows UI


### PR DESCRIPTION
## Summary

After [#84](https://github.com/jackal998/photo-manager/pull/84) established the per-file coverage gate and the canonical [`docs/testing.md`](docs/testing.md), this PR makes those rules load-bearing across the rest of the docs/skills tree so they actually stick across sessions. Without this, the rules live in one place; with it, every doc that mentions testing is consistent and points at the canonical source.

## Audit results

| Doc | Was | Now |
|---|---|---|
| `CLAUDE.md` | Said nothing about testing | Has a "Testing ground rules — non-negotiable" section: what a test exists to do (catch real bugs), explicit list of padding patterns to avoid, 3-layer model summary, 3-trigger workflow for new features, 70% per-file policy with omit justification, doc-update obligation, and a precedence note overriding global skills |
| `README.md` "Run tests" | Mentioned `pytest` + `fail_under` | Describes all 3 layers with run commands, links to `docs/testing.md`, explicitly forbids padding |
| `impact-map` SKILL | Said "which test exercises that path" — no layer awareness | Flags non-source consumers (QA drivers, UI string constants — the coupling that broke in #72), distinguishes layer 1/2/3 in caller-test mapping, includes the "what a real test looks like" anti-padding paragraph |
| `update-docs` SKILL | Trigger list ignored test-layer changes | New triggers when omit changes / integration tests added / qa-explore scenarios added / ≥5pp coverage shift; docs map adds `docs/testing.md` and `CLAUDE.md` |
| `qa-explore` SKILL | Self-contained, didn't position itself | One-paragraph header tagging it as layer 3 with cross-references |
| `docs/qa/README.md` | Said "not a regression suite" but nothing about layers | "Where this fits" 3-layer table at the top |

## Why this matters

The earlier session showed exactly how rules erode without doc backing: I shipped padding tests in #84 v1 because the only place the "no padding" rule existed was in your verbal direction during the conversation. Once you called it out, we wrote `docs/testing.md` — but a contributor (or future-me) who skips that one doc would have no signal from CLAUDE.md, the skills, or the README. This PR closes that gap.

The precedence note in `CLAUDE.md` is specifically aimed at the global `tdd-workflow` skill (which says "80%+ coverage including unit, integration, and E2E tests") — that's good general advice but doesn't match this project's considered 70%-per-file + 3-layer choice. The note ensures future sessions don't regress to the global default.

## Test plan

- [x] `pytest -q` — full suite green; 488 passed, 2 skipped; 88.40% total coverage
- [x] `python scripts/check_coverage_per_file.py` — all 33 tracked files clear 70%
- [x] No code changes (docs only) — CI risk is zero
- [x] Cross-references resolve: every relative link in the new content points at a file that exists in this PR's working tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)