### PR TITLE
chore: QA UIA focus fix, default-batch skill, permission policy

### DIFF
--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -28,9 +28,11 @@ observations grounded in screenshots — never in source code.
   `qa/sandbox/`) and writes its manifest to `qa/run-manifest.sqlite`.
   The user's root `settings.json` and `migration_manifest.sqlite` are
   not touched.
-- **Every `python main.py` launch is gated.** Pause and ask the user
-  in chat before each one, even within the same session, even if they
-  approved the previous launch. State the scenario number + title.
+- **Every `python main.py` launch is gated.** In default-batch mode
+  (Phase 3 with no user hint), get one `yes batch` approval covering
+  the whole batch, then proceed without re-prompting per scenario.
+  In subset/manual mode, pause and ask before each individual launch.
+  State the scenario number + title.
 - **No git commands at all.** No commits, no `git status`, no
   branches. (Reading `git log` is technically allowed by the project
   CLAUDE.md but you don't need it.)
@@ -88,9 +90,19 @@ If everything is already populated, skip the regen and move on.
 
 ## Phase 3 — Plan
 
-Print the full scenario menu (below). Ask the user which scenarios to
-run this session. **Don't default to all** — the 15-min cap means
-3–5 scenarios is realistic. Recommend a starter set if the user asks.
+**Default behavior — invoked with no additional prompt:** run **all
+11 scenarios** in batch via `qa.scenarios._batch`. Don't print the
+menu, don't ask which to run. Get one `yes batch` approval up front
+(per the gate rule below) and proceed. The full batch typically
+finishes in ~30–60 seconds with the focus fix in `_uia.py`.
+
+**Invoked with hints** (e.g. `/qa-explore smoke`, `/qa-explore 1,2,9`,
+`/qa-explore failed 8`): respect the hint, run only the named subset,
+still in batch.
+
+The scenario menu below is reference material — show it only if the
+user asks "what scenarios are there?" or wants to pick a subset
+manually.
 
 ### Standard scenario menu
 
@@ -120,13 +132,16 @@ run this session. **Don't default to all** — the 15-min cap means
 | 10 | Multi-source priority + cross-source dedup | `multi-source-a/` AND `multi-source-b/` (both in one scan) | EXACT_DUPLICATE across sources, near-dup grouping, source-order priority |
 | 11 | Video + Live Photo | `videos/` AND `live-photo/` | MP4/MOV recognized, no pHash for video, IMG_0001 HEIC+MOV pair grouped, action propagation |
 
-**Recommended starter sets:**
+**Subsets** (offer only when user asks for a smaller run):
 
-- "Smoke test" (~10 min): scenarios 1, 2, 9
-- "Format coverage" (~12 min): scenarios 1, 6, 8
-- "Stress probe" (~12 min): scenarios 3, 5, 11
+- "Smoke test": scenarios 1, 2, 9
+- "Format coverage": scenarios 1, 6, 8
+- "Stress probe": scenarios 3, 5, 11
+- "Failed 8": scenarios 3, 4, 5, 7, 8, 9, 10, 11 — historical re-batch
+  pattern when the first run hit harness flakes on most scenarios.
 
-If the user asks "what should I run?", suggest the smoke test.
+If the user asks "what should I run?", suggest **all** (the default).
+The full batch is fast enough to be the standard mode now.
 
 ## Phase 4 — Explore (per scenario)
 
@@ -254,9 +269,13 @@ for surprising states or edge cases the driver doesn't cover.
 For each scenario:
 
 1. **Pause and ask** in chat: `"About to launch main.py for scenario
-   N: <title>. OK?"` — wait for explicit yes. Do not batch this across
-   scenarios. (If the user asks for an end-to-end batch run, get a
-   single explicit "yes" up front for the whole batch and proceed.)
+   N: <title>. OK?"` — wait for explicit yes. In default-batch mode
+   (Phase 3 with no user hint) or when the user explicitly requests
+   an end-to-end batch run, get a single `yes batch` up front for
+   the whole batch and proceed without re-prompting per scenario.
+   The Phase-3 default for `/qa-explore` with no args **is** the
+   batch path — go straight to that prompt rather than asking which
+   scenarios to run.
 
 2. **Configure source folders** for this scenario (allowlisted, no prompt):
    ```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,11 +41,14 @@ When classification is ambiguous, treat as gated, not as ungated.
 
 So the gates aren't either too tight or too loose:
 
-- Reading public docs (npm, PyPI, GitHub via WebFetch) is NOT gated
-- Reading files inside `node_modules` / `.venv` is NOT gated
-- `git log`, `git status`, `git diff` are NOT gated
+- Reading public docs (npm, PyPI, GitHub via WebFetch) is allowed (auto-approved)
+- Reading files inside `node_modules` / `.venv` is allowed (auto-approved)
+- Read-only git commands are allowed (auto-approved): `git status`,
+  `git log`, `git diff`, `git show`, `git blame`, `git branch`,
+  `git branch --show-current`, `git remote show`
 - `pip install`, `npm install`, `git clone <url>` ARE gated
-- `git push`, `git reset --hard`, `git rebase` ARE gated
+- `git push`, `git reset --hard`, `git rebase`, `git checkout --`,
+  `git pull` ARE gated
 
 ## Mid-task pause protocol
 

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -106,6 +106,24 @@ def force_foreground(hwnd: int) -> None:
     _user32.SwitchToThisWindow(hwnd, True)
 
 
+def _focus(wrapper: UIAWrapper) -> None:
+    """Bring `wrapper`'s top-level window to the foreground before a click.
+
+    Pure pywinauto `set_focus()` does the AttachThreadInput dance, which is
+    far more reliable than Win32 `SwitchToThisWindow` against Windows'
+    foreground-lock heuristic. Falls back to SwitchToThisWindow if set_focus
+    raises (e.g. transient menu popups during teardown).
+    """
+    try:
+        wrapper.set_focus()
+    except Exception:
+        try:
+            _user32.SwitchToThisWindow(wrapper.handle, True)
+        except Exception:
+            pass
+    time.sleep(0.05)
+
+
 # ---------------------------------------------------------------------------
 # Connection helpers
 # ---------------------------------------------------------------------------
@@ -131,7 +149,7 @@ def open_menu(win: UIAWrapper, menu_title: str) -> UIAWrapper:
     Caller is responsible for clicking an item in the popup; the popup
     closes when an item is clicked or focus moves away.
     """
-    force_foreground(win.handle)
+    _focus(win)
     time.sleep(0.3)
     win.child_window(title=menu_title, control_type="MenuItem").click_input()
     time.sleep(0.5)
@@ -143,6 +161,7 @@ def open_menu(win: UIAWrapper, menu_title: str) -> UIAWrapper:
 
 def click_menu_item(popup: UIAWrapper, item_title: str) -> None:
     """Click a popup menu item. invoke() raises COMError on these — use click_input."""
+    _focus(popup)
     popup.child_window(title=item_title, control_type="MenuItem").click_input()
 
 
@@ -345,6 +364,7 @@ def run_scan_and_wait(
     """Click Start Scan, poll log until 'Done.' or error. Returns (full_log, elapsed)."""
     start_btn = dlg.child_window(title=SCAN_BTN_START, control_type="Button")
     log_edit = dlg.child_window(auto_id=SCAN_AID_LOG, control_type="Edit")
+    _focus(dlg)
     t0 = time.time()
     start_btn.invoke()
     log = wait_for_text_in(log_edit, ["Done.", "Error", "Failed"], timeout=timeout)
@@ -368,12 +388,14 @@ def extract_summary(log: str) -> list[str]:
 def close_and_load_manifest(dlg: UIAWrapper) -> None:
     """Click 'Close & Load' (post-scan dialog button)."""
     btn = dlg.child_window(title=SCAN_BTN_CLOSE_LOAD, control_type="Button")
+    _focus(dlg)
     btn.invoke()
     time.sleep(1.0)
 
 
 def cancel_scan_dialog(dlg: UIAWrapper) -> None:
     """Click the title-bar Close (×) to cancel a scan or close pre-scan."""
+    _focus(dlg)
     # Locale-named close button on the title bar
     try:
         for b in dlg.descendants(control_type="Button"):


### PR DESCRIPTION
## Summary

- **`qa/scenarios/_uia.py`**: add `_focus()` helper using
  `pywinauto.set_focus()` (with `SwitchToThisWindow` fallback), call
  it before every `click_input()` / `invoke()` site
  (`open_menu`, `click_menu_item`, `run_scan_and_wait`,
  `close_and_load_manifest`, `cancel_scan_dialog`). The previous
  `force_foreground` via `SwitchToThisWindow` was silently ignored
  under Windows foreground-lock when the agent terminal sat on top
  of the app, which made 9/11 batch scenarios fail with `menu popup
  did not appear for 'File'`. With this fix, 11/11 scenarios drive
  cleanly without manual focus management.

- **`.claude/skills/qa-explore/SKILL.md`**: Phase 3 now defaults to
  running the full 11-scenario batch via `qa.scenarios._batch` when
  `/qa-explore` is invoked with no hint. One `yes batch` approval
  covers the whole batch in default mode; subset/manual mode keeps
  per-launch gating. Phase 4 step 1 and the "Hard rules" gate bullet
  updated to match.

- **`CLAUDE.md`**: boundary clarifications now say read-only git is
  "allowed (auto-approved)" rather than "NOT gated"; explicit list
  expanded (`git show`, `git blame`, `git branch`, `git branch
  --show-current`, `git remote show`). Gated list expanded with
  `git checkout --` and `git pull`.

## Test plan

- [x] `qa.scenarios._batch` (full 11-scenario run) — passed 11/11 with
      no manual window-focus management; before this PR it was 2/11
      depending on which app happened to be frontmost.
- [x] `qa.scenarios.s01_happy_path` (single scenario) — output
      matches pre-PR baseline (Migration Manifest Summary, group rows,
      menu enable/disable transitions).
- [x] `python -c "from qa.scenarios import _uia"` — module imports
      cleanly with the new `_focus` helper.
- [ ] Verify CLAUDE.md boundary changes don't conflict with existing
      `.claude/settings.json` (tracked) ask-rules — they don't, since
      `ask` rules and `allow` rules are independent layers.

## Filed during the QA run

Three issues filed against the manifest scanner / dialog flow:

- #86 — Empty-folder scan: Close & Load button missing after zero-file scan
- #87 — Manifest summary "Total files scanned" undercounts decode-skipped files
- #88 — Live Photo HEIC+MOV pair does not form a group

These are not addressed by this PR (it's tooling/policy only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)