### PR TITLE
qa(s12): drive Save Manifest end-to-end; fix #91 WAL+copy data loss

### DIFF
--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -99,7 +99,7 @@ If everything is already populated, skip the regen and move on.
 ## Phase 3 — Plan
 
 **Default behavior — invoked with no additional prompt:** run **all
-11 scenarios** in batch via `qa.scenarios._batch`. Don't print the
+12 scenarios** in batch via `qa.scenarios._batch`. Don't print the
 menu, don't ask which to run. Get one `yes batch` approval up front
 (per the gate rule below) and proceed. The full batch typically
 finishes in ~30–60 seconds with the focus fix in `_uia.py`.
@@ -259,6 +259,43 @@ popup.child_window(title="Scan Sources…", control_type="MenuItem").click_input
 with locale-specific names (e.g. `系統`, `最小化` on a zh-TW Windows).
 Ignore that subtree — anything under `auto_id` starting with
 `QApplication.MainWindow` is the real app.
+
+**Native (non-Qt) Windows dialogs are fully locale-translated.**
+QFileDialog opens a Windows Common Item Dialog whose control names are
+in the OS display language: on zh-TW Windows the filename ComboBox is
+`檔案名稱:`, not `File name:`. **Don't hard-code English titles for
+controls in native dialogs.** Use locale-independent discovery — for
+the Save dialog filename Edit, find "the only `ComboBox` descendant
+that contains an `Edit`" (the `Save as type:` ComboBox has no editable
+Edit, so this picks the right one regardless of locale). Qt-managed
+widgets (everything inside the main window, scan dialog, message
+boxes) keep their English names because those come from
+photo-manager's source — locale-translation only hits the OS dialogs.
+
+**Setting Edit values: prefer UIA `ValuePattern.SetValue` over typing.**
+Two reasons:
+1. **IMEs intercept keystrokes.** `pywinauto.keyboard.send_keys("hello")`
+   on a system with a phonetic IME active (bopomofo, pinyin, hangul,
+   kana) gets eaten by the IME and produces phonetic glyphs instead
+   of the Latin string. Modifier-key combos (Ctrl+A/Ctrl+V/Enter)
+   bypass IME, but free text doesn't. The user's session may have
+   any IME active — your driver can't assume Latin keystrokes land.
+2. **Focus is fragile.** Typing requires the right widget to have
+   focus *at the moment of the keystroke*. Native dialogs steal
+   focus, popups steal focus, taskbar tooltips steal focus.
+
+`ValuePattern.SetValue` is a UIA-level write that bypasses keyboard,
+focus, and IME entirely:
+
+```python
+filename_edit.iface_value.SetValue(str(target_path))
+```
+
+Use it whenever you need to set an Edit's content. Reserve `send_keys`
+for keystrokes the application interprets *as keystrokes* (Enter to
+confirm, Esc to cancel, Ctrl+S, arrow keys for navigation). The
+existing `qa/scenarios/_uia.save_manifest_via_native_dialog` is the
+reference pattern — copy from it.
 
 **When UIA returns nothing useful** (custom-painted widget, blank
 `Custom` element with no children): that's your cue to fall back to a
@@ -477,6 +514,7 @@ running.
 | 9 | Walker exclusion rules | `qa.scenarios.s09_walker_exclusions` | ✓ ready |
 | 10 | Multi-source priority + dedup | `qa.scenarios.s10_multi_source` | ✓ ready |
 | 11 | Video + Live Photo | `qa.scenarios.s11_video_live` | ✓ ready |
+| 12 | Save Manifest Decisions | `qa.scenarios.s12_save_manifest` | ✓ ready |
 
 Source-folder configuration is per-scenario. Before launching the
 app, write the right `qa/settings.json` by running:
@@ -499,15 +537,15 @@ output.
 in one go, use `qa.scenarios._batch`:
 
 ```
-.venv/Scripts/python.exe -m qa.scenarios._batch              # all 10 (s02–s11)
+.venv/Scripts/python.exe -m qa.scenarios._batch              # all 12 (s01–s12)
 .venv/Scripts/python.exe -m qa.scenarios._batch s04_corrupted s09_walker_exclusions
 ```
 
 For each scenario it: configures `qa/settings.json` → launches
 `main.py` → waits 3.5 s → runs the driver → closes the window →
 waits for the subprocess to exit → moves to the next. Prints a final
-SUMMARY table with rc per scenario. The whole batch (10 scenarios)
-typically finishes in ~80–120 seconds. Each app launch is still a
+SUMMARY table with rc per scenario. The whole batch (12 scenarios)
+typically finishes in ~90–140 seconds. Each app launch is still a
 real launch — get the user's "yes batch" once before starting.
 
 **Optional optimization — skip the per-run Bash prompt.** Add this

--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -140,6 +140,7 @@ class FileOperationsHandler:
         """Export current decisions to a (possibly new) manifest file."""
         import os
         import shutil
+        import sqlite3
 
         manifest_path = getattr(self, "_manifest_path", None)
         if not manifest_path:
@@ -159,6 +160,15 @@ class FileOperationsHandler:
             if os.path.normcase(os.path.normpath(save_path)) != os.path.normcase(
                 os.path.normpath(manifest_path)
             ):
+                # #91: scanner writes the manifest in WAL mode and may still
+                # hold an active connection with uncheckpointed writes in the
+                # -wal sibling. shutil.copy2 only copies the main .sqlite, so
+                # without a checkpoint the destination ends up with no schema.
+                ckpt_conn = sqlite3.connect(manifest_path)
+                try:
+                    ckpt_conn.execute("PRAGMA wal_checkpoint(FULL)")
+                finally:
+                    ckpt_conn.close()
                 shutil.copy2(manifest_path, save_path)
 
             from infrastructure.manifest_repository import ManifestRepository

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -128,11 +128,11 @@ With the UIA-first drivers (current architecture):
 - Phase 1 (orient): ~10 s
 - Phase 2 (fixtures): ~30 s if regen needed, else instant
 - Phase 4 (explore): **~10–30 s per scenario** including launch +
-  scan + driver. The whole batch (10 scenarios via `_batch.py`) runs
-  end-to-end in ~80–120 s.
+  scan + driver. The whole batch (12 scenarios via `_batch.py`) runs
+  end-to-end in ~90–140 s.
 - Phase 5 (report): ~10–30 s per finding to file as a GitHub issue
 
-The skill ships with 11 standard scenarios. A batch run of all 10
+The skill ships with 12 standard scenarios. A batch run of all 11
 non-s01 scenarios via `python -m qa.scenarios._batch` is realistic;
 the user can also pick subsets ("Smoke test" #1/#2/#9 etc.).
 
@@ -151,6 +151,7 @@ the user can also pick subsets ("Smoke test" #1/#2/#9 etc.).
 | 9 | `qa.scenarios.s09_walker_exclusions` | `walker-exclusions` |
 | 10 | `qa.scenarios.s10_multi_source` | `multi-source-a`, `multi-source-b` |
 | 11 | `qa.scenarios.s11_video_live` | `videos`, `live-photo` |
+| 12 | `qa.scenarios.s12_save_manifest` | `near-duplicates` |
 
 Source-folder mapping lives in `qa/scenarios/_config.py`. To add a new
 scenario:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -109,7 +109,7 @@ calls out what would be uncaught even with a green CI.
 | `app/views/tree_model_builder.py` | 76% | s01, s06, s07, s10 | uncovered 24% is `setData()` `except: pass` defensive wrappers — only triggered if Qt's setData raises, which doesn't happen in practice |
 | `app/views/workers/manifest_load_worker.py` | 100% | every load | none |
 | `app/views/workers/scan_worker.py` | 91% | every scan scenario | minor — cancellation timing branch hard to test deterministically |
-| `app/views/handlers/file_operations.py` | 81% | s01 + every scenario that loads a manifest | uncovered 19% is QFileDialog interaction (file picker for save / open manifest) — covered by qa-explore but not asserted directly |
+| `app/views/handlers/file_operations.py` | 81% | s01 + every scenario that loads a manifest, plus s12 for Save Manifest Decisions end-to-end | uncovered 19% is QFileDialog interaction (file picker for open manifest) — Save Manifest is now driven by s12, with the WAL-checkpoint branch (#91) covered by both layer-1 unit test and the s12 layer-3 driver |
 | `app/views/handlers/context_menu.py` | 88% | s01 (menu probes) | low — `_open_folder` Windows + non-Windows + fallback paths covered; remaining 12% is Protocol stub bodies |
 | `app/views/dialogs/scan_dialog.py` | 84% | every scenario opens it | uncovered 16% is QFileDialog browse interaction + a few worker-signal branches |
 | `app/views/dialogs/execute_action_dialog.py` | 83% | s13 (planned, will exercise real send2trash through the GUI) | uncovered 17% is `_on_tree_context_menu` + the actual destructive `_on_execute` flow — qa-explore s13 will cover the happy path; spot-add a layer-2 test only if a destructive-flow bug surfaces that's hard to reproduce via the GUI |

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -34,6 +34,7 @@ ALL_SCENARIOS = [
     "s09_walker_exclusions",
     "s10_multi_source",
     "s11_video_live",
+    "s12_save_manifest",
 ]
 
 

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -26,6 +26,7 @@ SCENARIO_SOURCES: dict[str, list[str]] = {
     "s09_walker_exclusions": ["qa/sandbox/walker-exclusions"],
     "s10_multi_source":    ["qa/sandbox/multi-source-a", "qa/sandbox/multi-source-b"],
     "s11_video_live":      ["qa/sandbox/videos", "qa/sandbox/live-photo"],
+    "s12_save_manifest":   ["qa/sandbox/near-duplicates"],
 }
 
 

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -393,6 +393,89 @@ def close_and_load_manifest(dlg: UIAWrapper) -> None:
     time.sleep(1.0)
 
 
+def save_manifest_via_native_dialog(
+    pid: int, target_path: str, dialog_timeout: float = 10
+) -> None:
+    """Drive the native QFileDialog opened by File > Save Manifest Decisions….
+
+    1. Locate the filename Edit (ComboBox > Edit, locale-independent).
+    2. Set its value via UIA's ValuePattern.SetValue — bypasses keyboard
+       (so IMEs like bopomofo can't intercept) and bypasses the
+       locale-specific ComboBox label name.
+    3. Press Enter to invoke Save.
+    4. Wait for the result QMessageBox (success "Save Manifest" or
+       failure "Save Manifest Error") and dismiss it with Enter.
+       Raises if the result was the error dialog.
+    """
+    from pywinauto.keyboard import send_keys
+
+    save_hwnd = wait_for_dialog(pid, "Save Manifest Decisions", timeout=dialog_timeout)
+    save_dlg = connect_by_handle(save_hwnd)
+    _focus(save_dlg)
+    time.sleep(0.5)
+
+    # Find the filename Edit: the only Edit nested inside a ComboBox in the
+    # native Save dialog. (The other ComboBox is "Save as type:", which has
+    # no editable Edit descendant.) Locale-independent.
+    filename_edit = None
+    for combo in save_dlg.descendants(control_type="ComboBox"):
+        try:
+            edits = combo.descendants(control_type="Edit")
+            if edits:
+                filename_edit = edits[0]
+                break
+        except Exception:
+            continue
+    if filename_edit is None:
+        raise RuntimeError("filename Edit (ComboBox > Edit) not found in Save dialog")
+
+    # Set value via UIA's ValuePattern — bypasses keyboard, focus, and IME.
+    # Avoids both IME interception (bopomofo, etc.) and the locale-specific
+    # name of the filename ComboBox label.
+    filename_edit.iface_value.SetValue(str(target_path))
+    time.sleep(0.2)
+    send_keys("{ENTER}")
+
+    # Wait for either the success "Save Manifest" QMessageBox or the
+    # "Save Manifest Error" critical dialog. Both are dismissed with Enter.
+    # Surface the result so a failing scenario can tell which one appeared.
+    deadline = time.time() + dialog_timeout
+    info_hwnd = None
+    matched_title = None
+    while time.time() < deadline:
+        for hwnd, _cls, t in list_process_windows(pid):
+            if t in ("Save Manifest", "Save Manifest Error"):
+                info_hwnd = hwnd
+                matched_title = t
+                break
+        if info_hwnd:
+            break
+        time.sleep(0.2)
+    if info_hwnd is None:
+        windows = [t for _, _, t in list_process_windows(pid)]
+        raise TimeoutError(
+            f"neither 'Save Manifest' nor 'Save Manifest Error' appeared "
+            f"within {dialog_timeout}s; visible windows={windows!r}"
+        )
+    print(f"  result_dialog_title={matched_title!r}", flush=True)
+
+    info_dlg = connect_by_handle(info_hwnd)
+    if matched_title == "Save Manifest Error":
+        for label in info_dlg.descendants(control_type="Text"):
+            try:
+                txt = (label.window_text() or "").strip()
+                if txt:
+                    print(f"  error_text: {txt}", flush=True)
+            except Exception:
+                continue
+    _focus(info_dlg)
+    time.sleep(0.2)
+    send_keys("{ENTER}")
+    time.sleep(0.3)
+    if matched_title == "Save Manifest Error":
+        raise RuntimeError("Save dialog reported an error — see error_text above")
+
+
 def cancel_scan_dialog(dlg: UIAWrapper) -> None:
     """Click the title-bar Close (×) to cancel a scan or close pre-scan."""
     _focus(dlg)

--- a/qa/scenarios/s12_save_manifest.py
+++ b/qa/scenarios/s12_save_manifest.py
@@ -1,0 +1,104 @@
+"""Scenario 12 — File > Save Manifest Decisions.
+
+Required source: qa/sandbox/near-duplicates (5 files → 1 group of 5).
+
+Drives the Save Manifest Decisions flow end-to-end:
+  scan → close & load → File menu → Save Manifest Decisions… →
+  native Save dialog → success message box → status-bar verify →
+  open the saved sqlite and confirm the migration_manifest table is intact.
+
+Catches drift in: Save Manifest menu label / dialog title / success message
+text / status-bar copy / ManifestRepository.save() row count.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+from qa.scenarios import _uia
+
+REPO = Path(__file__).resolve().parents[2]
+TARGET = REPO / "qa" / "sandbox" / "_disposable" / "s12_manifest.sqlite"
+
+
+def main() -> int:
+    print("scenario: s12_save_manifest")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+    pid = win.process_id()
+
+    print("step: pre_clean")
+    TARGET.parent.mkdir(parents=True, exist_ok=True)
+    if TARGET.exists():
+        TARGET.unlink()
+    print(f"  target={TARGET}")
+    print(f"  target_exists_before={TARGET.exists()}")
+
+    print("step: open_scan_dialog")
+    dlg, _ = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    for line in _uia.extract_summary(log):
+        if line:
+            print(f"  log: {line}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+
+    print("step: open_save_dialog")
+    _, win = _uia.connect_main()
+    _uia.menu_path(win, _uia.MENU_FILE, _uia.FILE_SAVE_MANIFEST)
+
+    print("step: drive_save_dialog")
+    _uia.save_manifest_via_native_dialog(pid, str(TARGET.resolve()))
+
+    print("step: verify_artifact")
+    print(f"  target_exists={TARGET.is_file()}")
+    if not TARGET.is_file():
+        print("FAIL: saved manifest file did not appear at target path")
+        return 1
+
+    header = TARGET.read_bytes()[:16]
+    print(f"  target_is_sqlite={header.startswith(b'SQLite format 3')}")
+
+    conn = sqlite3.connect(str(TARGET))
+    try:
+        tables = [r[0] for r in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()]
+        print(f"  tables={sorted(tables)}")
+        if "migration_manifest" not in tables:
+            print("FAIL: migration_manifest table missing in saved sqlite")
+            return 1
+        total = conn.execute(
+            "SELECT COUNT(*) FROM migration_manifest"
+        ).fetchone()[0]
+        grouped = conn.execute(
+            "SELECT COUNT(*) FROM migration_manifest WHERE group_id IS NOT NULL"
+        ).fetchone()[0]
+        executed_zero = conn.execute(
+            "SELECT COUNT(*) FROM migration_manifest WHERE executed=0"
+        ).fetchone()[0]
+        print(f"  manifest_total_rows={total}")
+        print(f"  manifest_grouped_rows={grouped}")
+        print(f"  manifest_executed_zero_rows={executed_zero}")
+    finally:
+        conn.close()
+
+    print("step: verify_status_bar")
+    _, win = _uia.connect_main()
+    status = _uia.read_status_bar_text(win)
+    print(f"  status_bar_text={status!r}")
+    if "Manifest saved" not in status:
+        print("WARN: status bar did not contain 'Manifest saved' (may have cleared on timeout)")
+
+    print("scenario: s12_save_manifest DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -443,6 +443,46 @@ class TestSaveManifestDecisions:
         assert _read_decision(Path(new_path), "/a.jpg") == "delete"
         assert handler._manifest_path == new_path
 
+    @patch("PySide6.QtWidgets.QMessageBox.information")
+    def test_saves_when_source_has_uncheckpointed_wal(self, _mock, tmp_path):
+        """Regression for #91: source manifest with uncheckpointed WAL writes
+        must still produce a populated copy at the new path. Without the fix,
+        shutil.copy2 captured only the empty 4KB main .sqlite and save()
+        failed with 'no such table: migration_manifest'."""
+        recs = [_rec("/a.jpg", decision="delete")]
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=recs)])
+
+        db = tmp_path / "manifest.sqlite"
+        # Build the manifest in WAL mode and KEEP the connection open —
+        # mimics the scanner having just finished writing without checkpoint.
+        src_conn = sqlite3.connect(str(db))
+        try:
+            src_conn.execute("PRAGMA journal_mode = WAL")
+            src_conn.executescript(_DDL)
+            src_conn.execute(
+                "INSERT INTO migration_manifest (source_path, action) VALUES (?, ?)",
+                ("/a.jpg", "MOVE"),
+            )
+            src_conn.commit()
+            wal_path = Path(str(db) + "-wal")
+            assert wal_path.exists() and wal_path.stat().st_size > 0, (
+                "test setup: data should be in -wal sibling"
+            )
+
+            new_path = str(tmp_path / "exported.sqlite")
+            handler, _, _ = _make_handler(vm, str(db))
+
+            with patch(
+                "PySide6.QtWidgets.QFileDialog.getSaveFileName",
+                return_value=(new_path, ""),
+            ):
+                handler.save_manifest_decisions()
+
+            assert _read_decision(Path(new_path), "/a.jpg") == "delete"
+            assert handler._manifest_path == new_path
+        finally:
+            src_conn.close()
+
     def test_dialog_cancel_is_noop(self, tmp_path):
         """Cancelling the save dialog leaves the manifest unchanged."""
         recs = [_rec("/a.jpg")]


### PR DESCRIPTION
## Summary

- Add **s12_save_manifest** layer-3 driver covering File → Save Manifest Decisions… end-to-end (the only File-menu action with no driver coverage prior to this PR).
- **Fix #91** — `shutil.copy2` of the source manifest captured only an empty 4KB main `.sqlite` because the scanner's connection had uncheckpointed writes in the `-wal` sibling. `save()` then ran against the empty copy and failed with `no such table: migration_manifest`. Real-user data-loss path: anyone clicking Save Manifest immediately after a scan completes hit it. Fix: `PRAGMA wal_checkpoint(FULL)` via a second connection before copy.
- Capture lessons learned (IME interception of `send_keys`, locale-translated native Windows dialogs, prefer UIA `ValuePattern.SetValue` over typing) in the qa-explore skill so future drivers don't re-discover them.

## Why one PR

The scenario, the bug it surfaced, the fix, and the skill updates are tightly coupled — they're all parts of the same finding. The scenario exists to catch this kind of bug; the bug existed because the scenario didn't exist. Splitting them would obscure the cause-and-effect.

## What's in here

| File | Change |
|---|---|
| [`qa/scenarios/s12_save_manifest.py`](qa/scenarios/s12_save_manifest.py) | NEW — driver |
| [`qa/scenarios/_uia.py`](qa/scenarios/_uia.py) | NEW helper `save_manifest_via_native_dialog` (locale-independent control discovery + UIA `ValuePattern.SetValue` to bypass IME) |
| [`qa/scenarios/_config.py`](qa/scenarios/_config.py), [`_batch.py`](qa/scenarios/_batch.py) | s12 registered |
| [`app/views/handlers/file_operations.py`](app/views/handlers/file_operations.py) | #91 fix: WAL checkpoint before `shutil.copy2` |
| [`tests/test_file_operations.py`](tests/test_file_operations.py) | Layer-1 regression test for #91 |
| [`.claude/skills/qa-explore/SKILL.md`](.claude/skills/qa-explore/SKILL.md) | New Phase 4.0.5 paragraphs on IME + locale + ValuePattern; scenario table + counts |
| [`docs/qa/README.md`](docs/qa/README.md), [`docs/testing.md`](docs/testing.md) | Scenario count + per-module table |

## Test plan

- [x] `.venv/Scripts/python.exe -m pytest --no-cov` → **503 passed, 2 skipped** (+1 new test)
- [x] `.venv/Scripts/python.exe scripts/check_coverage_per_file.py` → all 33 files clear 70% floor; total 88%
- [x] `.venv/Scripts/python.exe -m qa.scenarios._batch s12_save_manifest` → rc=0, `result_dialog_title='Save Manifest'`, target sqlite has `migration_manifest` table with 5 rows, status bar shows `Manifest saved (5 decisions written)`
- [ ] Full batch (`.venv/Scripts/python.exe -m qa.scenarios._batch`) — recommend running once before merge to confirm s12 plays well alongside the other 11 scenarios

## Closes

- Closes #91 (fix + regression test)
- Already closed earlier this session: #47 (verified not reproducible — walker correctly returns 2 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)