### PR TITLE
qa(s13): drive Execute Action end-to-end (destructive recycle-bin send)

### DIFF
--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -99,7 +99,7 @@ If everything is already populated, skip the regen and move on.
 ## Phase 3 — Plan
 
 **Default behavior — invoked with no additional prompt:** run **all
-12 scenarios** in batch via `qa.scenarios._batch`. Don't print the
+13 scenarios** in batch via `qa.scenarios._batch`. Don't print the
 menu, don't ask which to run. Get one `yes batch` approval up front
 (per the gate rule below) and proceed. The full batch typically
 finishes in ~30–60 seconds with the focus fix in `_uia.py`.
@@ -515,6 +515,7 @@ running.
 | 10 | Multi-source priority + dedup | `qa.scenarios.s10_multi_source` | ✓ ready |
 | 11 | Video + Live Photo | `qa.scenarios.s11_video_live` | ✓ ready |
 | 12 | Save Manifest Decisions | `qa.scenarios.s12_save_manifest` | ✓ ready |
+| 13 | Execute Action (destructive — sends to recycle bin) | `qa.scenarios.s13_execute_action` | ✓ ready |
 
 Source-folder configuration is per-scenario. Before launching the
 app, write the right `qa/settings.json` by running:
@@ -537,7 +538,7 @@ output.
 in one go, use `qa.scenarios._batch`:
 
 ```
-.venv/Scripts/python.exe -m qa.scenarios._batch              # all 12 (s01–s12)
+.venv/Scripts/python.exe -m qa.scenarios._batch              # all 13 (s01–s13)
 .venv/Scripts/python.exe -m qa.scenarios._batch s04_corrupted s09_walker_exclusions
 ```
 

--- a/docs/qa/README.md
+++ b/docs/qa/README.md
@@ -128,11 +128,11 @@ With the UIA-first drivers (current architecture):
 - Phase 1 (orient): ~10 s
 - Phase 2 (fixtures): ~30 s if regen needed, else instant
 - Phase 4 (explore): **~10–30 s per scenario** including launch +
-  scan + driver. The whole batch (12 scenarios via `_batch.py`) runs
-  end-to-end in ~90–140 s.
+  scan + driver. The whole batch (13 scenarios via `_batch.py`) runs
+  end-to-end in ~100–155 s.
 - Phase 5 (report): ~10–30 s per finding to file as a GitHub issue
 
-The skill ships with 12 standard scenarios. A batch run of all 11
+The skill ships with 13 standard scenarios. A batch run of all 12
 non-s01 scenarios via `python -m qa.scenarios._batch` is realistic;
 the user can also pick subsets ("Smoke test" #1/#2/#9 etc.).
 
@@ -152,6 +152,7 @@ the user can also pick subsets ("Smoke test" #1/#2/#9 etc.).
 | 10 | `qa.scenarios.s10_multi_source` | `multi-source-a`, `multi-source-b` |
 | 11 | `qa.scenarios.s11_video_live` | `videos`, `live-photo` |
 | 12 | `qa.scenarios.s12_save_manifest` | `near-duplicates` |
+| 13 | `qa.scenarios.s13_execute_action` ⚠ destructive | `_disposable/s13_source` (regenerated each run; deleted files go to the operator's recycle bin) |
 
 Source-folder mapping lives in `qa/scenarios/_config.py`. To add a new
 scenario:

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -35,6 +35,7 @@ ALL_SCENARIOS = [
     "s10_multi_source",
     "s11_video_live",
     "s12_save_manifest",
+    "s13_execute_action",
 ]
 
 

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -27,6 +27,7 @@ SCENARIO_SOURCES: dict[str, list[str]] = {
     "s10_multi_source":    ["qa/sandbox/multi-source-a", "qa/sandbox/multi-source-b"],
     "s11_video_live":      ["qa/sandbox/videos", "qa/sandbox/live-photo"],
     "s12_save_manifest":   ["qa/sandbox/near-duplicates"],
+    "s13_execute_action":  ["qa/sandbox/_disposable/s13_source"],
 }
 
 

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -62,6 +62,17 @@ SCAN_AID_SOURCE_TABLE = (
     "QApplication.ScanDialog.QSplitter._SourceListWidget.QTableWidget"
 )
 
+# Execute Action dialog
+EXECUTE_DIALOG_TITLE = "Execute Actions — Review"
+EXECUTE_BTN = "Execute"
+EXECUTE_BTN_SELECT_BY_REGEX = "Select by Field/Regex…"
+EXECUTE_CONFIRM_TITLE = "All Files Will Be Deleted"
+
+# Set Action by Field/Regex dialog (inner — opened from Execute dialog)
+ACTION_DIALOG_TITLE = "Set Action by Field/Regex"
+ACTION_DIALOG_BTN_APPLY = "Apply"
+ACTION_DIALOG_BTN_CLOSE = "Close"
+
 
 # ---------------------------------------------------------------------------
 # Win32 plumbing — needed because Qt menu popups are top-level windows but
@@ -474,6 +485,127 @@ def save_manifest_via_native_dialog(
     time.sleep(0.3)
     if matched_title == "Save Manifest Error":
         raise RuntimeError("Save dialog reported an error — see error_text above")
+
+
+def open_execute_action_dialog(win: UIAWrapper) -> tuple[UIAWrapper, int]:
+    """Open Action > Execute Action… and return (dialog_wrapper, dialog_hwnd)."""
+    pid = win.process_id()
+    menu_path(win, MENU_ACTION, ACTION_EXECUTE)
+    hwnd = wait_for_dialog(pid, EXECUTE_DIALOG_TITLE, timeout=5)
+    return connect_by_handle(hwnd), hwnd
+
+
+def mark_all_via_regex(
+    execute_dlg: UIAWrapper,
+    field: str,
+    regex: str,
+    action_label: str,
+    dialog_timeout: float = 5,
+) -> None:
+    """Open the inner Set Action by Field/Regex dialog from inside the
+    Execute Action dialog, set field+regex+action, click Apply, then Close.
+
+    `field` is the visible text in the Field combo (e.g. "File Name").
+    `regex` is set via UIA's ValuePattern to bypass IME (see save-manifest
+    helper for the same rationale).
+    `action_label` is the visible label in the Set Action combo
+    (e.g. "delete" — see SETTABLE_DECISIONS in app/views/constants.py).
+    """
+    pid = execute_dlg.process_id()
+    select_btn = execute_dlg.child_window(
+        title=EXECUTE_BTN_SELECT_BY_REGEX, control_type="Button"
+    )
+    _focus(execute_dlg)
+    select_btn.click_input()
+
+    action_hwnd = wait_for_dialog(pid, ACTION_DIALOG_TITLE, timeout=dialog_timeout)
+    action_dlg = connect_by_handle(action_hwnd)
+    _focus(action_dlg)
+    time.sleep(0.3)
+
+    # Two ComboBoxes in this dialog: Field combo (top) and Set Action combo
+    # (bottom). Order is deterministic — find them by position (top-most first).
+    combos = sorted(
+        action_dlg.descendants(control_type="ComboBox"),
+        key=lambda c: c.rectangle().top,
+    )
+    if len(combos) < 2:
+        raise RuntimeError(
+            f"action dialog: expected >= 2 ComboBoxes, found {len(combos)}"
+        )
+    field_combo, action_combo = combos[0], combos[1]
+    field_combo.select(field)
+    time.sleep(0.1)
+
+    # Regex line edit — set via ValuePattern to bypass IME interception.
+    edits = action_dlg.descendants(control_type="Edit")
+    if not edits:
+        raise RuntimeError("action dialog: no Edit control found for regex")
+    # Filter out Edits inside ComboBoxes (those belong to the combos, not
+    # the standalone QLineEdit).
+    standalone_edits = []
+    for e in edits:
+        try:
+            parent = e.parent()
+            if parent.element_info.control_type != "ComboBox":
+                standalone_edits.append(e)
+        except Exception:
+            standalone_edits.append(e)
+    if not standalone_edits:
+        raise RuntimeError("action dialog: no standalone Edit (regex line) found")
+    regex_edit = standalone_edits[0]
+    regex_edit.iface_value.SetValue(regex)
+    time.sleep(0.1)
+
+    action_combo.select(action_label)
+    time.sleep(0.1)
+
+    apply_btn = action_dlg.child_window(
+        title=ACTION_DIALOG_BTN_APPLY, control_type="Button"
+    )
+    apply_btn.click_input()
+    time.sleep(0.3)
+
+    close_btn = action_dlg.child_window(
+        title=ACTION_DIALOG_BTN_CLOSE, control_type="Button"
+    )
+    close_btn.click_input()
+    time.sleep(0.3)
+
+
+def execute_and_confirm(
+    execute_dlg: UIAWrapper, dialog_timeout: float = 10
+) -> None:
+    """Click Execute on the Execute Action dialog, then Yes on the
+    'All Files Will Be Deleted' confirmation QMessageBox.
+
+    Returns when the Execute Action dialog has accepted (closed) — that's
+    the signal that send2trash + mark_executed have completed.
+    """
+    pid = execute_dlg.process_id()
+    execute_btn = execute_dlg.child_window(title=EXECUTE_BTN, control_type="Button")
+    _focus(execute_dlg)
+    execute_btn.click_input()
+
+    confirm_hwnd = wait_for_dialog(pid, EXECUTE_CONFIRM_TITLE, timeout=dialog_timeout)
+    confirm_dlg = connect_by_handle(confirm_hwnd)
+    _focus(confirm_dlg)
+    time.sleep(0.2)
+    yes_btn = confirm_dlg.child_window(title="Yes", control_type="Button")
+    yes_btn.click_input()
+    time.sleep(0.3)
+
+    # Wait for the Execute dialog to close (signals execution completed).
+    deadline = time.time() + dialog_timeout
+    while time.time() < deadline:
+        windows = [t for _, _, t in list_process_windows(pid)]
+        if EXECUTE_DIALOG_TITLE not in windows:
+            return
+        time.sleep(0.2)
+    raise TimeoutError(
+        f"Execute Action dialog did not close within {dialog_timeout}s after "
+        f"confirming the deletion prompt"
+    )
 
 
 def cancel_scan_dialog(dlg: UIAWrapper) -> None:

--- a/qa/scenarios/s13_execute_action.py
+++ b/qa/scenarios/s13_execute_action.py
@@ -1,0 +1,159 @@
+"""Scenario 13 — Execute Action (destructive: sends files to recycle bin).
+
+Required source: qa/sandbox/_disposable/s13_source/ (regenerated each run by
+the driver — 5 fresh JPEGs that get sent to the user's recycle bin when
+Execute fires).
+
+Drives the destructive Execute Action flow end-to-end:
+  regen disposable fixture (5 JPEGs) → scan → close & load →
+  open Execute Action dialog → Set by Field/Regex (field=File Name,
+  regex=.+, action=delete) → Apply → Close inner dialog → click Execute →
+  confirm "All Files Will Be Deleted" → Yes →
+  verify (a) original files no longer exist, (b) manifest rows for those
+  paths have executed=1.
+
+⚠ HEADS-UP: every run sends 5 files to the operator's real Windows recycle
+bin. The fixture is regenerated next run, so the bin grows by 5 each run
+until manually emptied. Acceptable per #80's destructive-scenario guidance.
+
+Catches drift in: Execute Action menu label / Execute dialog title / amber
+warning trigger / confirmation prompt copy / send2trash integration /
+ManifestRepository.mark_executed() write path.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import numpy as np
+from PIL import Image
+
+from qa.scenarios import _uia
+
+REPO = Path(__file__).resolve().parents[2]
+FIXTURE_DIR = REPO / "qa" / "sandbox" / "_disposable" / "s13_source"
+MANIFEST_PATH = REPO / "qa" / "run-manifest.sqlite"
+NUM_FILES = 5
+
+
+def _regen_fixture() -> list[Path]:
+    """Wipe FIXTURE_DIR and write NUM_FILES fresh near-duplicate JPEGs.
+
+    Mirrors scripts/make_qa_sandbox.make_near_duplicates: one base gradient
+    image, saved at descending JPEG qualities with distinct EXIF dates.
+    The scanner groups them as REVIEW_DUPLICATE/EXACT (one near-duplicate
+    group of NUM_FILES) so they show up in the Execute Action dialog's
+    review tree. Random gradients (no fixed seed) so each run produces
+    a fresh content set the operator's recycle bin won't already hold.
+    """
+    if FIXTURE_DIR.exists():
+        for f in FIXTURE_DIR.iterdir():
+            if f.is_file():
+                f.unlink()
+    FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
+
+    rng = np.random.default_rng()
+    base_color = rng.integers(0, 256, size=(3,))
+    fx = float(rng.uniform(0.5, 4.0))
+    fy = float(rng.uniform(0.5, 4.0))
+    h, w = 480, 640
+    yy, xx = np.meshgrid(np.arange(h), np.arange(w), indexing="ij")
+    arr = np.zeros((h, w, 3), dtype=np.float32)
+    for c in range(3):
+        arr[..., c] = (
+            base_color[c]
+            + 60 * np.sin(2 * np.pi * fx * xx / w + c)
+            + 60 * np.cos(2 * np.pi * fy * yy / h + c * 0.7)
+        )
+    base = Image.fromarray(np.clip(arr, 0, 255).astype(np.uint8))
+
+    qualities = [95, 88, 80, 72, 65]
+    paths: list[Path] = []
+    for i, q in enumerate(qualities):
+        exif = base.getexif()
+        exif[36867] = f"2024:05:01 1{i}:00:00"  # DateTimeOriginal
+        out = FIXTURE_DIR / f"s13_neardup_{i:02d}_q{q}.jpg"
+        base.save(str(out), "JPEG", quality=q, exif=exif.tobytes())
+        paths.append(out)
+    return paths
+
+
+def main() -> int:
+    print("scenario: s13_execute_action")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: regen_fixture")
+    fixture_paths = _regen_fixture()
+    print(f"  fixture_dir={FIXTURE_DIR}")
+    print(f"  fixture_count={len(fixture_paths)}")
+
+    print("step: open_scan_dialog")
+    dlg, _ = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    for line in _uia.extract_summary(log):
+        if line:
+            print(f"  log: {line}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+
+    print("step: open_execute_dialog")
+    _, win = _uia.connect_main()
+    exec_dlg, _ = _uia.open_execute_action_dialog(win)
+
+    print("step: mark_all_delete_via_regex")
+    _uia.mark_all_via_regex(
+        exec_dlg, field="File Name", regex=".+", action_label="delete"
+    )
+
+    print("step: execute_and_confirm")
+    _uia.execute_and_confirm(exec_dlg)
+    print("  execute_dialog_closed=True")
+
+    print("step: verify_files_removed")
+    still_present = [str(p) for p in fixture_paths if p.exists()]
+    removed = [str(p) for p in fixture_paths if not p.exists()]
+    print(f"  removed_count={len(removed)}")
+    print(f"  still_present_count={len(still_present)}")
+    for p in still_present:
+        print(f"  STILL_PRESENT: {p}")
+    if still_present:
+        print("FAIL: some fixture files were not removed by send2trash")
+        return 1
+
+    print("step: verify_manifest_executed")
+    if not MANIFEST_PATH.exists():
+        print(f"FAIL: manifest not found at {MANIFEST_PATH}")
+        return 1
+    conn = sqlite3.connect(str(MANIFEST_PATH))
+    try:
+        rows = conn.execute(
+            "SELECT source_path, executed FROM migration_manifest "
+            "WHERE source_path LIKE ?",
+            (f"%{FIXTURE_DIR.name}%",),
+        ).fetchall()
+        print(f"  matched_rows={len(rows)}")
+        not_executed = [r[0] for r in rows if r[1] != 1]
+        for r in rows:
+            print(f"  row: source_path={r[0]} executed={r[1]}")
+        if not rows:
+            print("FAIL: no manifest rows matched the fixture path")
+            return 1
+        if not_executed:
+            print(f"FAIL: {len(not_executed)} rows still have executed=0")
+            return 1
+    finally:
+        conn.close()
+
+    print("scenario: s13_execute_action DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Add **s13_execute_action** layer-3 driver covering Action → Execute Action… end-to-end. Closes one of the four gaps named in #80; s14 (Set-by-Regex standalone) and s15 (context-menu decisions) remain.
- 3 new reusable `_uia` helpers for the Execute dialog and the inner Set-Action-by-Regex dialog — locale-independent (works on zh-TW / en-US), IME-safe (uses `ValuePattern.SetValue` for the regex line edit per the lesson from #91 / s12).
- Each run regenerates 5 fresh near-duplicate JPEGs under `qa/sandbox/_disposable/s13_source/` and sends them to the operator's real Windows recycle bin via `send2trash`. Documented in the operator README + skill table.

## What's in here

| File | Change |
|---|---|
| [`qa/scenarios/s13_execute_action.py`](qa/scenarios/s13_execute_action.py) | NEW — driver + inline fixture regen (mirrors `make_qa_sandbox.make_near_duplicates` pattern) |
| [`qa/scenarios/_uia.py`](qa/scenarios/_uia.py) | 3 new helpers (`open_execute_action_dialog`, `mark_all_via_regex`, `execute_and_confirm`) + 7 new constants for the Execute / regex dialog flow |
| [`qa/scenarios/_config.py`](qa/scenarios/_config.py), [`_batch.py`](qa/scenarios/_batch.py) | s13 registered |
| [`docs/qa/README.md`](docs/qa/README.md), [`.claude/skills/qa-explore/SKILL.md`](.claude/skills/qa-explore/SKILL.md) | Scenario count 12 → 13, table row with destructive-flag annotation, batch-run command refresh |

This branch was originally stacked on `feature/s12-save-manifest`; #92 merged while s13 was being built so the diff vs master is now exactly s13's deltas (+300/-5, 6 files).

## Why is #68 not blocking?

Issue #68 is about `delete_service.delete_to_recycle()` raising on missing files. The Execute dialog has its own `_delete_file()` that uses `send2trash` directly and tracks missing files via `_missing_paths` instead of raising — so s13's happy path doesn't touch the #68 code path. #68 stays open for separate triage; s13 doesn't depend on its resolution.

## Test plan

- [x] `.venv/Scripts/python.exe -m qa.scenarios._batch s13_execute_action` → rc=0, last line `scenario: s13_execute_action DONE`
  - `removed_count=5`, `still_present_count=0` (send2trash succeeded for all)
  - All 5 manifest rows show `executed=1`
- [x] Scan summary confirms fixture forms 1 review group: `MOVE: 1, EXACT: 1, REVIEW_DUPLICATE: 3, UNDATED: 0`
- [x] `pytest --no-cov` → 503 passed, 2 skipped (no regressions; s13 is layer-3-only)
- [x] Per-file coverage gate → all 33 files clear 70%
- [ ] Full batch (`python -m qa.scenarios._batch`) once after merge — verify all 13 scenarios still play nice together

## Known characteristics (not bugs)

- Each run grows the operator's recycle bin by 5 files (fresh fixture each run; manually empty when desired).
- Driver does not assert recycle-bin contents — only that source files are gone and manifest is updated. Verifying recycle-bin state requires Shell APIs and is locale/version-fragile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)