### PR TITLE
qa(s14): drive Set Action by Field/Regex standalone (menu-bar path)

### DIFF
--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -36,6 +36,7 @@ ALL_SCENARIOS = [
     "s11_video_live",
     "s12_save_manifest",
     "s13_execute_action",
+    "s14_action_by_regex",
 ]
 
 

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -28,6 +28,7 @@ SCENARIO_SOURCES: dict[str, list[str]] = {
     "s11_video_live":      ["qa/sandbox/videos", "qa/sandbox/live-photo"],
     "s12_save_manifest":   ["qa/sandbox/near-duplicates"],
     "s13_execute_action":  ["qa/sandbox/_disposable/s13_source"],
+    "s14_action_by_regex": ["qa/sandbox/near-duplicates"],
 }
 
 

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -495,34 +495,18 @@ def open_execute_action_dialog(win: UIAWrapper) -> tuple[UIAWrapper, int]:
     return connect_by_handle(hwnd), hwnd
 
 
-def mark_all_via_regex(
-    execute_dlg: UIAWrapper,
-    field: str,
-    regex: str,
-    action_label: str,
-    dialog_timeout: float = 5,
+def _drive_action_dialog_form(
+    action_dlg: UIAWrapper, field: str, regex: str, action_label: str
 ) -> None:
-    """Open the inner Set Action by Field/Regex dialog from inside the
-    Execute Action dialog, set field+regex+action, click Apply, then Close.
+    """Fill the Set Action by Field/Regex dialog and submit.
 
-    `field` is the visible text in the Field combo (e.g. "File Name").
-    `regex` is set via UIA's ValuePattern to bypass IME (see save-manifest
-    helper for the same rationale).
-    `action_label` is the visible label in the Set Action combo
-    (e.g. "delete" — see SETTABLE_DECISIONS in app/views/constants.py).
+    Shared by both entry points (menu-bar standalone and Execute-dialog
+    inner). Caller must have already focused `action_dlg`.
+
+    Steps: select Field combo → SetValue regex → select Action combo →
+    Apply → Close. Regex uses UIA ValuePattern to bypass IME interception
+    of Latin keystrokes under bopomofo input.
     """
-    pid = execute_dlg.process_id()
-    select_btn = execute_dlg.child_window(
-        title=EXECUTE_BTN_SELECT_BY_REGEX, control_type="Button"
-    )
-    _focus(execute_dlg)
-    select_btn.click_input()
-
-    action_hwnd = wait_for_dialog(pid, ACTION_DIALOG_TITLE, timeout=dialog_timeout)
-    action_dlg = connect_by_handle(action_hwnd)
-    _focus(action_dlg)
-    time.sleep(0.3)
-
     # Two ComboBoxes in this dialog: Field combo (top) and Set Action combo
     # (bottom). Order is deterministic — find them by position (top-most first).
     combos = sorted(
@@ -571,6 +555,65 @@ def mark_all_via_regex(
     )
     close_btn.click_input()
     time.sleep(0.3)
+
+
+def mark_all_via_regex(
+    execute_dlg: UIAWrapper,
+    field: str,
+    regex: str,
+    action_label: str,
+    dialog_timeout: float = 5,
+) -> None:
+    """Open the inner Set Action by Field/Regex dialog from inside the
+    Execute Action dialog, set field+regex+action, click Apply, then Close.
+
+    `field` is the visible text in the Field combo (e.g. "File Name").
+    `regex` is set via UIA's ValuePattern to bypass IME (see save-manifest
+    helper for the same rationale).
+    `action_label` is the visible label in the Set Action combo
+    (e.g. "delete" — see SETTABLE_DECISIONS in app/views/constants.py).
+    """
+    pid = execute_dlg.process_id()
+    select_btn = execute_dlg.child_window(
+        title=EXECUTE_BTN_SELECT_BY_REGEX, control_type="Button"
+    )
+    _focus(execute_dlg)
+    select_btn.click_input()
+
+    action_hwnd = wait_for_dialog(pid, ACTION_DIALOG_TITLE, timeout=dialog_timeout)
+    action_dlg = connect_by_handle(action_hwnd)
+    _focus(action_dlg)
+    time.sleep(0.3)
+
+    _drive_action_dialog_form(action_dlg, field, regex, action_label)
+
+
+def mark_all_via_regex_standalone(
+    main_win: UIAWrapper,
+    field: str,
+    regex: str,
+    action_label: str,
+    dialog_timeout: float = 5,
+) -> None:
+    """Drive the standalone Set Action by Field/Regex flow from the menu bar.
+
+    Distinct from `mark_all_via_regex` — this opens the dialog via
+    Action menu → "Set Action by Field/Regex…" (no Execute Action dialog
+    in the picture). After Close, focus returns to the main window
+    rather than the Execute dialog.
+
+    Use for s14 (standalone Set Action) and any future scenario that
+    exercises bulk-decision assignment without entering Execute review.
+    """
+    pid = main_win.process_id()
+    menu_path(main_win, MENU_ACTION, ACTION_BY_REGEX)
+
+    action_hwnd = wait_for_dialog(pid, ACTION_DIALOG_TITLE, timeout=dialog_timeout)
+    action_dlg = connect_by_handle(action_hwnd)
+    _focus(action_dlg)
+    time.sleep(0.3)
+
+    _drive_action_dialog_form(action_dlg, field, regex, action_label)
 
 
 def execute_and_confirm(

--- a/qa/scenarios/s14_action_by_regex.py
+++ b/qa/scenarios/s14_action_by_regex.py
@@ -1,0 +1,131 @@
+"""Scenario 14 — Action > Set Action by Field/Regex (standalone, from menu).
+
+Required source: qa/sandbox/near-duplicates (5 files, basenames neardup_NN_qXX.jpg).
+
+Drives the standalone bulk-decision flow end-to-end:
+  scan → close & load → Action menu → Set Action by Field/Regex… →
+  field=File Name, regex=q[89]\\d, action=delete → Apply → Close →
+  verify (a) the 3 matching rows now have user_decision='delete' in the
+  manifest, (b) the 2 non-matching rows are unchanged from their pre-state.
+
+Distinct from s13 (which reaches the same handler via Execute Action's
+"Select by Field/Regex…" button) — this exercises the Action-menu entry
+that ships in main_window's menu bar, the path most users hit first.
+
+Catches drift in: Action menu label / dialog title / dialog widget order
+(Field combo first, Action combo second) / set_decision_by_regex match
+logic / batch_update_decisions write path / case-insensitive regex flag.
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+from qa.scenarios import _uia
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO / "qa" / "run-manifest.sqlite"
+FIXTURE_NAME_GLOB = "neardup_"  # matches all 5 fixture rows
+
+# Regex chosen so the case-insensitive match cleanly partitions the fixture:
+# matches q95, q88, q80 (3 rows) and skips q72, q65 (2 rows). If any of those
+# numbers ever shifts, this scenario will surface the change.
+FIELD = "File Name"
+REGEX = r"q[89]\d"
+ACTION = "delete"
+
+
+def _read_decisions() -> dict[str, str]:
+    """Return {basename: user_decision} for every fixture row in the manifest."""
+    if not MANIFEST_PATH.exists():
+        raise RuntimeError(f"manifest not found at {MANIFEST_PATH}")
+    conn = sqlite3.connect(str(MANIFEST_PATH))
+    try:
+        rows = conn.execute(
+            "SELECT source_path, user_decision FROM migration_manifest "
+            "WHERE source_path LIKE ?",
+            (f"%{FIXTURE_NAME_GLOB}%",),
+        ).fetchall()
+    finally:
+        conn.close()
+    return {Path(p).name: (d or "") for p, d in rows}
+
+
+def main() -> int:
+    print("scenario: s14_action_by_regex")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, _ = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    for line in _uia.extract_summary(log):
+        if line:
+            print(f"  log: {line}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+
+    print("step: snapshot_pre_decisions")
+    _, win = _uia.connect_main()
+    pre = _read_decisions()
+    if not pre:
+        print("FAIL: no fixture rows found in manifest after scan")
+        return 1
+    print(f"  pre_total={len(pre)}")
+    print(f"  pre_delete={sum(1 for v in pre.values() if v == 'delete')}")
+    print(f"  pre_empty={sum(1 for v in pre.values() if v == '')}")
+
+    print("step: apply_regex_via_menu")
+    rx = re.compile(REGEX, re.IGNORECASE)
+    expected_match = sorted(name for name in pre if rx.search(name))
+    expected_unchanged = sorted(name for name in pre if not rx.search(name))
+    print(f"  field={FIELD!r} regex={REGEX!r} action={ACTION!r}")
+    print(f"  expected_match={expected_match}")
+    print(f"  expected_unchanged={expected_unchanged}")
+    _uia.mark_all_via_regex_standalone(
+        win, field=FIELD, regex=REGEX, action_label=ACTION
+    )
+
+    print("step: verify_decisions_after_apply")
+    post = _read_decisions()
+    if set(post) != set(pre):
+        print(f"FAIL: row set changed; pre={sorted(pre)} post={sorted(post)}")
+        return 1
+
+    failures: list[str] = []
+    for name in expected_match:
+        if post[name] != "delete":
+            failures.append(f"{name}: expected 'delete', got {post[name]!r}")
+    for name in expected_unchanged:
+        if post[name] != pre[name]:
+            failures.append(
+                f"{name}: expected unchanged ({pre[name]!r}), got {post[name]!r}"
+            )
+
+    matched_rows = sum(1 for name in expected_match if post[name] == "delete")
+    unchanged_rows = sum(
+        1 for name in expected_unchanged if post[name] == pre[name]
+    )
+    print(f"  matched_rows={matched_rows} expected={len(expected_match)}")
+    print(f"  unchanged_rows={unchanged_rows} expected={len(expected_unchanged)}")
+    for name in sorted(post):
+        print(f"  row: name={name} pre={pre[name]!r} post={post[name]!r}")
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    print("scenario: s14_action_by_regex DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Drives the standalone Action-menu → **Set Action by Field/Regex…** flow end-to-end (sister to the Execute-dialog path covered by s13).
- Refactors `mark_all_via_regex` into a private `_drive_action_dialog_form` shared by both the Execute-dialog inner caller and a new menu-bar entry point `mark_all_via_regex_standalone`.
- Closes the third gap from #80; only s15 (right-click context menu) remains, opened separately as a sibling PR.

## What it catches

Drift in: Action menu label · dialog title (`Set Action by Field/Regex`) · widget order (Field combo first, Action combo second) · `set_decision_by_regex` match logic · `batch_update_decisions` write path · case-insensitive regex flag.

The fixture (`qa/sandbox/near-duplicates`, 5 rows) is partitioned by `q[89]\d` against File Name into 3 expected matches (q95/q88/q80 → `delete`) and 2 expected unchanged (q72/q65). Verification reads `user_decision` from `qa/run-manifest.sqlite` after Apply.

## Test plan

- [x] `python -m qa.scenarios._batch s14_action_by_regex` → `rc=0` with `matched_rows=3 expected=3`, `unchanged_rows=2 expected=2`
- [x] `pytest tests/` → 88.42% coverage, all green
- [x] `python -m py_compile qa/scenarios/{_uia,s14_action_by_regex,_batch,_config}.py` → OK
- [ ] Reviewer's discretion: full 14-scenario batch (s13 is destructive — sends 5 fresh JPEGs to recycle bin per existing design)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>