### PR TITLE
ui: unify dismiss-button label to "Close" across primary modals

### DIFF
--- a/app/views/dialogs/execute_action_dialog.py
+++ b/app/views/dialogs/execute_action_dialog.py
@@ -101,8 +101,16 @@ class ExecuteActionDialog(QDialog):
         layout.addWidget(self._warning_banner)
 
         has_decisions = bool(self._decided_records())
+        # Dismiss-label convention across all three primary modals is "Close":
+        # ScanDialog uses "Close" (relabeled to "Close & Load" post-scan to
+        # signal the mode change); ActionDialog uses "Close" because Apply
+        # already committed each regex; this dialog reuses the same label so
+        # users moving between modals see one dismiss verb. The destructive
+        # intent is reinforced at the "All Files Will Be Deleted" confirmation
+        # that fires on Execute — not at this dismiss button.
         self._btn_box = QDialogButtonBox(QDialogButtonBox.Ok | QDialogButtonBox.Cancel)
         self._btn_box.button(QDialogButtonBox.Ok).setText("Execute")
+        self._btn_box.button(QDialogButtonBox.Cancel).setText("Close")
         self._btn_box.button(QDialogButtonBox.Ok).setEnabled(has_decisions)
         self._btn_box.accepted.connect(self._on_execute_requested)
         self._btn_box.rejected.connect(self.reject)

--- a/app/views/dialogs/scan_dialog.py
+++ b/app/views/dialogs/scan_dialog.py
@@ -619,7 +619,15 @@ class ScanDialog(QDialog):
         self.accept()
 
     def closeEvent(self, event: QCloseEvent) -> None:
-        """Stop any running scan worker before closing."""
+        """Stop any running scan worker before closing.
+
+        Kept (rather than removed per #97's audit) because the override has a
+        concrete job: a user clicking the title-bar X mid-scan must trigger
+        worker.requestInterruption() so the QThread shuts down cleanly. Without
+        this hook, the dialog dismisses but the worker keeps running on a
+        detached thread until the process exits — that's the partial-state
+        leak s03_cancel_scan was written to catch.
+        """
         if self._worker and self._worker.isRunning():
             self._worker.requestInterruption()
             self._worker.wait(3000)


### PR DESCRIPTION
Closes #97 (Option A from the audit discussion).

## Summary

Three primary modals each use one of three valid UX patterns:

| Dialog | Pattern |
|---|---|
| ScanDialog | run-and-commit (`Close` → `Close & Load` post-scan) |
| ExecuteActionDialog | destructive OK / Cancel |
| ActionDialog | modify-and-continue (`Apply` / `Close`) |

Issue #97 surfaced the cosmetic inconsistency that users saw three different dismiss labels (`Close` / `Cancel` / `Close & Load`) across modals they navigate between. Forcing one convention everywhere would break semantics — \"Cancel & Load\" reads wrong on the Scan dialog, and \"Cancel\" on the Action dialog would be misleading because **Apply already committed each regex** by the time you dismiss.

## Smallest honest fix

Rename ExecuteActionDialog's `Cancel` button to `Close`. Now all three dialogs share the same dismiss label without forcing semantic mismatches. The destructive intent on Execute is reinforced by the existing `\"All Files Will Be Deleted\"` Yes/No confirmation modal that fires on the Execute button — not at the dismiss button.

```diff
+ self._btn_box.button(QDialogButtonBox.Cancel).setText(\"Close\")
```

(Plus a 7-line comment explaining the convention, so the next person to touch this doesn't wonder why a `QDialogButtonBox.Cancel` enum value renders as \"Close\".)

## Also addressed

#97's acceptance criteria asked the `closeEvent` override in `ScanDialog` to be either removed or its rationale documented inline. **Documented:** the override stops the worker thread when the user closes mid-scan, which is the partial-state leak `s03_cancel_scan` was written to catch. Removing it would silently regress that scenario.

## Decisions deliberately not taken

- **Did not** standardize on `Cancel` everywhere — would force `Cancel & Load` (wrong) and `Cancel` on Apply-then-dismiss (misleading).
- **Did not** rename `ScanDialog`'s post-scan `Close & Load` to plain `Close` — the relabel is honest about the mode change (the button now does TWO things). Keeping it.
- **Did not** rename `ActionDialog`'s `Close` — already consistent with the new convention.

The semantic patterns themselves stay as-is. Only the surface label is unified.

## Test plan

- [x] `pytest -q` — green, 88.46% (no source coverage shift)
- [x] `scripts/check_coverage_per_file.py` — all 36 files clear 70%
- [x] `python -m qa.scenarios._batch s05_huge_preview s13_execute_action s14_action_by_regex` — 3/3 pass (the scenarios that touch all three affected modals)
- [x] No tests referenced the old `\"Cancel\"` string
- [x] No UIA constants in `qa/scenarios/_uia.py` needed updating (no scenario clicked the Execute dialog's Cancel button — they always confirm via Execute → Yes-on-confirm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)