### PR TITLE
fix(ui): preserve prior manifest's actions when a new Open Manifest fails

### DIFF
--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -101,7 +101,13 @@ class FileOperationsHandler:
         from app.views.workers.manifest_load_worker import ManifestLoadWorker
 
         self.status_reporter.show_status("Opening manifest…", 0)
-        self._set_manifest_actions_enabled(False)
+        # Only disable manifest-gated actions if no prior manifest is loaded.
+        # When manifest A is already in memory and the user is opening B, leave
+        # A's actions enabled during the load — they're the user's safety net
+        # if B fails (#108). _on_manifest_loaded re-asserts enabled on success;
+        # _on_manifest_failed leaves them alone when a prior manifest exists.
+        if not getattr(self, "_manifest_path", None):
+            self._set_manifest_actions_enabled(False)
 
         default_sort = getattr(self.vm, "_default_sort", [])
         worker = ManifestLoadWorker(path, default_sort, parent=self.parent)
@@ -131,7 +137,12 @@ class FileOperationsHandler:
         logger.error("Open manifest failed: {}", error)
         QMessageBox.critical(self.parent, "Open Manifest Error", error)
         self.status_reporter.show_status("Open manifest failed")
-        self._set_manifest_actions_enabled(False)
+        # Only disable on failure if no prior manifest was loaded (#108). If a
+        # valid manifest is still in memory (self._manifest_path is set), the
+        # user is back to reviewing it after dismissing the error — leave its
+        # actions enabled rather than stranding them disabled.
+        if not getattr(self, "_manifest_path", None):
+            self._set_manifest_actions_enabled(False)
 
     def _set_manifest_actions_enabled(self, enabled: bool) -> None:
         try:

--- a/qa/scenarios/s16_open_manifest.py
+++ b/qa/scenarios/s16_open_manifest.py
@@ -16,9 +16,9 @@ Drives the Open Manifest flow end-to-end, both happy and error paths:
     s16_corrupt.sqlite → File → Open Manifest… → drive to corrupt
     path → confirm "Open Manifest Error" critical dialog appears →
     confirm status bar reports "Open manifest failed" → confirm
-    manifest-gated menu items are now disabled (current observed
-    behavior — note it leaves the previously-loaded manifest's
-    actions disabled too; that's a follow-up UX bug, not s16's job).
+    manifest-gated menu items REMAIN ENABLED because the previously-
+    loaded manifest is still in memory (#108: failed loads must not
+    strand a prior valid manifest's actions disabled).
 
 Catches drift in: Open Manifest menu label / dialog title /
 ManifestLoadWorker signal chain (progress / finished / failed) /
@@ -129,17 +129,17 @@ def main() -> int:
         print("WARN: status bar did not echo 'Open manifest failed' (may have cleared on timeout)")
 
     print("step: invariant_actions_after_error")
-    # _on_manifest_failed disables manifest-gated actions. Documenting the
-    # current behavior — even though this leaves the previously-loaded
-    # manifest's actions disabled (a separate UX issue worth filing if you
-    # see the WARN below), capture it as the observed state so future drift
-    # surfaces.
+    # #108: a failed Open Manifest must not strand the previously-loaded
+    # manifest's actions disabled. The user opened a corrupt B while A was
+    # active; after dismissing the error they're back to reviewing A, so
+    # A's manifest-gated actions stay enabled.
     inv_actions_post = _invariants.assert_manifest_actions_consistent(
-        win, expected_enabled=False
+        win, expected_enabled=True
     )
     if not inv_actions_post:
-        print("WARN: manifest actions did NOT settle to disabled after failure "
-              "(unexpected — _on_manifest_failed should disable them)")
+        print("FAIL: prior manifest's actions were stranded disabled after a "
+              "failed Open Manifest (regression of #108)")
+        return 1
 
     print("scenario: s16_open_manifest DONE")
     return 0

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -595,6 +595,7 @@ class TestManifestLoadCallbacks:
         assert "2" in status_msg and "3" in status_msg
 
     def test_on_manifest_failed_logs_and_disables_actions(self):
+        """No prior manifest loaded → failure disables actions (first-load case)."""
         from app.views.handlers.file_operations import FileOperationsHandler
         from types import SimpleNamespace
 
@@ -615,8 +616,88 @@ class TestManifestLoadCallbacks:
         assert "disk on fire" in crit.call_args[0][2]
         # Status updated to a failure message.
         status.show_status.assert_called_once()
-        # Manifest-dependent actions disabled via the shared controller call.
+        # No prior manifest — failure disables actions via the shared controller.
         parent.menu_controller.set_manifest_actions.assert_called_once_with(False)
+
+    def test_on_manifest_failed_preserves_prior_manifest_actions(self, tmp_path):
+        """#108: failed load with a prior manifest loaded leaves its actions enabled.
+
+        Reproduces the bug from #108: user has manifest A loaded and clicks
+        Open Manifest…, picks a corrupt file, the load fails. Before the fix,
+        the failure callback unconditionally disabled actions, stranding the
+        user's still-valid manifest A inaccessible. After the fix, actions
+        stay enabled because A is still in memory.
+        """
+        from app.views.handlers.file_operations import FileOperationsHandler
+        from types import SimpleNamespace
+
+        vm = SimpleNamespace(groups=[])
+        status = MagicMock()
+        parent = MagicMock()
+        parent.menu_controller = MagicMock()
+        handler = FileOperationsHandler(
+            vm=vm, settings=MagicMock(),
+            parent_widget=parent, ui_updater=MagicMock(), status_reporter=status,
+        )
+        # Pretend manifest A is already loaded.
+        handler._manifest_path = str(tmp_path / "manifest_a.sqlite")
+
+        with patch("PySide6.QtWidgets.QMessageBox.critical"):
+            handler._on_manifest_failed("disk on fire")
+
+        # Status still reports the failure.
+        status.show_status.assert_called_once()
+        # But actions are NOT toggled — A's enabled state is preserved.
+        parent.menu_controller.set_manifest_actions.assert_not_called()
+
+    def test_start_manifest_load_disables_actions_when_no_prior_manifest(self, tmp_path):
+        """First-ever Open Manifest: optimistic disable while load is in flight."""
+        from app.views.handlers.file_operations import FileOperationsHandler
+        from types import SimpleNamespace
+
+        vm = SimpleNamespace(groups=[], _default_sort=[])
+        parent = MagicMock()
+        parent.menu_controller = MagicMock()
+        handler = FileOperationsHandler(
+            vm=vm, settings=MagicMock(),
+            parent_widget=parent, ui_updater=MagicMock(), status_reporter=MagicMock(),
+        )
+
+        with patch("app.views.workers.manifest_load_worker.ManifestLoadWorker") as worker_cls:
+            worker_cls.return_value = MagicMock()
+            handler._start_manifest_load(str(tmp_path / "new.sqlite"))
+
+        # No prior manifest — actions get disabled while the worker runs.
+        parent.menu_controller.set_manifest_actions.assert_called_once_with(False)
+
+    def test_start_manifest_load_preserves_prior_manifest_actions(self, tmp_path):
+        """#108: Open Manifest while A is loaded leaves A's actions enabled during the load.
+
+        Without this gating, the user momentarily loses access to A's actions
+        between picking B in the file dialog and B's worker firing finished /
+        failed. If B fails, A's actions never come back (covered by the
+        sibling _on_manifest_failed test above). If B succeeds, the flicker
+        is at least visible. Either way, prior-loaded A should stay enabled.
+        """
+        from app.views.handlers.file_operations import FileOperationsHandler
+        from types import SimpleNamespace
+
+        vm = SimpleNamespace(groups=[], _default_sort=[])
+        parent = MagicMock()
+        parent.menu_controller = MagicMock()
+        handler = FileOperationsHandler(
+            vm=vm, settings=MagicMock(),
+            parent_widget=parent, ui_updater=MagicMock(), status_reporter=MagicMock(),
+        )
+        # Pretend manifest A is already loaded.
+        handler._manifest_path = str(tmp_path / "manifest_a.sqlite")
+
+        with patch("app.views.workers.manifest_load_worker.ManifestLoadWorker") as worker_cls:
+            worker_cls.return_value = MagicMock()
+            handler._start_manifest_load(str(tmp_path / "manifest_b.sqlite"))
+
+        # Prior manifest exists — start_manifest_load must NOT pre-emptively disable.
+        parent.menu_controller.set_manifest_actions.assert_not_called()
 
     def test_set_manifest_actions_enabled_delegates_to_controller(self):
         """_set_manifest_actions_enabled forwards to MenuController.set_manifest_actions."""


### PR DESCRIPTION
Closes #108.

## The bug

User has manifest A loaded and is reviewing it. They click File → Open Manifest…, pick a corrupt or invalid file. Before this fix, the load failure unconditionally disabled all manifest-gated menu items — stranding the user's still-valid manifest A inaccessible. Restart-the-app territory.

s16's pre-fix invariant captured the buggy behavior with `expected_enabled=False`; this PR flips it to `expected_enabled=True` and the assertion *has to flip* — that's the regression guard for #108.

## Two callbacks both pessimistically disabled actions

[`_start_manifest_load`](https://github.com/jackal998/photo-manager/blob/master/app/views/handlers/file_operations.py#L99) fired `_set_manifest_actions_enabled(False)` optimistically, before the worker even started — caused a brief flicker on success and the never-re-enabled state on failure.

[`_on_manifest_failed`](https://github.com/jackal998/photo-manager/blob/master/app/views/handlers/file_operations.py#L130) fired the same disable, sealing the bad state.

## Fix

Gate both disables on **"no prior manifest is loaded"**. When `self._manifest_path` is set, the user has a working manifest in memory; neither the optimistic disable in `_start_manifest_load` nor the on-failure disable should touch its action state. The optimistic disable still applies to the first-ever load (no prior manifest), preserving the original lifecycle. `_on_manifest_loaded` continues to set actions enabled on success unconditionally.

```diff
 def _start_manifest_load(self, path: str) -> None:
     self.status_reporter.show_status("Opening manifest…", 0)
-    self._set_manifest_actions_enabled(False)
+    if not getattr(self, "_manifest_path", None):
+        self._set_manifest_actions_enabled(False)
     ...

 def _on_manifest_failed(self, error: str) -> None:
     ...
     self.status_reporter.show_status("Open manifest failed")
-    self._set_manifest_actions_enabled(False)
+    if not getattr(self, "_manifest_path", None):
+        self._set_manifest_actions_enabled(False)
```

## Layer-1 tests

- existing `test_on_manifest_failed_logs_and_disables_actions` still passes — covers the no-prior-manifest case (first-ever load failure)
- new `test_on_manifest_failed_preserves_prior_manifest_actions` — failure with `_manifest_path` set must NOT call `set_manifest_actions`
- new `test_start_manifest_load_disables_actions_when_no_prior_manifest` — first-ever load still disables (current lifecycle preserved)
- new `test_start_manifest_load_preserves_prior_manifest_actions` — load with `_manifest_path` set must NOT pre-emptively disable

## Layer-3

`s16_open_manifest`'s `invariant_actions_after_error` assertion flipped from `expected_enabled=False` to `expected_enabled=True`. Driver docstring + comment updated to reflect the post-fix behavior.

## Test plan

- [x] `pytest -q` — green, **88.82%** (was 88.46%; new tests added pure layer-1 coverage)
- [x] `scripts/check_coverage_per_file.py` — all 36 files clear 70%
- [x] `python -m qa.scenarios._batch s16_open_manifest` — `rc=0`. After error path: `inv: manifest_actions_consistent expected_enabled=True ok=True` ← the regression guard
- [x] No source coverage shifts on unrelated modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)