### PR TITLE
qa(s17): drive ScanDialog _SourceListWidget operations

### DIFF
--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -99,7 +99,7 @@ If everything is already populated, skip the regen and move on.
 ## Phase 3 — Plan
 
 **Default behavior — invoked with no additional prompt:** run **all
-16 scenarios** in batch via `qa.scenarios._batch`. Don't print the
+17 scenarios** in batch via `qa.scenarios._batch`. Don't print the
 menu, don't ask which to run. Get one `yes batch` approval up front
 (per the gate rule below) and proceed. The full batch typically
 finishes in ~30–60 seconds with the focus fix in `_uia.py`.
@@ -519,6 +519,7 @@ running.
 | 14 | Set Action by Field/Regex (menu-bar path) | `qa.scenarios.s14_action_by_regex` | ✓ ready |
 | 15 | Right-click context menu Set Action → delete / keep | `qa.scenarios.s15_context_menu` | ✓ ready |
 | 16 | File → Open Manifest async load (happy + error path) | `qa.scenarios.s16_open_manifest` | ✓ ready |
+| 17 | Scan dialog widgets (add / remove / reorder / recursive) | `qa.scenarios.s17_scan_dialog_widgets` | ✓ ready |
 
 Several drivers also call cross-scenario invariant probes from
 `qa/scenarios/_invariants.py` — they assert that the status bar matches
@@ -549,14 +550,14 @@ output.
 in one go, use `qa.scenarios._batch`:
 
 ```
-.venv/Scripts/python.exe -m qa.scenarios._batch              # all 16 (s01–s16)
+.venv/Scripts/python.exe -m qa.scenarios._batch              # all 17 (s01–s17)
 .venv/Scripts/python.exe -m qa.scenarios._batch s04_corrupted s09_walker_exclusions
 ```
 
 For each scenario it: configures `qa/settings.json` → launches
 `main.py` → waits 3.5 s → runs the driver → closes the window →
 waits for the subprocess to exit → moves to the next. Prints a final
-SUMMARY table with rc per scenario. The whole batch (16 scenarios)
+SUMMARY table with rc per scenario. The whole batch (17 scenarios)
 typically finishes in ~120–200 seconds. Each app launch is still a
 real launch — get the user's "yes batch" once before starting.
 

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -39,6 +39,7 @@ ALL_SCENARIOS = [
     "s14_action_by_regex",
     "s15_context_menu",
     "s16_open_manifest",
+    "s17_scan_dialog_widgets",
 ]
 
 

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -31,6 +31,9 @@ SCENARIO_SOURCES: dict[str, list[str]] = {
     "s14_action_by_regex": ["qa/sandbox/near-duplicates"],
     "s15_context_menu":    ["qa/sandbox/near-duplicates"],
     "s16_open_manifest":   ["qa/sandbox/near-duplicates"],
+    # s17 starts from an empty source list — the driver populates it via the
+    # in-dialog widgets; that's the whole point of the scenario.
+    "s17_scan_dialog_widgets": [],
 }
 
 

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -61,6 +61,9 @@ SCAN_AID_OUTPUT_PATH = "QApplication.ScanDialog.QLineEdit"
 SCAN_AID_SOURCE_TABLE = (
     "QApplication.ScanDialog.QSplitter._SourceListWidget.QTableWidget"
 )
+SCAN_AID_TREE_PATH_FIELD = (
+    "QApplication.ScanDialog.QSplitter.QGroupBox._FolderTreePanel.QLineEdit"
+)
 
 # Execute Action dialog
 EXECUTE_DIALOG_TITLE = "Execute Actions — Review"
@@ -402,6 +405,236 @@ def close_and_load_manifest(dlg: UIAWrapper) -> None:
     _focus(dlg)
     btn.invoke()
     time.sleep(1.0)
+
+
+# ---------------------------------------------------------------------------
+# ScanDialog source-list widget operations (s17) — drive _SourceListWidget
+# directly: add via tree-panel path field, reorder via ↑↓, toggle Recursive,
+# remove via ×. Y-coordinate sort makes per-row dispatch unambiguous because
+# the only QCheckBox / ↑ / ↓ / × controls in the dialog are the per-row ones.
+# ---------------------------------------------------------------------------
+
+
+def _find_tree_path_field(dlg: UIAWrapper) -> UIAWrapper:
+    """Return the _FolderTreePanel QLineEdit (where the user types a path).
+
+    Tries the auto_id constant first; falls back to "the QLineEdit whose
+    placeholder mentions 'absolute folder path'" so we survive auto_id
+    hierarchy drift if Qt re-parents the widget.
+    """
+    try:
+        edit = dlg.child_window(
+            auto_id=SCAN_AID_TREE_PATH_FIELD, control_type="Edit"
+        )
+        edit.element_info  # force resolution
+        return edit
+    except Exception:
+        pass
+    # Fallback — placeholder text comes from photo-manager source, locale-stable.
+    for edit in dlg.descendants(control_type="Edit"):
+        try:
+            help_text = (edit.legacy_properties().get("Help") or "").lower()
+            if "absolute folder path" in help_text:
+                return edit
+        except Exception:
+            continue
+    raise RuntimeError("tree-panel path field not found in ScanDialog")
+
+
+def add_source_via_path_field(dlg: UIAWrapper, path: str) -> None:
+    """Add a source folder via the tree-panel path field + ``+ Add`` button.
+
+    Sets the path text via UIA ValuePattern (IME-safe, focus-independent),
+    then clicks the adjacent ``+ Add`` QPushButton whose ``clicked`` signal
+    runs ``_on_add_typed``. We deliberately do NOT press Enter here:
+    ``Start Scan`` is the dialog's default button (``setDefault(True)``),
+    so any Enter keystroke that reaches the dialog instead of the focused
+    QLineEdit kicks off a scan with whatever's already in the source list.
+    Windows foreground-lock and IME races make that focus delivery
+    intermittent — the result was a stray scan running in the background,
+    holding the run-manifest.sqlite handle, and producing a ``Scan Failed``
+    QMessageBox later when the next scan tried to overwrite the file.
+    Clicking the dedicated button has no such race surface.
+    """
+    edit = _find_tree_path_field(dlg)
+    _focus(dlg)
+    edit.iface_value.SetValue(str(path))
+    time.sleep(0.1)
+
+    add_btn = next(
+        (
+            b
+            for b in dlg.descendants(control_type="Button")
+            if (b.window_text() or "").strip() == "+ Add"
+        ),
+        None,
+    )
+    if add_btn is None:
+        raise RuntimeError("'+ Add' button not found in ScanDialog")
+    try:
+        add_btn.invoke()
+    except Exception:
+        add_btn.click_input()
+    time.sleep(0.3)
+
+
+def _table_cells_by_row(dlg: UIAWrapper) -> list[list[tuple[int, int, int, int]]]:
+    """Return per-row cell rectangles, row-sorted top-to-bottom and
+    column-sorted left-to-right within each row.
+
+    Each cell is ``(left, top, right, bottom)`` in screen coordinates.
+    Used to locate row controls (Recursive checkbox, ↑/↓ pair, ×) by
+    pixel position — Qt's setCellWidget'd children are NOT exposed in
+    the UIA tree, so DataItem rectangles are the only reliable hook.
+    """
+    try:
+        table = dlg.child_window(
+            auto_id=SCAN_AID_SOURCE_TABLE, control_type="Table"
+        )
+    except Exception:
+        return []
+    raw: list[tuple[int, int, int, int]] = []
+    for it in table.descendants(control_type="DataItem"):
+        try:
+            r = it.rectangle()
+            raw.append((r.left, r.top, r.right, r.bottom))
+        except Exception:
+            continue
+    if not raw:
+        return []
+
+    raw.sort(key=lambda c: (c[1], c[0]))
+    rows: list[list[tuple[int, int, int, int]]] = []
+    cur: list[tuple[int, int, int, int]] = []
+    last_y = -10**9
+    for left, top, right, bottom in raw:
+        if abs(top - last_y) > 10:
+            if cur:
+                rows.append(sorted(cur, key=lambda c: c[0]))
+            cur = [(left, top, right, bottom)]
+            last_y = top
+        else:
+            cur.append((left, top, right, bottom))
+    if cur:
+        rows.append(sorted(cur, key=lambda c: c[0]))
+    return rows
+
+
+def read_source_paths(dlg: UIAWrapper) -> list[str]:
+    """Return source-table paths in row order (top-to-bottom).
+
+    Reads only column 1 (path text), which is a real QTableWidgetItem
+    and so is exposed in the UIA tree. The Recursive / ↑↓ / × cells
+    are setCellWidget'd and have no accessible state — callers cannot
+    read those, only act on them.
+    """
+    try:
+        table = dlg.child_window(
+            auto_id=SCAN_AID_SOURCE_TABLE, control_type="Table"
+        )
+    except Exception:
+        return []
+    candidates: list[tuple[int, str]] = []
+    for cell in table.descendants(control_type="DataItem"):
+        try:
+            txt = (cell.window_text() or "").strip()
+            if not txt or ("\\" not in txt and "/" not in txt):
+                continue
+            candidates.append((cell.rectangle().top, txt))
+        except Exception:
+            continue
+    candidates.sort(key=lambda c: c[0])
+    return [t for _, t in candidates]
+
+
+def click_source_row_button(dlg: UIAWrapper, row: int, kind: str) -> None:
+    """Click ↑ / ↓ / × on the given 0-indexed row by pixel coordinates.
+
+    ``kind`` is one of ``"up"``, ``"down"``, ``"remove"``.
+
+    setCellWidget'd buttons are not exposed in Qt's UIA tree, so we
+    target them by clicking inside the column DataItem rectangle:
+
+      - col 3 contains the ↑↓ pair side-by-side; click left third for
+        ↑, right third for ↓ (centered button widths are 26px each).
+      - col 4 contains the × button; click center.
+
+    After the click the table is rebuilt from scratch (see
+    _SourceListWidget._move / ._remove); callers should re-read row
+    state via read_source_paths.
+    """
+    import pywinauto.mouse
+
+    if kind not in {"up", "down", "remove"}:
+        raise ValueError(f"kind must be up|down|remove, got {kind!r}")
+
+    rows = _table_cells_by_row(dlg)
+    if row < 0 or row >= len(rows):
+        raise IndexError(f"row {row} out of range (have {len(rows)} rows)")
+    cells = rows[row]
+    if len(cells) < 5:
+        raise RuntimeError(
+            f"row {row} has only {len(cells)} cells; expected 5 "
+            f"(#, Path, Recursive, ↑↓, ×)"
+        )
+
+    if kind == "remove":
+        left, top, right, bottom = cells[4]
+    else:
+        left, top, right, bottom = cells[3]
+
+    cy = top + (bottom - top) // 2
+    if kind == "up":
+        # ↑ sits in the left half of column 3
+        cx = left + (right - left) // 4
+    elif kind == "down":
+        # ↓ sits in the right half of column 3
+        cx = left + 3 * (right - left) // 4
+    else:  # remove
+        cx = left + (right - left) // 2
+
+    _focus(dlg)
+    pywinauto.mouse.click(button="left", coords=(cx, cy))
+    time.sleep(0.3)
+
+
+def toggle_source_row_recursive(dlg: UIAWrapper, row: int) -> None:
+    """Toggle the Recursive checkbox in the given 0-indexed row.
+
+    setCellWidget'd checkboxes do not surface in the UIA tree, so we
+    click the center of the column-2 cell rectangle. Qt routes the
+    click to the cell widget (centered checkbox) which fires
+    stateChanged → _on_recursive_changed.
+
+    There is no UIA-level way to read the resulting toggle state back;
+    callers should treat this as fire-and-forget and verify the
+    behavioral effect through other channels (e.g. a subsequent scan
+    using non-recursive depth produces a different file count).
+    """
+    import pywinauto.mouse
+
+    rows = _table_cells_by_row(dlg)
+    if row < 0 or row >= len(rows):
+        raise IndexError(f"row {row} out of range (have {len(rows)} rows)")
+    cells = rows[row]
+    if len(cells) < 3:
+        raise RuntimeError(
+            f"row {row} has only {len(cells)} cells; expected at least 3"
+        )
+    left, top, right, bottom = cells[2]
+    cx = left + (right - left) // 2
+    cy = top + (bottom - top) // 2
+    _focus(dlg)
+    pywinauto.mouse.click(button="left", coords=(cx, cy))
+    time.sleep(0.2)
+
+
+def click_remove_all_sources(dlg: UIAWrapper) -> None:
+    """Click the 'Remove All' header button to empty the source list."""
+    btn = dlg.child_window(title=SCAN_BTN_REMOVE_ALL, control_type="Button")
+    _focus(dlg)
+    btn.click_input()
+    time.sleep(0.3)
 
 
 def _find_filename_edit(native_dlg: UIAWrapper) -> UIAWrapper:

--- a/qa/scenarios/s17_scan_dialog_widgets.py
+++ b/qa/scenarios/s17_scan_dialog_widgets.py
@@ -1,0 +1,164 @@
+"""Scenario 17 — Scan dialog _SourceListWidget operations.
+
+Required source: none — driver populates the source list from inside
+the dialog. SCENARIO_SOURCES["s17_scan_dialog_widgets"] is intentionally
+empty.
+
+Drives every widget operation on _SourceListWidget end-to-end:
+  - add via _FolderTreePanel path field (UIA ValuePattern, IME-safe)
+  - reorder via the ↑ button
+  - toggle Recursive via the per-row checkbox
+  - remove via the × button
+  - tail: clear + re-add one folder, run scan, close & load — proves
+    widget mutations actually feed _build_sources() and the scan worker
+
+Catches drift in: row-button click coordinates (column-3 / column-4
+DataItem rectangles), the row-index lambda capture in _rebuild_table,
+_move / _remove off-by-ones, signal wiring between
+_FolderTreePanel.folder_requested and _SourceListWidget.add_entry,
+and the path the empty-list settings take through _load_from_settings.
+
+Distinct from s10 / s12 / s16 which all preload the source list from
+qa/settings.json — only s17 exercises the in-dialog widgets.
+
+Recursive-state caveat: setCellWidget'd checkboxes are not surfaced
+in Qt's UIA tree, so the driver cannot read the toggle state back.
+The toggle click is fire-and-forget — verified at the action layer
+(no exception, scan still succeeds), not at the state layer. Visible
+state regression there would be caught by /qa-explore screenshot
+review, not this driver.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from qa.scenarios import _invariants, _uia
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO / "qa" / "run-manifest.sqlite"
+
+SOURCE_UNIQUE = REPO / "qa" / "sandbox" / "unique"
+SOURCE_NEAR = REPO / "qa" / "sandbox" / "near-duplicates"
+SOURCE_HUGE = REPO / "qa" / "sandbox" / "huge"
+
+
+def _basenames_match(paths: list[str], expected: list[str]) -> bool:
+    """True if `paths` basenames equal `expected` in the same order."""
+    if len(paths) != len(expected):
+        return False
+    return all(
+        Path(p).name.lower() == name.lower() for p, name in zip(paths, expected)
+    )
+
+
+def main() -> int:
+    print("scenario: s17_scan_dialog_widgets")
+    app, win = _uia.connect_main()
+    pid = win.process_id()
+    print(f"connected: pid={pid} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, _ = _uia.open_scan_dialog(win)
+
+    # ── 1. Empty-state baseline ───────────────────────────────────────────
+    print("step: assert_empty_baseline")
+    paths = _uia.read_source_paths(dlg)
+    print(f"  initial_paths={paths!r}")
+    if paths:
+        print(f"FAIL: expected empty source list, got {paths!r}")
+        return 1
+
+    # ── 2. Add three sources via tree-panel path field ────────────────────
+    print("step: add_three_sources")
+    for src in (SOURCE_UNIQUE, SOURCE_NEAR, SOURCE_HUGE):
+        _uia.add_source_via_path_field(dlg, str(src.resolve()))
+
+    paths = _uia.read_source_paths(dlg)
+    print(f"  paths_after_add={[Path(p).name for p in paths]!r}")
+    if not _basenames_match(paths, ["unique", "near-duplicates", "huge"]):
+        print("FAIL: source list order/contents mismatch after add")
+        return 1
+
+    # ── 3. Reorder: row 1 (near-duplicates) ↑ ─────────────────────────────
+    print("step: reorder_row_up")
+    _uia.click_source_row_button(dlg, row=1, kind="up")
+    paths = _uia.read_source_paths(dlg)
+    print(f"  paths_after_up={[Path(p).name for p in paths]!r}")
+    if not _basenames_match(paths, ["near-duplicates", "unique", "huge"]):
+        print("FAIL: order after ↑ click mismatch")
+        return 1
+
+    # ── 4. Toggle Recursive on row 1 (now 'unique') ───────────────────────
+    # setCellWidget checkboxes are invisible to UIA; assert the click did
+    # not raise and the table state otherwise survived. State change is
+    # exercised behaviorally by the scan tail not failing.
+    print("step: toggle_recursive_row1")
+    _uia.toggle_source_row_recursive(dlg, row=1)
+    paths = _uia.read_source_paths(dlg)
+    if not _basenames_match(paths, ["near-duplicates", "unique", "huge"]):
+        print(f"FAIL: paths shifted unexpectedly after toggle: {paths!r}")
+        return 1
+
+    # ── 5. Remove row 2 (huge) via × ──────────────────────────────────────
+    print("step: remove_row2")
+    _uia.click_source_row_button(dlg, row=2, kind="remove")
+    paths = _uia.read_source_paths(dlg)
+    print(f"  paths_after_remove={[Path(p).name for p in paths]!r}")
+    if not _basenames_match(paths, ["near-duplicates", "unique"]):
+        print("FAIL: paths after × click mismatch")
+        return 1
+
+    # ── 6. Tail sanity: clear, re-add one folder, scan, close & load ──────
+    print("step: clear_via_remove_all")
+    _uia.click_remove_all_sources(dlg)
+    paths = _uia.read_source_paths(dlg)
+    if paths:
+        print(f"FAIL: Remove All did not clear; paths={paths!r}")
+        return 1
+
+    print("step: re_add_for_scan")
+    _uia.add_source_via_path_field(dlg, str(SOURCE_NEAR.resolve()))
+    paths = _uia.read_source_paths(dlg)
+    print(f"  paths_before_scan={[Path(p).name for p in paths]!r}")
+    if not _basenames_match(paths, ["near-duplicates"]):
+        print("FAIL: re-add did not produce the expected single row")
+        return 1
+
+    # Wipe any prior manifest so the post-scan exists() check is meaningful.
+    if MANIFEST_PATH.exists():
+        try:
+            MANIFEST_PATH.unlink()
+        except OSError:
+            pass
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    for line in _uia.extract_summary(log):
+        if line:
+            print(f"  log: {line}")
+
+    print("step: close_and_load")
+    _uia.close_and_load_manifest(dlg)
+    if not MANIFEST_PATH.exists():
+        print(f"FAIL: scan did not produce manifest at {MANIFEST_PATH}")
+        return 1
+    print(f"  manifest_path={MANIFEST_PATH}")
+
+    # ── 7. Cross-scenario invariant — manifest-gated menu items enabled ───
+    print("step: invariant_actions_enabled")
+    _, win = _uia.connect_main()
+    inv = _invariants.assert_manifest_actions_consistent(
+        win, expected_enabled=True
+    )
+    if not inv:
+        print("FAIL: manifest-gated menu items not all enabled after close & load")
+        return 1
+
+    print("scenario: s17_scan_dialog_widgets DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Adds qa/scenarios/s17_scan_dialog_widgets.py — drives every widget operation on `_SourceListWidget` from an **empty** source list: add via path field, ↑ reorder, toggle Recursive, × remove, then a real scan + close & load to prove the widget mutations feed `_build_sources()` and the worker. Closes #100.
- Helpers added in qa/scenarios/_uia.py: `add_source_via_path_field` (clicks `+ Add`, not Enter — Start Scan's `setDefault(True)` makes Enter unsafe under focus races), `read_source_paths`, `_table_cells_by_row`, `click_source_row_button` and `toggle_source_row_recursive` (pixel-coord clicks inside DataItem rectangles, since `setCellWidget`'d controls are invisible to UIA), `click_remove_all_sources`, plus `SCAN_AID_TREE_PATH_FIELD`.
- Registration: scenario added to `ALL_SCENARIOS` and to `SCENARIO_SOURCES` (with empty list — driver populates the list itself, that's the point). `SKILL.md` scenario table + three "16 → 17" references updated.

No source edits to `app/`. No new layer-1 tests — per project CLAUDE.md, the driver IS the layer-3 test for this feature; helpers are thin UIA wrappers without pure-logic branches worth padding for.

### Why pixel coordinates for the row controls

Qt's `setCellWidget`'d widgets do not surface in the UIA tree, neither under the QTableWidget (which exposes only Headers + DataItems) nor anywhere else in the dialog. The Recursive checkbox / ↑↓ pair / × button can only be reached by clicking inside the column DataItem rectangles, with the column index encoding which control gets hit. As a corollary, recursive-checkbox **state** cannot be read back through UIA — the toggle is fire-and-forget, verified behaviorally by the scan tail not failing.

### Why click `+ Add` instead of pressing Enter

Start Scan is `setDefault(True)` on the dialog. After a `ValuePattern.SetValue` call to populate the path field, an Enter keystroke routinely reaches the dialog instead of the focused QLineEdit (Windows foreground-lock + IME races), firing the default button instead of `returnPressed`. The result: a phantom scan running with whatever's in the source list, holding `run-manifest.sqlite` open, and producing `[WinErr 32] file in use` → "Scan Failed" QMessageBox when the explicit later scan tries to overwrite the file. Clicking the dedicated `+ Add` QPushButton (whose `clicked` is wired straight to `_on_add_typed`) has no race surface.

## Test plan

- [x] `pytest -q` — 524 passed, 2 skipped, 88.82% global coverage, per-file 70% gate clears
- [x] `python -m qa.scenarios._batch s17_scan_dialog_widgets` — green, scan_elapsed_s≈1.2s, manifest at expected path, `manifest_actions_consistent ok=True`
- [x] Full 17-scenario batch — 16/17 green; s17 hit the pre-existing post-launch File-menu-popup harness flake (#105/#107 territory). Driver itself passes cleanly when re-run in isolation, confirming this is the inter-scenario harness flake biting the latest scenario, not a regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)