### PR TITLE
fix(ui): pluralize 'pair'/'file'/'group' in status bar (#109)

### DIFF
--- a/app/views/components/status_messages.py
+++ b/app/views/components/status_messages.py
@@ -23,6 +23,40 @@ class _StatusReporter(Protocol):
     def show_status(self, message: str, timeout: int = DEFAULT_TIMEOUT_MS) -> None: ...
 
 
+def plural_form(n: int, singular: str, plural: str | None = None) -> str:
+    """Return the noun form (singular vs plural) without the count.
+
+    Use this when you need custom number formatting (thousands separator,
+    locale, etc.) at the call site::
+
+        f"{n:,} {plural_form(n, 'isolated file')}"   # "10,000 isolated files"
+
+    For the common case of plain ``"<n> <noun>"``, use ``pluralize`` instead.
+
+    The default plural is ``f"{singular}s"``. Pass an explicit ``plural``
+    only for irregular forms (geese, mice, children).
+    """
+    if n == 1:
+        return singular
+    return plural or singular + "s"
+
+
+def pluralize(n: int, singular: str, plural: str | None = None) -> str:
+    """Return ``"<n> <singular>"`` when n == 1, else ``"<n> <plural>"``.
+
+    Use this for status-bar messages that contain multiple count+noun
+    phrases (where ``report_count`` doesn't fit) or for irregular plurals
+    where appending ``s`` is wrong.
+
+    Examples:
+        ``pluralize(1, "pair")`` → ``"1 pair"``
+        ``pluralize(5, "pair")`` → ``"5 pairs"``
+        ``pluralize(3, "isolated file")`` → ``"3 isolated files"``
+        ``pluralize(2, "child", "children")`` → ``"2 children"``
+    """
+    return f"{n} {plural_form(n, singular, plural)}"
+
+
 def report_count(
     reporter: _StatusReporter,
     verb: str,

--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -8,7 +8,7 @@ from PySide6.QtCore import QObject
 from PySide6.QtWidgets import QDialog, QFileDialog, QMessageBox
 from loguru import logger
 
-from app.views.components.status_messages import report_count
+from app.views.components.status_messages import pluralize, report_count
 
 # Single source of truth for the QFileDialog filter string used wherever
 # the app opens or saves a manifest. Keeping this centralized avoids the
@@ -130,7 +130,8 @@ class FileOperationsHandler:
         n_items = sum(len(g.items) for g in groups)
         logger.info("Opened manifest: {} | groups={} items={}", path, n_groups, n_items)
         self.status_reporter.show_status(
-            f"Opened manifest: {n_groups} pairs to review ({n_items} files)"
+            f"Opened manifest: {pluralize(n_groups, 'pair')} to review "
+            f"({pluralize(n_items, 'file')})"
         )
 
     def _on_manifest_failed(self, error: str) -> None:

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -19,6 +19,7 @@ from PySide6.QtWidgets import (
 from loguru import logger
 
 from app.views.components.menu_controller import MenuController
+from app.views.components.status_messages import plural_form, pluralize
 
 # Import extracted components
 from app.views.components.tree_controller import TreeController
@@ -286,9 +287,11 @@ class MainWindow(QMainWindow):
                 isolated = max(0, total - grouped)
             except (sqlite3.Error, OSError):
                 pass
-            parts = [f"{n} group(s)"]
+            parts = [pluralize(n, "group")]
             if isolated:
-                parts.append(f"{isolated:,} isolated file(s)")
+                # Preserve thousands separator on isolated count — typical
+                # libraries can have tens of thousands of un-grouped files.
+                parts.append(f"{isolated:,} {plural_form(isolated, 'isolated file')}")
             self.statusBar().showMessage(
                 f"Loaded manifest: {', '.join(parts)}", 10000
             )

--- a/app/views/workers/manifest_load_worker.py
+++ b/app/views/workers/manifest_load_worker.py
@@ -22,6 +22,8 @@ from PySide6.QtCore import QThread, Signal
 
 from loguru import logger
 
+from app.views.components.status_messages import plural_form
+
 
 class ManifestLoadWorker(QThread):
     """Loads all rows from a manifest SQLite in a background thread.
@@ -73,5 +75,7 @@ class ManifestLoadWorker(QThread):
         if self._default_sort:
             SortService().sort(groups, self._default_sort)
 
-        self.progress.emit(f"Loaded {len(groups):,} group(s).")
+        self.progress.emit(
+            f"Loaded {len(groups):,} {plural_form(len(groups), 'group')}."
+        )
         self.finished.emit(groups)

--- a/qa/scenarios/s16_open_manifest.py
+++ b/qa/scenarios/s16_open_manifest.py
@@ -83,9 +83,15 @@ def main() -> int:
     print(f"  status_at_load={status_at_load!r}")
 
     print("step: assert_status_shape")
-    # The helper returned the status text it observed at success — re-check
-    # the shape here so failures point at the regex, not at a polling race.
-    if not re.search(r"Opened manifest:.*pair.*file", status_at_load):
+    # Tight shape match — verifies the literal phrase "to review" and
+    # the parenthesised file count survive any future copy edits. Allows
+    # either singular ("1 pair") or plural ("5 pairs") on both nouns;
+    # the singular/plural correctness for N=1 is enforced by the
+    # tests/test_status_messages.py unit tests (#109).
+    if not re.search(
+        r"Opened manifest: \d+ pairs? to review \(\d+ files?\)",
+        status_at_load,
+    ):
         print(f"FAIL: status shape mismatch — got {status_at_load!r}")
         return 1
 

--- a/tests/test_status_messages.py
+++ b/tests/test_status_messages.py
@@ -3,7 +3,12 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock
 
-from app.views.components.status_messages import DEFAULT_TIMEOUT_MS, report_count
+from app.views.components.status_messages import (
+    DEFAULT_TIMEOUT_MS,
+    plural_form,
+    pluralize,
+    report_count,
+)
 
 
 def test_report_count_singular_omits_s():
@@ -38,3 +43,46 @@ def test_report_count_custom_timeout():
     reporter = MagicMock()
     report_count(reporter, "Loaded", 3, "group", timeout=10000)
     reporter.show_status.assert_called_once_with("Loaded 3 groups", 10000)
+
+
+# ── pluralize / plural_form (added for #109) ──────────────────────────────
+
+
+def test_pluralize_one_uses_singular():
+    """The bug from #109: '1 pairs' should be '1 pair'."""
+    assert pluralize(1, "pair") == "1 pair"
+
+
+def test_pluralize_many_appends_default_s():
+    assert pluralize(5, "pair") == "5 pairs"
+
+
+def test_pluralize_zero_is_plural():
+    """Zero is plural in English: '0 pairs', not '0 pair'."""
+    assert pluralize(0, "pair") == "0 pairs"
+
+
+def test_pluralize_multi_word_noun():
+    """Multi-word nouns get the trailing 's' on the whole phrase."""
+    assert pluralize(3, "isolated file") == "3 isolated files"
+    assert pluralize(1, "isolated file") == "1 isolated file"
+
+
+def test_pluralize_irregular_explicit_plural():
+    """Irregular forms supply the plural explicitly."""
+    assert pluralize(2, "child", "children") == "2 children"
+    assert pluralize(1, "child", "children") == "1 child"
+
+
+def test_plural_form_returns_word_only():
+    """plural_form is the primitive — count formatting is the caller's job."""
+    assert plural_form(1, "group") == "group"
+    assert plural_form(5, "group") == "groups"
+    assert plural_form(0, "group") == "groups"
+
+
+def test_plural_form_supports_thousands_formatted_count():
+    """The motivating callsite: status bar with thousands-separator count."""
+    n = 12345
+    assert f"{n:,} {plural_form(n, 'isolated file')}" == "12,345 isolated files"
+    assert f"{1:,} {plural_form(1, 'isolated file')}" == "1 isolated file"


### PR DESCRIPTION
## Summary

Fixes #109. A 1-group manifest currently reads `Opened manifest: 1 pairs to review (1 files)` — wrong agreement on every manifest open with exactly one group. Three callsites had the plural hardcoded.

- New primitives in `app/views/components/status_messages.py` next to the existing `report_count`:
  - `plural_form(n, singular, plural=None)` — noun only, lets the caller format the count (preserves `:,` thousands separator at the two sites that need it).
  - `pluralize(n, singular, plural=None)` — `"<n> <noun>"`, common case, built on `plural_form`.
- Wired into the three callsites:
  - [file_operations.py](app/views/handlers/file_operations.py#L133) — `Opened manifest: N pair(s) to review (M file(s))`
  - [main_window.py](app/views/main_window.py#L289) — `Loaded manifest: N group(s)[, M:, isolated file(s)]`
  - [manifest_load_worker.py](app/views/workers/manifest_load_worker.py#L76) — `Loaded N:, group(s).` progress message
- Layer-1 tests in `tests/test_status_messages.py`: n=1, n=0, n=many, multi-word nouns, irregular plurals, and the thousands-separator integration.
- s16 regex tightened from `r"Opened manifest:.*pair.*file"` to `r"Opened manifest: \d+ pairs? to review \(\d+ files?\)"`. The shape match guards future copy edits that drop "to review" or the parens; singular/plural correctness for N=1 is enforced by the new unit tests, not the regex (which still allows `s?` on both nouns by design).

## Acceptance criteria check

- [x] `Opened manifest: 1 pair to review (1 file)` on a 1-group, 1-file manifest
- [x] `Opened manifest: 5 pairs to review (12 files)` on a multi-group manifest (no regression)
- [x] Same fix applied to `_load_manifest_from_path` (`main_window.py`) so `Loaded manifest:` and `Opened manifest:` use the same pluralization shape
- [x] Layer-1 unit tests covering singular / plural cases
- [x] s16 driver regex tightened

## Test plan

- [x] `pytest -q --no-cov` — 531 passed, 2 skipped (524 → 531, +7 new tests)
- [x] `pytest` with coverage — 88.86% global, per-file 70% gate clears (`scripts/check_coverage_per_file.py` reports `[ok] All 36 tracked files clear`)
- [ ] Layer-3 confirm via s16 driver re-run after merge — covered by the existing scenario; no behavior change to s16's other steps

🤖 Generated with [Claude Code](https://claude.com/claude-code)