### PR TITLE
fix(ui): focus Close button after empty/failed scan (#86)

### DIFF
--- a/app/views/dialogs/scan_dialog.py
+++ b/app/views/dialogs/scan_dialog.py
@@ -607,10 +607,19 @@ class ScanDialog(QDialog):
         self._log(f"\nERROR: {error}")
         self._btn_scan.setEnabled(True)
         QMessageBox.critical(self, "Scan Failed", error)
+        # No manifest was produced; Close is the canonical exit. Pull focus
+        # there so the user has an obvious next action (focus ring + Enter
+        # dismisses) instead of a UI that looks identical to pre-scan (#86).
+        self._btn_close.setFocus()
 
     def _on_completed_empty(self) -> None:
         """Empty input is benign — re-enable Start Scan, no modal."""
         self._btn_scan.setEnabled(True)
+        # Same rationale as _on_failed (#86): no manifest produced, Close is
+        # the way out, focus gives the user a visible signal that the scan
+        # ended. Start Scan stays enabled so the user can fix sources and
+        # retry without dismissing the dialog.
+        self._btn_close.setFocus()
 
     def _load_and_close(self) -> None:
         """Call the completion callback and close the dialog."""

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -964,6 +964,35 @@ def execute_and_confirm(
     )
 
 
+def close_scan_dialog_via_close_button(dlg: UIAWrapper) -> None:
+    """Click the regular ``Close`` button (the one wired to ``self.reject``).
+
+    Distinct from ``close_and_load_manifest`` which clicks ``Close & Load``
+    on the post-success path. Use this on the empty-scan or failed-scan
+    paths where no manifest was produced — that's the canonical user exit
+    after #86 wired focus to this button.
+    """
+    btn = dlg.child_window(title="Close", control_type="Button")
+    _focus(dlg)
+    btn.invoke()
+    time.sleep(0.5)
+
+
+def focused_button_name(dlg: UIAWrapper) -> str:
+    """Return the title of whatever Button currently has UIA focus in dlg.
+
+    Returns ``""`` if no Button is focused. Used by s02 to assert that the
+    Close button is the focus target after an empty-scan completion (#86).
+    """
+    for btn in dlg.descendants(control_type="Button"):
+        try:
+            if btn.has_keyboard_focus():
+                return (btn.window_text() or "").strip()
+        except Exception:
+            continue
+    return ""
+
+
 def cancel_scan_dialog(dlg: UIAWrapper) -> None:
     """Click the title-bar Close (×) to cancel a scan or close pre-scan."""
     _focus(dlg)

--- a/qa/scenarios/s02_empty_folder.py
+++ b/qa/scenarios/s02_empty_folder.py
@@ -2,11 +2,14 @@
 
 Required sources: qa/sandbox/empty
 Probes: how the app handles a scan that finds zero files.
+
+Catches drift in: post-empty-scan focus cue (#86 — Close button must
+receive focus so the user has a visible exit), and the empty-state log
+line shape ("Done. No media files found — nothing to scan.").
 """
 from __future__ import annotations
 
 import sys
-import time
 
 from qa.scenarios import _uia
 
@@ -32,17 +35,26 @@ def main() -> int:
     pid = win.process_id()
     wins = [t for _, _, t in _uia.list_process_windows(pid)]
     print(f"  open_windows={wins!r}")
-    # Did anything pop up? (empty-state dialog, message, etc.)
     extra = [t for t in wins if t not in ("Photo Manager", "Scan Sources")]
     print(f"  extra_dialogs={extra!r}")
+    if extra:
+        print(f"FAIL: unexpected dialogs after empty scan: {extra!r}")
+        return 1
+
+    # #86 — Close is the canonical exit on the empty path; the source-side
+    # fix routes focus there so the user has a visible cue. Assert it.
+    print("step: assert_close_button_focused")
+    focused = _uia.focused_button_name(dlg)
+    print(f"  focused_button={focused!r}")
+    if focused != "Close":
+        print(
+            f"FAIL: expected 'Close' button to have focus after empty scan, "
+            f"got {focused!r} (regression of #86)"
+        )
+        return 1
 
     print("step: close_dialog")
-    try:
-        _uia.close_and_load_manifest(dlg)
-    except Exception as e:
-        print(f"  close_load_failed={e!r}")
-        # Fall back to title-bar close
-        _uia.cancel_scan_dialog(dlg)
+    _uia.close_scan_dialog_via_close_button(dlg)
 
     print("step: read_results")
     _, win = _uia.connect_main()

--- a/tests/test_scan_dialog.py
+++ b/tests/test_scan_dialog.py
@@ -383,6 +383,64 @@ class TestSourceListLayout:
         assert widget._table.minimumHeight() >= 180
 
 
+# ---------------------------------------------------------------------------
+# Post-scan terminal-state focus (#86)
+# ---------------------------------------------------------------------------
+
+
+class TestPostScanCloseFocus:
+    """#86 — after a terminal scan event that produces no manifest (empty
+    input or hard failure), focus must move to the Close button so the
+    user has a visible "way out" cue rather than a UI that looks identical
+    to pre-scan state. Uses ``focusWidget()`` rather than ``hasFocus()``
+    because the latter requires the window to be active, while
+    ``focusWidget()`` tracks the last ``setFocus`` target on a top-level
+    widget regardless of visibility — fine for a unit test.
+    """
+
+    def _make_dialog(self, qapp, tmp_path):
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text('{"sources":{}}', encoding="utf-8")
+        return ScanDialog(JsonSettings(settings_path))
+
+    def test_completed_empty_focuses_close_button(self, qapp, tmp_path):
+        dlg = self._make_dialog(qapp, tmp_path)
+        dlg._on_completed_empty()
+        assert dlg.focusWidget() is dlg._btn_close
+
+    def test_completed_empty_re_enables_start_scan(self, qapp, tmp_path):
+        """Focus on Close must not foreclose retry — Start Scan stays
+        enabled so the user can fix the source list and re-scan."""
+        dlg = self._make_dialog(qapp, tmp_path)
+        dlg._btn_scan.setEnabled(False)
+        dlg._on_completed_empty()
+        assert dlg._btn_scan.isEnabled()
+
+    def test_failed_focuses_close_button(self, qapp, tmp_path, monkeypatch):
+        """Same focus cue after a real scan failure. Modal blocks in a real
+        run; no-op it for the test so the synchronous flow continues."""
+        from PySide6.QtWidgets import QMessageBox
+
+        monkeypatch.setattr(QMessageBox, "critical", lambda *a, **k: None)
+
+        dlg = self._make_dialog(qapp, tmp_path)
+        dlg._on_failed("simulated pipeline error")
+        assert dlg.focusWidget() is dlg._btn_close
+
+    def test_failed_re_enables_start_scan(self, qapp, tmp_path, monkeypatch):
+        from PySide6.QtWidgets import QMessageBox
+
+        monkeypatch.setattr(QMessageBox, "critical", lambda *a, **k: None)
+
+        dlg = self._make_dialog(qapp, tmp_path)
+        dlg._btn_scan.setEnabled(False)
+        dlg._on_failed("simulated pipeline error")
+        assert dlg._btn_scan.isEnabled()
+
+
 class TestPathFieldEntry:
     """#40 — typing/pasting an absolute path should add it to the source list."""
 


### PR DESCRIPTION
## Summary

Fixes #86. After a scan that produces no manifest (empty input or hard failure), the dialog state is visually identical to pre-scan — Start Scan re-enabled, Close button untouched, no signal that anything ended. The QA-explore reporter actually fell back to the title-bar X to dismiss.

The Close button **already exists** at the bottom of the dialog and is wired to `self.reject` — but neither the user nor the QA agent recognized it as the post-scan exit, because nothing in the UI emphasizes it after the terminal event.

**Source-side fix** ([scan_dialog.py](app/views/dialogs/scan_dialog.py)): one-line addition — `self._btn_close.setFocus()` — at the end of both `_on_completed_empty` and `_on_failed`. The focus ring now signals "this is the way out", Enter dismisses, and Start Scan stays enabled so the user can fix sources and retry without dismissing first.

Doesn't change button text, doesn't disable any action, doesn't break the post-success path (`_on_finished` is untouched — `Close & Load` remains the obvious action there).

## Tests

**Layer 1** — `tests/test_scan_dialog.py::TestPostScanCloseFocus` (4 new):
- focus lands on Close after `_on_completed_empty`
- Start Scan stays enabled (retry not foreclosed)
- same for `_on_failed` (with `QMessageBox.critical` monkeypatched to skip the blocking modal in unit context)
- Start Scan stays enabled after `_on_failed`

Uses `dlg.focusWidget()` rather than `hasFocus()` because the latter requires the window to be active; the former tracks the last `setFocus` target on a top-level widget regardless of visibility.

**Layer 3** — `qa.scenarios.s02_empty_folder` updated:
- Replaces the prior `close_and_load_manifest` → title-bar-X fallback with a direct click on the (now focus-cued) Close button.
- Asserts `focused_button_name(dlg) == "Close"` before clicking — would catch a regression of #86 in any future CI run of the batch.
- Two new helpers in [`qa/scenarios/_uia.py`](qa/scenarios/_uia.py): `focused_button_name(dlg)` and `close_scan_dialog_via_close_button(dlg)`.

## Verification

- [x] `pytest -q --no-cov` — 535 passed, 2 skipped (531 → 535, +4 new)
- [x] `pytest` with coverage — per-file 70% gate clears
- [x] `python -m qa.scenarios._batch s02_empty_folder` — green; trace shows `focused_button='Close'` and the new direct-Close exit working

🤖 Generated with [Claude Code](https://claude.com/claude-code)