### PR TITLE
fix(scan): reconcile manifest summary with skipped count (#87)

### DIFF
--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -219,7 +219,7 @@ class ScanWorker(QThread):
         # Capture print_summary output and re-emit as progress
         buf = io.StringIO()
         with redirect_stdout(buf):
-            print_summary(rows)
+            print_summary(rows, skipped=len(skipped))
         for line in buf.getvalue().splitlines():
             self._emit(line)
 

--- a/qa/scenarios/s04_corrupted.py
+++ b/qa/scenarios/s04_corrupted.py
@@ -3,6 +3,14 @@
 Required sources: qa/sandbox/corrupted
 Probes: hash/EXIF error paths — does the scan tolerate a corrupted file,
 log a meaningful error, and continue?
+
+Catches drift in: post-#87 summary reconciliation. The fixture has 1
+truncated JPEG which decodes to phash=None and is excluded from the
+manifest. The summary must reconcile:
+  - "Indexed in manifest :       0"
+  - "Skipped (unreadable):       1"
+A regression that brings back the misleading "Total files scanned: 0"
+without a Skipped line gets caught here.
 """
 from __future__ import annotations
 
@@ -33,6 +41,21 @@ def main() -> int:
         k in l.lower() for k in ("error", "warning", "fail", "skip", "corrupt")
     )]
     print(f"  error_keyword_lines={len(err_lines)}")
+
+    # #87: the summary must reconcile with the per-step counts above.
+    print("step: assert_summary_reconciles")
+    if "Indexed in manifest" not in log:
+        print("FAIL: summary missing 'Indexed in manifest' headline (regression of #87)")
+        return 1
+    if "Total files scanned" in log:
+        print("FAIL: summary still uses old misleading 'Total files scanned' label (#87)")
+        return 1
+    if "Skipped (unreadable)" not in log:
+        print(
+            "FAIL: corrupt-only scan must surface a 'Skipped (unreadable)' "
+            "line so the headline 0 reconciles with 'Hashed 1/1' (#87)"
+        )
+        return 1
 
     print("step: close_dialog")
     try:

--- a/scan.py
+++ b/scan.py
@@ -233,7 +233,7 @@ def main() -> int:
     print("Classifying…", flush=True)
     rows = classify(hash_results, threshold=args.threshold, source_priority=source_priority)
 
-    print_summary(rows)
+    print_summary(rows, skipped=len(skipped))
 
     if args.dry_run:
         print("--dry-run: manifest not written.", flush=True)

--- a/scanner/manifest.py
+++ b/scanner/manifest.py
@@ -80,14 +80,30 @@ def write_manifest(rows: list[ManifestRow], output: Path) -> None:
         conn.commit()
 
 
-def print_summary(rows: list[ManifestRow]) -> None:
-    """Print an action-count summary table to stdout."""
+def print_summary(rows: list[ManifestRow], skipped: int = 0) -> None:
+    """Print an action-count summary table to stdout.
+
+    Args:
+        rows: Classified manifest rows (action breakdown is derived from these).
+        skipped: Count of files that were walked + hashed but excluded from
+            the manifest (unreadable / decode-failed). When > 0, a separate
+            ``Skipped (unreadable)`` line is printed so the headline number
+            reconciles with the ``Skipped N unreadable file(s):`` line that
+            scan_worker / scan.py emit earlier in the log (#87).
+
+    The headline label is ``Indexed in manifest`` — accurately describing
+    ``len(rows)``, which is the manifest row count, not a "files scanned"
+    count. The previous wording falsely implied 0 files were processed when
+    every file was decode-skipped (#87).
+    """
     from collections import Counter
     counts: Counter = Counter(r.action for r in rows)
     total = len(rows)
 
     print("\n── Migration Manifest Summary ──────────────────────")
-    print(f"  Total files scanned : {total:>7,}")
+    print(f"  Indexed in manifest : {total:>7,}")
+    if skipped:
+        print(f"  Skipped (unreadable): {skipped:>7,}")
     for action in ("KEEP", "MOVE", "EXACT", "REVIEW_DUPLICATE", "UNDATED"):
         n = counts.get(action, 0)
         pct = 100 * n / total if total else 0

--- a/tests/test_scanner_manifest.py
+++ b/tests/test_scanner_manifest.py
@@ -162,6 +162,48 @@ class TestPrintSummary:
         out = capsys.readouterr().out
         assert "0" in out
 
+    # ── #87: headline label + skipped reconciliation ───────────────────────
+
+    def test_headline_label_is_indexed_in_manifest(self, capsys):
+        """The headline counts manifest rows, so the label must say so —
+        not 'Total files scanned' (which falsely implies files walked +
+        hashed). Catches the misleading-label bug from #87."""
+        print_summary([_row("/a.jpg", "MOVE", dest_path="/d/a.jpg")])
+        out = capsys.readouterr().out
+        assert "Indexed in manifest" in out
+        assert "Total files scanned" not in out
+
+    def test_skipped_line_omitted_when_zero(self, capsys):
+        """No skipped files → no Skipped line (avoids visual noise on the
+        happy path)."""
+        print_summary([_row("/a.jpg", "MOVE", dest_path="/d/a.jpg")])
+        out = capsys.readouterr().out
+        assert "Skipped (unreadable)" not in out
+
+    def test_skipped_line_appears_when_nonzero(self, capsys):
+        """The whole point of #87: when files were walked + hashed but
+        excluded from the manifest, surface the count so the headline
+        reconciles with the per-step log lines above."""
+        print_summary([], skipped=3)
+        out = capsys.readouterr().out
+        assert "Skipped (unreadable)" in out
+        assert "3" in out
+
+    def test_skipped_zero_value_not_printed(self, capsys):
+        """Explicit skipped=0 is the same as the default — no line printed."""
+        print_summary([_row("/a.jpg", "MOVE", dest_path="/d/a.jpg")], skipped=0)
+        out = capsys.readouterr().out
+        assert "Skipped (unreadable)" not in out
+
+    def test_corrupt_only_scenario_reconciles(self, capsys):
+        """The exact #87 reproduction: 1 file walked, decode-failed → 0 in
+        manifest, 1 skipped. Both numbers must appear so the user can
+        reconcile against the 'Hashed 1/1' line earlier in the log."""
+        print_summary([], skipped=1)
+        out = capsys.readouterr().out
+        assert "Indexed in manifest :       0" in out
+        assert "Skipped (unreadable):       1" in out
+
 
 # ── TestManifestSchemaColumns ───────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Fixes #87. The manifest-summary headline read `Total files scanned: <len(rows)>`, but `rows` is the post-classify manifest — files that were walked + hashed but failed to decode are dropped before classify. With one truncated JPEG, the GUI log contradicted itself:

```
→ 1 files
Total: 1 media files
Hashed 1/1
Skipped 1 unreadable file(s):
...
Total files scanned :       0
```

Two changes in [`scanner/manifest.py::print_summary`](scanner/manifest.py):

- **Rename** the headline `Total files scanned` → `Indexed in manifest`. The number is the manifest row count, and the new label is honest about that.
- **Add** an optional `skipped: int = 0` parameter; when nonzero, emit a `Skipped (unreadable)` line directly under the headline so the summary reconciles with the `Skipped N unreadable file(s):` line that the scan worker already prints earlier in the log.

Plumbed from both callsites:
- [`app/views/workers/scan_worker.py`](app/views/workers/scan_worker.py) (GUI) — passes `len(skipped)`, which includes both raise-during-hash and silent-decode-failure cases. Silent-decode is the one that produced #87's reproducer.
- [`scan.py`](scan.py) (CLI) — passes `len(skipped)`, which currently only includes raise-during-hash cases. The CLI's missing silent-decode detection is a pre-existing inconsistency with the GUI, not in scope here.

After fix (s04 driver trace):
```
Indexed in manifest :       0
Skipped (unreadable):       1
KEEP                :       0  (0.0%)
...
```

## Tests

**Layer 1** ([`tests/test_scanner_manifest.py::TestPrintSummary`](tests/test_scanner_manifest.py), 5 new):
- headline label is `Indexed in manifest`, not `Total files scanned`
- skipped line omitted when `skipped=0` (avoids visual noise on happy path)
- skipped line appears when `skipped>0`
- explicit `skipped=0` matches default
- exact #87 repro shape: `Indexed:0 + Skipped:1`

**Layer 3** ([`qa.scenarios.s04_corrupted`](qa/scenarios/s04_corrupted.py)):
- New `assert_summary_reconciles` step asserts the new headline is present, the old label is gone, and the `Skipped (unreadable)` line is emitted on the corrupt-only path. Future regressions land at the layer-3 batch.

## Verification

- [x] `pytest -q --no-cov` — 540 passed, 2 skipped (535 → 540, +5 new)
- [x] `pytest` with coverage — per-file 70% gate clears
- [x] `python -m qa.scenarios._batch s04_corrupted` — green; trace shows the new headline + `Skipped (unreadable): 1` reconciliation

🤖 Generated with [Claude Code](https://claude.com/claude-code)