### PR TITLE
qa(s19): drive right-click → Open Folder context-menu action (#102)

### DIFF
--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -99,7 +99,7 @@ If everything is already populated, skip the regen and move on.
 ## Phase 3 — Plan
 
 **Default behavior — invoked with no additional prompt:** run **all
-18 scenarios** in batch via `qa.scenarios._batch`. Don't print the
+19 scenarios** in batch via `qa.scenarios._batch`. Don't print the
 menu, don't ask which to run. Get one `yes batch` approval up front
 (per the gate rule below) and proceed. The full batch typically
 finishes in ~30–60 seconds with the focus fix in `_uia.py`.
@@ -521,6 +521,7 @@ running.
 | 16 | File → Open Manifest async load (happy + error path) | `qa.scenarios.s16_open_manifest` | ✓ ready |
 | 17 | Scan dialog widgets (add / remove / reorder / recursive) | `qa.scenarios.s17_scan_dialog_widgets` | ✓ ready |
 | 18 | Log menu (Open Latest Log / Delete Log / Log Dir / Delete Log Dir) | `qa.scenarios.s18_log_menu` | ✓ ready |
+| 19 | Right-click context menu → Open Folder (explorer.exe /select integration) | `qa.scenarios.s19_context_menu_open_folder` | ✓ ready |
 
 Several drivers also call cross-scenario invariant probes from
 `qa/scenarios/_invariants.py` — they assert that the status bar matches
@@ -551,14 +552,14 @@ output.
 in one go, use `qa.scenarios._batch`:
 
 ```
-.venv/Scripts/python.exe -m qa.scenarios._batch              # all 18 (s01–s18)
+.venv/Scripts/python.exe -m qa.scenarios._batch              # all 19 (s01–s19)
 .venv/Scripts/python.exe -m qa.scenarios._batch s04_corrupted s09_walker_exclusions
 ```
 
 For each scenario it: configures `qa/settings.json` → launches
 `main.py` → waits 3.5 s → runs the driver → closes the window →
 waits for the subprocess to exit → moves to the next. Prints a final
-SUMMARY table with rc per scenario. The whole batch (18 scenarios)
+SUMMARY table with rc per scenario. The whole batch (19 scenarios)
 typically finishes in ~120–200 seconds. Each app launch is still a
 real launch — get the user's "yes batch" once before starting.
 

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -41,6 +41,7 @@ ALL_SCENARIOS = [
     "s16_open_manifest",
     "s17_scan_dialog_widgets",
     "s18_log_menu",
+    "s19_context_menu_open_folder",
 ]
 
 

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -36,6 +36,7 @@ SCENARIO_SOURCES: dict[str, list[str]] = {
     "s17_scan_dialog_widgets": [],
     # s18 doesn't run a scan; the source list is irrelevant.
     "s18_log_menu":            [],
+    "s19_context_menu_open_folder": ["qa/sandbox/near-duplicates"],
 }
 
 

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -120,6 +120,45 @@ def list_process_windows(pid: int) -> list[tuple[int, str, str]]:
     return out
 
 
+def list_explorer_windows() -> list[tuple[int, str]]:
+    """Return [(hwnd, title)] for every visible top-level Windows Explorer
+    window, regardless of process owner.
+
+    Identifies them by Win32 class ``CabinetWClass`` — what File Explorer
+    uses for its standard folder windows. Used by s19 to verify that the
+    ``Open Folder`` context-menu action spawned a new Explorer window.
+    Includes pre-existing user windows; callers should snapshot before
+    the action and diff after.
+    """
+    out: list[tuple[int, str]] = []
+
+    def cb(hwnd, _):
+        if _user32.IsWindowVisible(hwnd):
+            cls = ctypes.create_unicode_buffer(256)
+            _user32.GetClassNameW(hwnd, cls, 256)
+            if cls.value == "CabinetWClass":
+                title = ctypes.create_unicode_buffer(512)
+                _user32.GetWindowTextW(hwnd, title, 512)
+                out.append((hwnd, title.value))
+        return True
+
+    _user32.EnumWindows(_WNDENUMPROC(cb), 0)
+    return out
+
+
+_WM_CLOSE = 0x0010
+
+
+def close_window_by_hwnd(hwnd: int) -> None:
+    """Politely ask a window to close via PostMessage(WM_CLOSE).
+
+    Does NOT use ``taskkill`` — explorer.exe is the user's shell process
+    (manages desktop, taskbar, system tray); killing it would log them
+    out. ``WM_CLOSE`` only closes the targeted folder window.
+    """
+    _user32.PostMessageW(hwnd, _WM_CLOSE, 0, 0)
+
+
 def find_popup(pid: int) -> int | None:
     """Find the Qt menu popup window owned by pid (Win32 class contains 'Popup')."""
     for hwnd, cls, _title in list_process_windows(pid):
@@ -1068,6 +1107,7 @@ def cancel_scan_dialog(dlg: UIAWrapper) -> None:
 CTX_SET_ACTION = "Set Action"
 CTX_DELETE = "delete"
 CTX_KEEP = "keep (remove action)"
+CTX_OPEN_FOLDER = "Open Folder"
 
 _VK_CONTROL = 0x11
 _KEYEVENTF_KEYUP = 0x0002

--- a/qa/scenarios/s19_context_menu_open_folder.py
+++ b/qa/scenarios/s19_context_menu_open_folder.py
@@ -1,0 +1,142 @@
+"""Scenario 19 — Right-click context menu → Open Folder (#102).
+
+Required source: qa/sandbox/near-duplicates (5 .jpg fixtures).
+
+Drives the Open Folder action on a result-tree row end-to-end:
+  scan → close & load →
+  left-click row → right-click row → Open Folder →
+  verify a new Windows Explorer window spawned with the fixture folder open →
+  close that window cleanly via WM_CLOSE.
+
+Catches drift in:
+  - Open Folder action wiring under _create_single_selection_menu
+    (app/views/handlers/context_menu.py:93-122)
+  - The Windows branch (subprocess.Popen(["explorer", "/select,", path]))
+  - Path normalization in `normalize_windows_path`
+
+Distinct from s15 which covers the Set Action submenu of the same context
+menu; the two actions branch in different parts of
+``_create_single_selection_menu`` so s15 doesn't catch Open Folder drift.
+
+Verification approach: Win32 ``EnumWindows`` snapshot before/after the
+click, filtered to class ``CabinetWClass`` (Explorer's folder-window
+class). Looking for a NEW window with the fixture folder name in title
+is robust to whatever Explorer windows the user already has open.
+
+Cleanup: the spawned Explorer window is dismissed via
+``PostMessageW(hwnd, WM_CLOSE, 0, 0)`` so the test doesn't leak windows
+into the user's session. taskkill on explorer.exe would nuke the whole
+shell — desktop, taskbar, tray — so we never use it here.
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+from qa.scenarios import _uia
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO / "qa" / "run-manifest.sqlite"
+
+ROW_TARGET = "neardup_00_q95.jpg"
+EXPECTED_FOLDER_NAME = "near-duplicates"
+
+
+def main() -> int:
+    print("scenario: s19_context_menu_open_folder")
+    app, win = _uia.connect_main()
+    pid = win.process_id()
+    print(f"connected: pid={pid} title={win.window_text()!r}")
+
+    # ── Set up a manifest so the result tree has rows to right-click ──────
+    print("step: scan_and_load")
+    dlg, _ = _uia.open_scan_dialog(win)
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    _uia.close_and_load_manifest(dlg)
+    if not MANIFEST_PATH.exists():
+        print(f"FAIL: scan did not produce manifest at {MANIFEST_PATH}")
+        return 1
+    _, win = _uia.connect_main()
+
+    # ── Snapshot existing Explorer windows before the click ───────────────
+    print("step: snapshot_explorer_baseline")
+    baseline = _uia.list_explorer_windows()
+    baseline_hwnds = {hwnd for hwnd, _ in baseline}
+    print(f"  baseline_explorer_count={len(baseline)}")
+
+    # ── Right-click target row, navigate to Open Folder ───────────────────
+    print(f"step: right_click_row {ROW_TARGET!r}")
+    _uia.left_click_tree_row(win, ROW_TARGET)
+    _uia.right_click_tree_row(win, ROW_TARGET)
+    _uia.select_popup_menu_path(pid, [_uia.CTX_OPEN_FOLDER])
+
+    # ── Wait for Explorer to spawn, find the new window ───────────────────
+    print("step: wait_for_explorer_window")
+    new_hwnds: list[tuple[int, str]] = []
+    deadline = time.time() + 5
+    while time.time() < deadline:
+        current = _uia.list_explorer_windows()
+        new_hwnds = [(h, t) for h, t in current if h not in baseline_hwnds]
+        if new_hwnds:
+            break
+        time.sleep(0.2)
+    print(f"  new_explorer_windows={[(h, t) for h, t in new_hwnds]!r}")
+
+    if not new_hwnds:
+        print(
+            "FAIL: no new Explorer window appeared within 5s after Open Folder "
+            "(regression of #102 — Open Folder action wiring or subprocess "
+            "invocation broken)"
+        )
+        return 1
+
+    # The window title is the Explorer-displayed folder name, which on
+    # Windows defaults to the folder's basename. Match case-insensitively
+    # and as a substring (some locales prefix with parent path).
+    matching = [
+        (h, t) for h, t in new_hwnds
+        if EXPECTED_FOLDER_NAME.lower() in (t or "").lower()
+    ]
+    print(f"  matching_by_folder_name={[(h, t) for h, t in matching]!r}")
+
+    if not matching:
+        # New Explorer windows appeared but none had near-duplicates in
+        # the title. Could be: Explorer opened a different folder than
+        # expected (path normalization regression), or the locale labels
+        # differently — investigate before failing hard. Close whatever
+        # we spawned, then fail.
+        for hwnd, _t in new_hwnds:
+            _uia.close_window_by_hwnd(hwnd)
+        print(
+            f"FAIL: spawned Explorer window did not show "
+            f"{EXPECTED_FOLDER_NAME!r} (titles were "
+            f"{[t for _, t in new_hwnds]!r})"
+        )
+        return 1
+
+    # ── Cleanup: close the spawned window via WM_CLOSE ────────────────────
+    print("step: close_spawned_explorer")
+    for hwnd, _t in matching:
+        _uia.close_window_by_hwnd(hwnd)
+
+    # Verify it actually closed (PostMessage is async; give it a beat).
+    time.sleep(0.5)
+    after = _uia.list_explorer_windows()
+    after_hwnds = {hwnd for hwnd, _ in after}
+    leaked = [(h, t) for h, t in matching if h in after_hwnds]
+    if leaked:
+        # Soft-warn: the window didn't honor WM_CLOSE in time. Not a
+        # test failure (the action under test fired correctly), but
+        # the operator will see an Explorer window still open.
+        print(f"WARN: spawned Explorer windows did not close: {leaked!r}")
+    else:
+        print("  cleanup ok: spawned Explorer window closed")
+
+    print("scenario: s19_context_menu_open_folder DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes #102. Adds layer-3 coverage for the Open Folder action under the result-tree right-click menu. s15 covers the Set Action submenu but the two actions branch in different parts of `_create_single_selection_menu` ([context_menu.py:93-122](app/views/handlers/context_menu.py#L93)), so a regression in either path was invisible to the other.

### Verification approach

The issue suggested three options for confirming Explorer spawned. Two of them don't actually work for this codebase:

- **Option A (process tasklist)**: too brittle — explorer.exe always runs.
- **Option C (log tail)**: doesn't apply — `context_menu.py` doesn't emit a log line on the Open Folder path.

Going with **Option B (window-class enumeration)**: snapshot top-level windows with class `CabinetWClass` (Windows Explorer's folder-window class) before vs after the click. The diff must contain a new Explorer window whose title is the fixture folder basename (`near-duplicates`).

```
new_explorer_windows=[(2885414, 'near-duplicates')]
matching_by_folder_name=[(2885414, 'near-duplicates')]
```

This covers:
- the `subprocess.Popen(["explorer", "/select,", path])` invocation (already unit-tested in [test_context_menu.py:470-501](tests/test_context_menu.py#L470); layer-3 now confirms the wiring actually fires it)
- `normalize_windows_path`'s output landing at a real OS folder
- the `_create_single_selection_menu` action wiring

### Cleanup

The spawned Explorer window is dismissed via `PostMessageW(hwnd, WM_CLOSE, 0, 0)` so the test doesn't leak into the user's session. `taskkill` on explorer.exe would nuke the whole shell (desktop, taskbar, tray) — we never use it.

```
step: close_spawned_explorer
  cleanup ok: spawned Explorer window closed
```

### New helpers in `qa/scenarios/_uia.py`

- `list_explorer_windows()` → `list[(hwnd, title)]` across all pids (uses `EnumWindows` filtered by `CabinetWClass`)
- `close_window_by_hwnd(hwnd)` — polite `WM_CLOSE` (explicitly NOT `taskkill`)
- `CTX_OPEN_FOLDER = "Open Folder"` constant

No app source changes. No new layer-1 tests — the boundary is already covered in `tests/test_context_menu.py`.

## Acceptance criteria

- [x] s19 driver runs cleanly via `python -m qa.scenarios._batch s19_context_menu_open_folder`
- [x] Verification confirms Open Folder fired with the right path (matching Explorer window title)
- [x] No leaked Explorer windows after the run (verified WM_CLOSE took)

## Test plan

- [x] `pytest -q --no-cov` — 540 passed, 2 skipped (no new layer-1 tests)
- [x] `python -m qa.scenarios._batch s19_context_menu_open_folder` — green; trace shows `new_explorer_windows=[(..., 'near-duplicates')]` then clean WM_CLOSE

🤖 Generated with [Claude Code](https://claude.com/claude-code)