### PR TITLE
qa(s18): close spawned Notepad/Explorer windows via WM_CLOSE

### DIFF
--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -548,6 +548,27 @@ short — they should encode the canonical happy path, nothing more.
 Open-ended exploration is the LLM's job, on top of the driver's
 output.
 
+**Cleanup convention — drivers that spawn external shell windows
+(Notepad, Explorer, etc. via `os.startfile`, `explorer.exe`,
+`QDesktopServices::openUrl`) MUST clean them up before returning.**
+Otherwise each batch run leaves windows piled up on the operator's
+desktop. The pattern, used by s18 and s19:
+
+```python
+baseline = _uia.list_top_level_windows(_uia.DEFAULT_SHELL_CLASSES)
+# … perform the click …
+time.sleep(1.0)
+closed = _uia.close_new_shell_windows(baseline)
+print(f"  closed_shell_windows={[(c, t) for _h, c, t in closed]!r}")
+```
+
+`close_new_shell_windows` sends `WM_CLOSE` (NEVER `taskkill` on
+explorer.exe — that nukes the user's whole shell). The default class
+allowlist (`DEFAULT_SHELL_CLASSES = ("CabinetWClass", "Notepad",
+"Notepad++")`) covers the windows we know how to close safely; if a
+user has a different default text editor (VSCode, Sublime), those
+windows leak — document the residual in the driver header.
+
 **Batch runner.** When the user wants to run several (or all) scenarios
 in one go, use `qa.scenarios._batch`:
 

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -120,30 +120,53 @@ def list_process_windows(pid: int) -> list[tuple[int, str, str]]:
     return out
 
 
-def list_explorer_windows() -> list[tuple[int, str]]:
-    """Return [(hwnd, title)] for every visible top-level Windows Explorer
-    window, regardless of process owner.
+# Default Win32 classes for top-level windows that QA drivers spawn as a
+# side effect of os.startfile / explorer.exe shell calls. Closing windows
+# of these classes is safe (they're file/folder viewers, not core shell
+# infrastructure like Progman or Shell_TrayWnd).
+DEFAULT_SHELL_CLASSES: tuple[str, ...] = (
+    "CabinetWClass",   # Windows File Explorer folder window
+    "Notepad",         # Built-in Notepad (default for .log / .txt)
+    "Notepad++",       # Notepad++ if user has it as default
+)
 
-    Identifies them by Win32 class ``CabinetWClass`` — what File Explorer
-    uses for its standard folder windows. Used by s19 to verify that the
-    ``Open Folder`` context-menu action spawned a new Explorer window.
-    Includes pre-existing user windows; callers should snapshot before
-    the action and diff after.
+
+def list_top_level_windows(
+    classes: tuple[str, ...] | None = None,
+) -> list[tuple[int, str, str]]:
+    """Return ``[(hwnd, win32_class, title)]`` for visible top-level windows.
+
+    If ``classes`` is given, return only windows whose Win32 class name
+    is in the tuple. Use this to snapshot before a click that spawns OS
+    shell windows, then diff after to find what appeared.
     """
-    out: list[tuple[int, str]] = []
+    out: list[tuple[int, str, str]] = []
 
     def cb(hwnd, _):
         if _user32.IsWindowVisible(hwnd):
             cls = ctypes.create_unicode_buffer(256)
             _user32.GetClassNameW(hwnd, cls, 256)
-            if cls.value == "CabinetWClass":
+            if classes is None or cls.value in classes:
                 title = ctypes.create_unicode_buffer(512)
                 _user32.GetWindowTextW(hwnd, title, 512)
-                out.append((hwnd, title.value))
+                out.append((hwnd, cls.value, title.value))
         return True
 
     _user32.EnumWindows(_WNDENUMPROC(cb), 0)
     return out
+
+
+def list_explorer_windows() -> list[tuple[int, str]]:
+    """Return [(hwnd, title)] for every visible top-level Windows Explorer
+    window, regardless of process owner.
+
+    Backward-compat wrapper — prefer ``list_top_level_windows`` for new
+    callers. Used by s19's title-shape assertion for the Open Folder action.
+    """
+    return [
+        (hwnd, title)
+        for hwnd, _cls, title in list_top_level_windows(("CabinetWClass",))
+    ]
 
 
 _WM_CLOSE = 0x0010
@@ -157,6 +180,53 @@ def close_window_by_hwnd(hwnd: int) -> None:
     out. ``WM_CLOSE`` only closes the targeted folder window.
     """
     _user32.PostMessageW(hwnd, _WM_CLOSE, 0, 0)
+
+
+def close_new_shell_windows(
+    baseline: list[tuple[int, str, str]],
+    classes: tuple[str, ...] | None = None,
+) -> list[tuple[int, str, str]]:
+    """Snapshot-diff helper: close any shell windows that appeared since
+    ``baseline`` was captured.
+
+    Designed for drivers that intentionally spawn Notepad / Explorer /
+    similar viewers as a side effect of the action under test (s18 Log
+    menu, s19 Open Folder). Workflow::
+
+        baseline = list_top_level_windows(DEFAULT_SHELL_CLASSES)
+        # … perform the click that spawns the shell window …
+        time.sleep(1)
+        closed = close_new_shell_windows(baseline)
+
+    Args:
+        baseline: List of ``(hwnd, class, title)`` taken before the action.
+            Only ``hwnd`` is read; class/title are ignored, kept for
+            symmetry with the producer.
+        classes: Class allowlist for the *current* snapshot. Defaults to
+            ``DEFAULT_SHELL_CLASSES``. Pass a narrower tuple to scope
+            cleanup (e.g. ``("CabinetWClass",)`` to close only Explorer
+            spawns, leaving Notepad alone).
+
+    Returns:
+        ``[(hwnd, class, title)]`` for every window that was sent
+        WM_CLOSE — useful for logging "what we cleaned up".
+
+    Note: only windows in ``classes`` are considered. If the user's
+    default app for .log / .csv files is something other than Notepad
+    or Notepad++ (e.g. VSCode, Sublime), those windows are NOT
+    auto-closed. The driver should document that residual.
+    """
+    if classes is None:
+        classes = DEFAULT_SHELL_CLASSES
+    baseline_hwnds = {h for h, _, _ in baseline}
+    new = [
+        (h, c, t)
+        for h, c, t in list_top_level_windows(classes)
+        if h not in baseline_hwnds
+    ]
+    for hwnd, _cls, _title in new:
+        close_window_by_hwnd(hwnd)
+    return new
 
 
 def find_popup(pid: int) -> int | None:

--- a/qa/scenarios/s18_log_menu.py
+++ b/qa/scenarios/s18_log_menu.py
@@ -18,20 +18,24 @@ Each item has two paths in main_window.py:_open_*_log*:
 
 Which path fires depends on the user's machine state — today's app log
 exists post-init_logging, but the delete-log dir only exists if the user
-has executed deletions. Either path is acceptable per item; this driver
-just verifies that nothing UNEXPECTED appears (a third title would mean
+has executed deletions before. Either path is acceptable per item; this
+driver verifies that nothing UNEXPECTED appears (a third title would mean
 copy drift or a misrouted handler).
 
-⚠️  Side effect: each click that hits the success path spawns a real
-Explorer / Notepad window in a separate process. Those windows persist
-after the test (they belong to OS shell processes that the QA harness
-can't track). Running the s18 driver leaks 1–4 OS windows onto the
-user's desktop — accepted as the cost of layer-3 coverage per #101.
+Cleanup (added in #102 follow-up): each click captures a baseline of
+top-level shell windows (CabinetWClass / Notepad / Notepad++) before
+clicking, then sends WM_CLOSE to any new ones in those classes after.
+This keeps the user's desktop clean across runs. Caveats:
+  - Windows that aren't in DEFAULT_SHELL_CLASSES (e.g. VSCode,
+    Sublime, EditPad if those are the user's default for .log/.csv)
+    are NOT auto-closed — the OS treats those as long-lived editors
+    where forced WM_CLOSE could surprise the user.
+  - WM_CLOSE is asynchronous; the post-test verification is best-effort.
 
 Mode B (forcibly emptying the log dirs to verify all four Not-Found
-warning copies) is explicitly out-of-scope per #101's "Constraints"
-section — the cleanup would be operator-destructive on the user's real
-PhotoManager appdata directory.
+warning copies deterministically) is explicitly out-of-scope per #101's
+"Constraints" section — the cleanup would be operator-destructive on
+the user's real PhotoManager appdata directory.
 
 Catches drift in: menu item titles (registered in
 app/views/components/menu_controller.py), QMessageBox warning titles
@@ -72,7 +76,8 @@ def main() -> int:
 
     for item, expected_not_found_title in _LOG_ITEMS:
         print(f"step: click {item!r}")
-        baseline = _photo_manager_window_titles(pid)
+        baseline_pm = _photo_manager_window_titles(pid)
+        baseline_shell = _uia.list_top_level_windows(_uia.DEFAULT_SHELL_CLASSES)
 
         try:
             _uia.menu_path(win, _uia.MENU_LOG, item)
@@ -80,18 +85,29 @@ def main() -> int:
             print(f"FAIL: menu navigation to Log > {item!r} raised {exc!r}")
             return 1
 
-        # Give either path (success → no dialog; not-found → QMessageBox)
-        # ~1s to settle. QMessageBox.warning is synchronous from the slot's
-        # perspective, but UIA enumeration of the new top-level window can
-        # lag the modal's actual show() by a few frames.
+        # Give either path (success → external shell window; not-found →
+        # PM-owned QMessageBox) ~1s to settle. Both modal show() and
+        # os.startfile spawn happen async-ish from the slot's perspective,
+        # but UIA + EnumWindows enumeration of new top-level windows can
+        # lag the show() by a few frames.
         time.sleep(1.0)
-        after = _photo_manager_window_titles(pid)
-        new_titles = after - baseline
-        print(f"  new_pm_windows={sorted(new_titles)!r}")
+        after_pm = _photo_manager_window_titles(pid)
+        new_pm_titles = after_pm - baseline_pm
+        print(f"  new_pm_windows={sorted(new_pm_titles)!r}")
 
-        if not new_titles:
-            print(f"  ok: success path (os.startfile spawned external window)")
-        elif new_titles == {expected_not_found_title}:
+        # Clean up any shell windows the click may have spawned BEFORE
+        # checking the PM-side outcome — keeps the desktop tidy even if
+        # an assertion below fails and we early-return.
+        closed = _uia.close_new_shell_windows(baseline_shell)
+        if closed:
+            print(
+                f"  closed_shell_windows="
+                f"{[(c, t) for _h, c, t in closed]!r}"
+            )
+
+        if not new_pm_titles:
+            print(f"  ok: success path (cleaned up {len(closed)} shell window(s))")
+        elif new_pm_titles == {expected_not_found_title}:
             print(f"  ok: not-found path with expected title — dismissing")
             if not _uia.dismiss_dialog_by_title(pid, expected_not_found_title):
                 print(
@@ -102,7 +118,7 @@ def main() -> int:
         else:
             print(
                 f"FAIL: unexpected dialogs after clicking {item!r}: "
-                f"{sorted(new_titles)!r} "
+                f"{sorted(new_pm_titles)!r} "
                 f"(expected either no new dialog OR exactly "
                 f"{{{expected_not_found_title!r}}})"
             )


### PR DESCRIPTION
## Summary

Follow-up to #115 (s18) and #116 (s19). Brings s18 to the same desktop-hygiene bar that s19 introduced: capture a baseline of top-level shell windows before each click, send `WM_CLOSE` to any new ones afterward.

Without this, every batch run leaks 1–4 Notepad/Explorer windows. The s18 PR (#115) flagged the leak but accepted it as the cost of coverage; #116 established `WM_CLOSE` as the safe primitive (never `taskkill` on `explorer.exe` — that nukes the user's whole shell). Applying the same pattern to s18 closes the leak.

### Helper-layer refactor in `qa/scenarios/_uia.py`

Extracted s19's window-snapshot logic into reusable primitives:

- `list_top_level_windows(classes=None) -> [(hwnd, class, title)]` — `EnumWindows` with optional class allowlist
- `close_new_shell_windows(baseline, classes=None) -> [closed]` — snapshot-diff that sends `WM_CLOSE` to whatever's new in the configured class set
- `DEFAULT_SHELL_CLASSES = ("CabinetWClass", "Notepad", "Notepad++")`
- `list_explorer_windows()` retained as a thin wrapper for s19's title-shape assertion (backward compat — s19 isn't touched)

### s18 driver changes

Per Log-menu click: capture a `DEFAULT_SHELL_CLASSES` baseline before the click, run the click, then call `close_new_shell_windows` to clean up anything that spawned. Also extends the success-path log line to count cleanups.

### SKILL.md update

Adds a "Cleanup convention" subsection in the Scenario drivers section: drivers that spawn external shell windows MUST clean them up via this pattern. Documents the `WM_CLOSE`-not-`taskkill` rule and the residual for users whose default editor for `.log`/`.csv` isn't Notepad/Notepad++ (VSCode, Sublime — those would need to be added to `DEFAULT_SHELL_CLASSES` if support's desired, but forced `WM_CLOSE` on long-lived editors could surprise the operator).

## Verification trace

```
step: click 'Open Latest Log'
  closed_shell_windows=[('Notepad', 'app_20260504.log - 記事本')]
  ok: success path (cleaned up 1 shell window(s))
step: click 'Open Latest Delete Log'
  closed_shell_windows=[('Notepad', 'delete_20260420_214111.csv - 記事本')]
  ok: success path (cleaned up 1 shell window(s))
step: click 'Open Log Directory'
  ok: success path (cleaned up 0 shell window(s))     # Explorer reuse
step: click 'Open Delete Log Directory'
  ok: success path (cleaned up 0 shell window(s))     # Explorer reuse
```

The directory-target items close 0 because Windows Explorer activates an already-open folder window rather than spawning a new one (default shell behavior; the user often has the log directory open from a prior run). Items 1 and 2 genuinely spawn fresh Notepads and now close cleanly. s19's batch run was re-verified post-refactor — still passes.

## Test plan

- [x] `pytest -q --no-cov` — 540 passed, 2 skipped (no behavior change at layer 1)
- [x] `python -m qa.scenarios._batch s18_log_menu` — green; trace shows 2 Notepad windows closed, 0 leaks
- [x] `python -m qa.scenarios._batch s19_context_menu_open_folder` — still green post-`list_explorer_windows` refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)