### PR TITLE
qa(s21) + fix: List > Remove from List driver, fix multi-word plural

### DIFF
--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -99,7 +99,7 @@ If everything is already populated, skip the regen and move on.
 ## Phase 3 — Plan
 
 **Default behavior — invoked with no additional prompt:** run **all
-19 scenarios** in batch via `qa.scenarios._batch`. Don't print the
+20 scenarios** in batch via `qa.scenarios._batch`. Don't print the
 menu, don't ask which to run. Get one `yes batch` approval up front
 (per the gate rule below) and proceed. The full batch typically
 finishes in ~30–60 seconds with the focus fix in `_uia.py`.
@@ -522,6 +522,7 @@ running.
 | 17 | Scan dialog widgets (add / remove / reorder / recursive) | `qa.scenarios.s17_scan_dialog_widgets` | ✓ ready |
 | 18 | Log menu (Open Latest Log / Delete Log / Log Dir / Delete Log Dir) | `qa.scenarios.s18_log_menu` | ✓ ready |
 | 19 | Right-click context menu → Open Folder (explorer.exe /select integration) | `qa.scenarios.s19_context_menu_open_folder` | ✓ ready |
+| 21 | List menu → Remove from List (no-selection / single / multi) | `qa.scenarios.s21_list_menu_remove` | ✓ ready |
 
 Several drivers also call cross-scenario invariant probes from
 `qa/scenarios/_invariants.py` — they assert that the status bar matches
@@ -573,14 +574,14 @@ windows leak — document the residual in the driver header.
 in one go, use `qa.scenarios._batch`:
 
 ```
-.venv/Scripts/python.exe -m qa.scenarios._batch              # all 19 (s01–s19)
+.venv/Scripts/python.exe -m qa.scenarios._batch              # all 20 (s01–s19, s21)
 .venv/Scripts/python.exe -m qa.scenarios._batch s04_corrupted s09_walker_exclusions
 ```
 
 For each scenario it: configures `qa/settings.json` → launches
 `main.py` → waits 3.5 s → runs the driver → closes the window →
 waits for the subprocess to exit → moves to the next. Prints a final
-SUMMARY table with rc per scenario. The whole batch (19 scenarios)
+SUMMARY table with rc per scenario. The whole batch (20 scenarios)
 typically finishes in ~120–200 seconds. Each app launch is still a
 real launch — get the user's "yes batch" once before starting.
 

--- a/app/views/components/status_messages.py
+++ b/app/views/components/status_messages.py
@@ -62,11 +62,18 @@ def report_count(
     verb: str,
     count: int,
     noun: str,
+    plural: str | None = None,
     timeout: int = DEFAULT_TIMEOUT_MS,
 ) -> None:
     """Report a completed action with a count. e.g. ``Removed 5 items``.
 
-    Pluralizes *noun* by appending ``s`` when count is not exactly 1.
+    Default pluralization appends ``s`` to *noun* when count is not
+    exactly 1. For irregular plurals (children) or multi-word phrases
+    where the bare suffix rule lands on the wrong word
+    ("item from list" → "item from lists"), pass *plural* explicitly:
+
+        report_count(reporter, "Removed", n, "item from list",
+                     plural="items from list")
     """
-    suffix = "" if count == 1 else "s"
-    reporter.show_status(f"{verb} {count} {noun}{suffix}", timeout)
+    form = noun if count == 1 else (plural or noun + "s")
+    reporter.show_status(f"{verb} {count} {form}", timeout)

--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -226,7 +226,11 @@ class FileOperationsHandler:
                 self.ui_updater.refresh_tree(self.vm.groups)
                 self._sync_removed_to_db(paths_for_db)
                 report_count(
-                    self.status_reporter, "Removed", len(highlighted_items), "item from list"
+                    self.status_reporter,
+                    "Removed",
+                    len(highlighted_items),
+                    "item from list",
+                    plural="items from list",
                 )
                 return
 
@@ -272,7 +276,13 @@ class FileOperationsHandler:
             self._sync_removed_to_db(paths_for_db)
 
             total_removed = len(file_paths) + len(group_numbers)
-            report_count(self.status_reporter, "Removed", total_removed, "item from list")
+            report_count(
+                self.status_reporter,
+                "Removed",
+                total_removed,
+                "item from list",
+                plural="items from list",
+            )
 
         except Exception as e:
             logger.error("Remove items from list failed: {}", e)

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -42,6 +42,7 @@ ALL_SCENARIOS = [
     "s17_scan_dialog_widgets",
     "s18_log_menu",
     "s19_context_menu_open_folder",
+    "s21_list_menu_remove",
 ]
 
 

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -37,6 +37,7 @@ SCENARIO_SOURCES: dict[str, list[str]] = {
     # s18 doesn't run a scan; the source list is irrelevant.
     "s18_log_menu":            [],
     "s19_context_menu_open_folder": ["qa/sandbox/near-duplicates"],
+    "s21_list_menu_remove":         ["qa/sandbox/near-duplicates"],
 }
 
 

--- a/qa/scenarios/s21_list_menu_remove.py
+++ b/qa/scenarios/s21_list_menu_remove.py
@@ -1,0 +1,202 @@
+"""Scenario 21 — List menu → Remove from List (menu-bar path).
+
+Required source: qa/sandbox/near-duplicates (5 files, basenames
+neardup_NN_qXX.jpg).
+
+Drives the menu-bar entry routed through
+MainWindow._remove_from_list_toolbar →
+file_operations.remove_from_list_toolbar — three branches that s01
+currently only probes for enabled-state, never invokes:
+
+  (a) No selection: List → Remove from List → "Remove from List"
+      QMessageBox carrying "No items selected" body. Manifest
+      unchanged.
+  (b) Single highlight: left-click one row → List → Remove from List
+      → status bar "Removed 1 item from list", that row marked
+      'removed' in the manifest, others unchanged.
+  (c) Multi highlight: left-click + Ctrl+click → List → Remove from
+      List → status bar "Removed 2 items from list", both rows
+      marked 'removed', untouched rows unchanged.
+
+Distinct from s20 (right-click multi-row branch through
+remove_items_from_list) and from s15 (Set Action via context menu).
+This scenario covers remove_from_list_toolbar specifically.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+from qa.scenarios import _invariants, _uia
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO / "qa" / "run-manifest.sqlite"
+
+ROW_SINGLE = "neardup_00_q95.jpg"
+ROW_MULTI_A = "neardup_01_q88.jpg"
+ROW_MULTI_B = "neardup_02_q80.jpg"
+ROWS_UNTOUCHED = ("neardup_03_q72.jpg", "neardup_04_q65.jpg")
+ALL_ROWS = (ROW_SINGLE, ROW_MULTI_A, ROW_MULTI_B, *ROWS_UNTOUCHED)
+
+
+def _read_decisions() -> dict[str, str]:
+    """Return {basename: user_decision} for every fixture row in the manifest."""
+    if not MANIFEST_PATH.exists():
+        raise RuntimeError(f"manifest not found at {MANIFEST_PATH}")
+    conn = sqlite3.connect(str(MANIFEST_PATH))
+    try:
+        rows = conn.execute(
+            "SELECT source_path, user_decision FROM migration_manifest "
+            "WHERE source_path LIKE ?",
+            ("%neardup_%",),
+        ).fetchall()
+    finally:
+        conn.close()
+    return {Path(p).name: (d or "") for p, d in rows}
+
+
+def main() -> int:
+    print("scenario: s21_list_menu_remove")
+    app, win = _uia.connect_main()
+    pid = win.process_id()
+    print(f"connected: pid={pid} title={win.window_text()!r}")
+
+    # ── Setup: scan + close & load ────────────────────────────────────────
+    print("step: open_scan_dialog")
+    dlg, _ = _uia.open_scan_dialog(win)
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+
+    print("step: close_and_load")
+    _uia.close_and_load_manifest(dlg)
+    _, win = _uia.connect_main()
+
+    print("step: snapshot_pre_decisions")
+    pre = _read_decisions()
+    if set(pre) != set(ALL_ROWS):
+        print(
+            f"FAIL: fixture row mismatch; pre={sorted(pre)} "
+            f"expected={sorted(ALL_ROWS)}"
+        )
+        return 1
+    print(f"  pre_decisions={dict(sorted(pre.items()))}")
+
+    failures: list[str] = []
+
+    # ── (a) No-selection branch ───────────────────────────────────────────
+    print("step: branch_a_no_selection")
+    _uia.menu_path(win, _uia.MENU_LIST, "Remove from List")
+    try:
+        msgbox_hwnd = _uia.wait_for_dialog(pid, "Remove from List", timeout=5)
+    except TimeoutError:
+        print(
+            "FAIL: no-selection branch did not surface "
+            "'Remove from List' QMessageBox"
+        )
+        return 1
+    msgbox = _uia.connect_by_handle(msgbox_hwnd)
+    body_seen = False
+    for label in msgbox.descendants(control_type="Text"):
+        try:
+            t = (label.window_text() or "").strip()
+            if "No items selected" in t:
+                body_seen = True
+                print(f"  body_text={t!r}")
+                break
+        except Exception:
+            continue
+    if not body_seen:
+        failures.append(
+            "no-selection QMessageBox missing 'No items selected' body"
+        )
+    if not _uia.dismiss_dialog_by_title(pid, "Remove from List", timeout=3):
+        failures.append(
+            "could not dismiss no-selection 'Remove from List' QMessageBox"
+        )
+    post_a = _read_decisions()
+    if post_a != pre:
+        failures.append(
+            f"manifest mutated by no-selection branch: pre={pre} post={post_a}"
+        )
+
+    # ── (b) Single-row highlight branch ───────────────────────────────────
+    print(f"step: branch_b_single target={ROW_SINGLE!r}")
+    _, win = _uia.connect_main()
+    _uia.left_click_tree_row(win, ROW_SINGLE)
+    _uia.menu_path(win, _uia.MENU_LIST, "Remove from List")
+    inv_b = _invariants.assert_status_bar_matches(
+        win, r"Removed 1 item from list", within_s=2.5
+    )
+    if not inv_b:
+        failures.append("status bar did not echo 'Removed 1 item from list'")
+    post_b = _read_decisions()
+    print(f"  post_b={dict(sorted(post_b.items()))}")
+    if post_b.get(ROW_SINGLE) != "removed":
+        failures.append(
+            f"single branch: {ROW_SINGLE} user_decision="
+            f"{post_b.get(ROW_SINGLE)!r}, expected 'removed'"
+        )
+    for other in ALL_ROWS:
+        if other == ROW_SINGLE:
+            continue
+        if post_b.get(other) != pre.get(other):
+            failures.append(
+                f"single branch leaked into {other}: "
+                f"pre={pre.get(other)!r} post={post_b.get(other)!r}"
+            )
+
+    # ── (c) Multi-row highlight branch ────────────────────────────────────
+    print(f"step: branch_c_multi targets=[{ROW_MULTI_A!r}, {ROW_MULTI_B!r}]")
+    _, win = _uia.connect_main()
+    _uia.left_click_tree_row(win, ROW_MULTI_A)
+    _uia.ctrl_click_tree_row(win, ROW_MULTI_B)
+    _uia.menu_path(win, _uia.MENU_LIST, "Remove from List")
+    inv_c = _invariants.assert_status_bar_matches(
+        win, r"Removed 2 items from list", within_s=2.5
+    )
+    if not inv_c:
+        failures.append("status bar did not echo 'Removed 2 items from list'")
+    post_c = _read_decisions()
+    print(f"  post_c={dict(sorted(post_c.items()))}")
+    if post_c.get(ROW_MULTI_A) != "removed":
+        failures.append(
+            f"multi branch: {ROW_MULTI_A} user_decision="
+            f"{post_c.get(ROW_MULTI_A)!r}, expected 'removed'"
+        )
+    if post_c.get(ROW_MULTI_B) != "removed":
+        failures.append(
+            f"multi branch: {ROW_MULTI_B} user_decision="
+            f"{post_c.get(ROW_MULTI_B)!r}, expected 'removed'"
+        )
+    for other in ROWS_UNTOUCHED:
+        if post_c.get(other) != pre.get(other):
+            failures.append(
+                f"untouched {other}: pre={pre.get(other)!r} "
+                f"post={post_c.get(other)!r}"
+            )
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    print("step: invariant_actions_enabled")
+    inv_actions = _invariants.assert_manifest_actions_consistent(
+        win, expected_enabled=True
+    )
+    if not inv_actions:
+        print(
+            "FAIL: manifest-gated menu items not all enabled after "
+            "Remove from List"
+        )
+        return 1
+
+    print("scenario: s21_list_menu_remove DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_status_messages.py
+++ b/tests/test_status_messages.py
@@ -45,6 +45,31 @@ def test_report_count_custom_timeout():
     reporter.show_status.assert_called_once_with("Loaded 3 groups", 10000)
 
 
+def test_report_count_multi_word_noun_uses_explicit_plural():
+    """Caught by s21: the bare-suffix rule attaches 's' to the LAST word
+    of a multi-word noun, producing 'Removed 2 item from lists' instead
+    of 'Removed 2 items from list'. Callers fix this by passing the
+    correct plural form explicitly."""
+    reporter = MagicMock()
+    report_count(
+        reporter, "Removed", 2, "item from list", plural="items from list"
+    )
+    reporter.show_status.assert_called_once_with(
+        "Removed 2 items from list", DEFAULT_TIMEOUT_MS
+    )
+
+
+def test_report_count_singular_ignores_plural_arg():
+    """When count is 1, the singular form wins regardless of plural=."""
+    reporter = MagicMock()
+    report_count(
+        reporter, "Removed", 1, "item from list", plural="items from list"
+    )
+    reporter.show_status.assert_called_once_with(
+        "Removed 1 item from list", DEFAULT_TIMEOUT_MS
+    )
+
+
 # ── pluralize / plural_form (added for #109) ──────────────────────────────
 
 


### PR DESCRIPTION
## Summary

- Adds [qa/scenarios/s21_list_menu_remove.py](qa/scenarios/s21_list_menu_remove.py) — drives every branch of the menu-bar `List → Remove from List` flow that s01 only probes for enabled-state: no selection (QMessageBox), single highlight (`Removed 1 item from list` + manifest mark), multi highlight (`Removed 2 items from list` + manifest mark). Closes [#104](https://github.com/jackal998/photo-manager/issues/104).
- **Bug fix surfaced by s21**: `report_count` mispluralized multi-word nouns. `"item from list"` + `s`-suffix produced `"Removed 2 item from lists"`. Same shape as [#109](https://github.com/jackal998/photo-manager/issues/109)/[#112](https://github.com/jackal998/photo-manager/pull/112) ("1 pairs"). The existing test suite missed it — the only multi-word noun test case used `count=1`, where no suffix is applied.
- Registration: appended to `ALL_SCENARIOS`, added to `SCENARIO_SOURCES` (`["qa/sandbox/near-duplicates"]`), `SKILL.md` scenario table + counts updated (s01–s19, s21 → 20 scenarios).

### The fix

- `report_count` in [app/views/components/status_messages.py](app/views/components/status_messages.py) now accepts an optional `plural=` argument, mirroring the existing `pluralize`/`plural_form` API for irregular plurals. Default behavior (single-word noun + bare `s`) is unchanged.
- Both `"item from list"` call sites in [app/views/handlers/file_operations.py](app/views/handlers/file_operations.py) — `remove_from_list_toolbar` (this PR's surface) and `remove_items_from_list` (s20's future surface) — pass `plural="items from list"` explicitly.
- Two regression tests in [tests/test_status_messages.py](tests/test_status_messages.py) cover the plural-override path and the singular-wins-over-`plural=` case.

### Why fix here, not in a separate PR

s21's whole point is to verify the status-bar copy. Without the fix the test would have to be weakened to match the buggy output, then re-tightened in a follow-up PR. One coherent commit: the test catches the bug, the fix lands with the test that proves it. Same precedent as #112.

## Test plan

- [x] `pytest -q` — 542 passed, 2 skipped (+2 from new regression tests over the previous baseline of 540), per-file 70% gate clears
- [x] `python -m qa.scenarios._batch s21_list_menu_remove` — green, all three branches:
  - `body_text='No items selected. Please select rows first.'`
  - `inv: status_bar_matches r='Removed 1 item from list' ok=True`
  - `inv: status_bar_matches r='Removed 2 items from list' ok=True`
  - `inv: manifest_actions_consistent ok=True discrepancies=[]`

🤖 Generated with [Claude Code](https://claude.com/claude-code)