### PR TITLE
ci: add qa-batch workflow for layer-3 drift detection (#74)

### DIFF
--- a/.github/workflows/qa-batch.yml
+++ b/.github/workflows/qa-batch.yml
@@ -1,0 +1,124 @@
+name: qa-batch
+
+# Run the layer-3 qa-explore batch on PRs that touch UI / scanner / qa surface.
+# Goal: catch driver-vs-app label drift and state-transition regressions
+# before merge, instead of relying on a manual `python -m qa.scenarios._batch`
+# discipline (#74).
+#
+# Status: NON-REQUIRED, informational. Per #74's acceptance criteria, this
+# workflow needs ≥10 consecutive flake-free runs on real PRs before being
+# promoted to a required status check via branch protection. Until then,
+# treat a red qa-batch as a signal to investigate, not a merge blocker.
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/qa-batch.yml'
+      - 'app/views/**'
+      - 'qa/**'
+      - 'scanner/**'
+      - 'infrastructure/**'
+      - 'requirements.txt'
+      - 'dev-requirements.txt'
+      - 'qa/requirements.txt'
+      - 'scripts/make_qa_sandbox.py'
+      - 'scripts/make_qa_images.py'
+  workflow_dispatch: {}   # allow manual trigger from the Actions UI for debugging
+
+concurrency:
+  group: qa-batch-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  qa:
+    runs-on: windows-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: |
+            requirements.txt
+            dev-requirements.txt
+            qa/requirements.txt
+
+      # exiftool is a runtime boundary the scanner uses for HEIC / RAW / MOV /
+      # MP4 metadata. Chocolatey is preinstalled on windows-latest runners.
+      - name: Install exiftool
+        run: choco install exiftool -y --no-progress
+
+      - name: Install Python deps
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          pip install -r dev-requirements.txt
+          pip install -r qa/requirements.txt
+
+      # Idempotent fixture builder. Generates qa/sandbox/ on a fresh checkout.
+      - name: Build qa sandbox fixtures
+        run: python scripts/make_qa_sandbox.py
+
+      - name: Run qa batch
+        id: batch
+        shell: pwsh
+        env:
+          QT_ACCESSIBILITY: '1'
+          # Pin DPI so pixel-coord clicks (s17, s20) match local-dev positions.
+          QT_SCALE_FACTOR: '1'
+          QT_AUTO_SCREEN_SCALE_FACTOR: '0'
+          # Force unbuffered stdout so the live log surfaces in the runner UI.
+          PYTHONUNBUFFERED: '1'
+          # Unicode arrows / ellipsis in driver output: avoid cp1252 encode errors.
+          PYTHONIOENCODING: 'utf-8'
+        run: |
+          python -m qa.scenarios._batch 2>&1 | Tee-Object -FilePath qa-batch.log
+          # Forward the batch's exit code; PowerShell pipes default to the
+          # tail-element rc which is Tee-Object's (always 0). The variable
+          # `$LASTEXITCODE` from the python invocation is what matters.
+          exit $LASTEXITCODE
+
+      # Always emit a per-scenario rc summary to the job page so triage from
+      # the PR is one click. Runs even on failure so we see WHICH scenarios
+      # failed without digging through the full log.
+      - name: Per-scenario summary
+        if: always()
+        shell: pwsh
+        run: |
+          if (Test-Path qa-batch.log) {
+            Add-Content $env:GITHUB_STEP_SUMMARY '## QA batch summary'
+            Add-Content $env:GITHUB_STEP_SUMMARY ''
+            Add-Content $env:GITHUB_STEP_SUMMARY '```'
+            Select-String -Path qa-batch.log -Pattern '^=====|^total:|^\s+\[(OK|FAIL)\]' |
+              ForEach-Object { $_.Line } |
+              Add-Content $env:GITHUB_STEP_SUMMARY
+            Add-Content $env:GITHUB_STEP_SUMMARY '```'
+          } else {
+            Add-Content $env:GITHUB_STEP_SUMMARY '## QA batch summary'
+            Add-Content $env:GITHUB_STEP_SUMMARY ''
+            Add-Content $env:GITHUB_STEP_SUMMARY '_qa-batch.log was not produced — see the "Run qa batch" step for setup-time errors._'
+          }
+
+      # Upload the full log so debugging a failed scenario doesn't require
+      # re-running CI. 7-day retention is plenty for triage cycles.
+      - name: Upload full batch log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: qa-batch-log
+          path: qa-batch.log
+          if-no-files-found: ignore
+          retention-days: 7
+
+      # Belt-and-braces cleanup. The runner is ephemeral so this rarely
+      # matters, but a hung main.py from a flaky scenario can leave
+      # background processes that confuse subsequent steps within the same
+      # job. Always exit 0 — failure in cleanup must not mask the real result.
+      - name: Cleanup any leaked python.exe
+        if: always()
+        shell: pwsh
+        run: |
+          taskkill /F /IM python.exe /T 2>$null
+          exit 0

--- a/.github/workflows/qa-batch.yml
+++ b/.github/workflows/qa-batch.yml
@@ -29,6 +29,12 @@ concurrency:
   group: qa-batch-${{ github.ref }}
   cancel-in-progress: true
 
+# Public-repo hardening: workflow is read-only, no write back to the repo,
+# no token-scoped operations. Locking permissions explicitly here keeps it
+# audit-ready and resilient to future GitHub default changes.
+permissions:
+  contents: read
+
 jobs:
   qa:
     runs-on: windows-latest

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -207,6 +207,35 @@ CI-runnable subset that catches the most common drift class.
 
 ---
 
+## Known CI limitations
+
+### `s12_save_manifest` fails on GitHub-hosted runners ([#129](https://github.com/jackal998/photo-manager/issues/129))
+
+The qa-batch workflow runs all 21 scenarios on `windows-latest` and
+**always reports `s12_save_manifest` as failing**. This is honest
+signalling, not a regression: the failure has a known root cause that
+hosted-runner constraints make unfixable without changing the app.
+
+What's going on: the File → Save Manifest Decisions… flow opens a
+native Windows `IFileSaveDialog`. That dialog uses a COM modal loop
+which only pumps COM messages — not regular `WM_*` messages — and the
+hosted runner additionally doesn't deliver real synthesized mouse or
+keyboard input. So `PostMessage(BM_CLICK)`, `PostMessage(WM_KEYDOWN,
+VK_RETURN)`, UIA `Invoke`, and `click_input` all return success on
+the runner but the Save action never fires. See [#129](https://github.com/jackal998/photo-manager/issues/129)
+for the full diagnostic data and the alternatives evaluated.
+
+Locally on a real Windows desktop session, `s12` runs green as part
+of the full 21-scenario batch — its drift coverage is intact.
+
+The PR-time CI signal works correctly for the other 20 scenarios:
+when a label or a state-transition shifts under any of those, the
+qa-batch job goes red on the relevant scenario and the workflow
+summary names it. Until [#129](https://github.com/jackal998/photo-manager/issues/129)
+resolves, treat a qa-batch failure on s12 alone as expected.
+
+---
+
 ## Open work
 
 - **Layer 2 is on-demand**, not on the roadmap. Add a spot-test under

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -20,7 +20,11 @@ import time
 from pathlib import Path
 
 REPO = Path(__file__).resolve().parents[2]
-PY = str(REPO / ".venv" / "Scripts" / "python.exe")
+# Inherit the Python that invoked us — works under .venv (the local-dev
+# convention), under a CI runner where actions/setup-python puts python on
+# PATH directly, and under any other venv layout (conda, pyenv-win, etc).
+# Previously hardcoded as REPO/.venv/Scripts/python.exe, which broke CI.
+PY = sys.executable
 
 ALL_SCENARIOS = [
     "s01_happy_path",

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -97,9 +97,18 @@ def run_one(name: str) -> tuple[int, str]:
         driver_rc = r.returncode
         if driver_rc != 0:
             driver_err = "non-zero exit"
-    except subprocess.TimeoutExpired:
+    except subprocess.TimeoutExpired as exc:
         driver_err = "driver timeout"
         print(f"DRIVER TIMEOUT after 180s", flush=True)
+        # Surface whatever the driver printed before hanging — by default
+        # TimeoutExpired drops it on the floor, which makes hangs
+        # essentially undebuggable from CI logs.
+        if exc.stdout:
+            partial = exc.stdout if isinstance(exc.stdout, str) else exc.stdout.decode("utf-8", "replace")
+            print(f"DRIVER PARTIAL STDOUT:\n{partial}", flush=True)
+        if exc.stderr:
+            partial_err = exc.stderr if isinstance(exc.stderr, str) else exc.stderr.decode("utf-8", "replace")
+            print(f"DRIVER PARTIAL STDERR:\n{partial_err.strip()[:2000]}", flush=True)
     except Exception as e:
         driver_err = repr(e)
         print(f"DRIVER EXC: {e!r}", flush=True)

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -997,7 +997,39 @@ def save_manifest_via_native_dialog(
     # (so this still works on zh-TW where the button reads "存檔") and
     # ``click_input`` delivers a real synthesized click that doesn't
     # depend on foreground state staying glued to the dialog.
+    # Diagnostic: dialog rect + every Button + the picked button. Removed
+    # once CI is reliably green; until then, this is invaluable when the
+    # bottom-row heuristic picks the wrong control.
+    try:
+        dr = save_dlg.rectangle()
+        print(
+            f"  save_dlg_rect=({dr.left},{dr.top},{dr.right},{dr.bottom})",
+            flush=True,
+        )
+        for b in save_dlg.descendants(control_type="Button"):
+            try:
+                br = b.rectangle()
+                t = (b.window_text() or "").strip()
+                print(
+                    f"    btn title={t!r} "
+                    f"rect=({br.left},{br.top},{br.right},{br.bottom})",
+                    flush=True,
+                )
+            except Exception:
+                continue
+    except Exception:
+        pass
     save_btn = _find_native_dialog_action_button(save_dlg)
+    try:
+        sr = save_btn.rectangle()
+        st = (save_btn.window_text() or "").strip()
+        print(
+            f"  picked save_btn: title={st!r} "
+            f"rect=({sr.left},{sr.top},{sr.right},{sr.bottom})",
+            flush=True,
+        )
+    except Exception:
+        pass
     _focus(save_dlg)
     save_btn.click_input()
 

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -851,6 +851,38 @@ def click_remove_all_sources(dlg: UIAWrapper) -> None:
     time.sleep(0.3)
 
 
+def _find_dialog_button(dlg: UIAWrapper, title: str) -> UIAWrapper:
+    """Find a Button by ``title`` inside ``dlg``, picking the bottom-most match.
+
+    Disambiguates against locale-specific title-bar buttons that share the
+    same accessible name as the dialog's form-row buttons. Concrete case:
+    on a zh-TW Windows session the title-bar Close button reads "關閉" so a
+    plain ``dlg.child_window(title="Close", control_type="Button")`` resolves
+    cleanly to the Apply/Close form button. On en-US (e.g. GitHub's
+    ``windows-latest`` runners) the title-bar Close button is also "Close",
+    creating an ambiguous match that pywinauto's ``__resolve_control``
+    times out on rather than picking either.
+
+    The form-row buttons sit at the bottom of the dialog rect; the title-bar
+    button sits at the top. Sort by ``rectangle().top`` and take the
+    bottom-most. When only one Button matches the title (the zh-TW case),
+    "bottom-most" reduces to "the one button" — local behavior unchanged.
+
+    Raises ``RuntimeError`` when no Button matches the title.
+    """
+    candidates: list[tuple[int, UIAWrapper]] = []
+    for btn in dlg.descendants(control_type="Button"):
+        try:
+            if (btn.window_text() or "").strip() == title:
+                candidates.append((btn.rectangle().top, btn))
+        except Exception:
+            continue
+    if not candidates:
+        raise RuntimeError(f"no Button with title {title!r} found in dialog")
+    candidates.sort(key=lambda x: x[0])
+    return candidates[-1][1]
+
+
 def _find_filename_edit(native_dlg: UIAWrapper) -> UIAWrapper:
     """Find the filename Edit in a Windows native Open/Save dialog.
 
@@ -894,7 +926,12 @@ def save_manifest_via_native_dialog(
     # Avoids both IME interception (bopomofo, etc.) and the locale-specific
     # name of the filename ComboBox label.
     filename_edit.iface_value.SetValue(str(target_path))
-    time.sleep(0.2)
+    # 0.8s gives the native Save dialog time to validate the filename and
+    # enable its OK button before we press Enter. CI runners are noticeably
+    # slower at this validation than a desktop session — at 0.2s the Enter
+    # was occasionally landing on a still-disabled button and the save
+    # silently no-op'd. Local impact is +0.6s on s12 only; net trivial.
+    time.sleep(0.8)
     send_keys("{ENTER}")
 
     # Success path no longer raises a "Save Manifest" QMessageBox — the
@@ -1060,15 +1097,14 @@ def _drive_action_dialog_form(
     action_combo.select(action_label)
     time.sleep(0.1)
 
-    apply_btn = action_dlg.child_window(
-        title=ACTION_DIALOG_BTN_APPLY, control_type="Button"
-    )
+    # Use _find_dialog_button (bottom-most match) — on en-US Windows the
+    # title-bar Close button shares the form Close's accessible name and a
+    # plain child_window lookup goes ambiguous.
+    apply_btn = _find_dialog_button(action_dlg, ACTION_DIALOG_BTN_APPLY)
     apply_btn.click_input()
     time.sleep(0.3)
 
-    close_btn = action_dlg.child_window(
-        title=ACTION_DIALOG_BTN_CLOSE, control_type="Button"
-    )
+    close_btn = _find_dialog_button(action_dlg, ACTION_DIALOG_BTN_CLOSE)
     close_btn.click_input()
     time.sleep(0.3)
 
@@ -1225,7 +1261,11 @@ def close_scan_dialog_via_close_button(dlg: UIAWrapper) -> None:
     paths where no manifest was produced — that's the canonical user exit
     after #86 wired focus to this button.
     """
-    btn = dlg.child_window(title="Close", control_type="Button")
+    # _find_dialog_button picks the bottom-most "Close" — disambiguates
+    # against the en-US title-bar Close button whose accessible name is
+    # also "Close" (zh-TW renders it as "關閉" so locally there's only
+    # one match either way).
+    btn = _find_dialog_button(dlg, "Close")
     _focus(dlg)
     btn.invoke()
     time.sleep(0.5)

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -1030,8 +1030,24 @@ def save_manifest_via_native_dialog(
         )
     except Exception:
         pass
-    _focus(save_dlg)
-    save_btn.click_input()
+    # Try UIA Invoke pattern first — doesn't synthesize mouse events,
+    # which the GitHub runner doesn't reliably deliver to a real
+    # window. Fall back to click_input for environments where Invoke
+    # isn't supported on the button (and on a real desktop session
+    # both work; click_input there has been the historical path).
+    invoked = False
+    try:
+        save_btn.iface_invoke.Invoke()
+        invoked = True
+    except Exception as exc:
+        print(
+            f"  iface_invoke unavailable on save_btn ({exc!r}); "
+            f"falling back to click_input",
+            flush=True,
+        )
+    if not invoked:
+        _focus(save_dlg)
+        save_btn.click_input()
 
     # Poll until one of three end states. The success signal is the
     # ARTIFACT existing on disk (not just the dialog closing) — Qt's

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -884,6 +884,63 @@ def _find_dialog_button(dlg: UIAWrapper, title: str) -> UIAWrapper:
     return candidates[-1][1]
 
 
+def _find_native_dialog_action_button(native_dlg: UIAWrapper) -> UIAWrapper:
+    """Locate the action button (Save/Open/OK) of a native Common Item Dialog.
+
+    Locale-independent: identifies by structure, not visible text. Windows
+    Common Item Dialog's bottom row contains the action button + Cancel,
+    plus sometimes a navigation-pane toggle ("Hide Folders" / "Browse
+    Folders") on the far left.
+
+    Layout (right-to-left): Cancel (rightmost), action button (Save /
+    Open / OK), [optional] navigation toggle. So among the bottom-row
+    buttons, the action button is the **2nd-from-rightmost**.
+
+    Why not press Enter via ``send_keys``? On the GitHub-hosted
+    ``windows-latest`` runner foreground semantics differ from a real
+    desktop session; ``send_keys`` delivers globally to whatever is
+    foreground and intermittently misses the dialog, leaving the Save
+    unfired. ``click_input`` on a structurally-located button is
+    locale-independent and doesn't rely on foreground staying glued
+    to the dialog.
+
+    Raises ``RuntimeError`` (with a diagnostic listing every Button)
+    when the bottom row contains fewer than 2 buttons (no Cancel
+    pair to disambiguate against).
+    """
+    dlg_rect = native_dlg.rectangle()
+    candidates: list[tuple[int, int, UIAWrapper]] = []
+    for b in native_dlg.descendants(control_type="Button"):
+        try:
+            r = b.rectangle()
+            if r.top >= dlg_rect.bottom - 80:
+                candidates.append((r.left, r.top, b))
+        except Exception:
+            continue
+    if len(candidates) < 2:
+        all_btns: list[str] = []
+        for b in native_dlg.descendants(control_type="Button"):
+            try:
+                r = b.rectangle()
+                t = (b.window_text() or "").strip()
+                all_btns.append(
+                    f"title={t!r} rect=({r.left},{r.top},{r.right},{r.bottom})"
+                )
+            except Exception:
+                continue
+        raise RuntimeError(
+            f"native dialog: expected >= 2 bottom-row buttons "
+            f"(action + Cancel), got {len(candidates)}; "
+            f"dlg_rect={dlg_rect!r}; all_buttons={all_btns!r}"
+        )
+    # Sort descending by ``left`` (rightmost first). Cancel is the
+    # rightmost in every Common Item Dialog variant; the action button
+    # is immediately to its left, regardless of whether the optional
+    # navigation toggle is also present further to the left.
+    candidates.sort(key=lambda c: c[0], reverse=True)
+    return candidates[1][2]
+
+
 def _find_filename_edit(native_dlg: UIAWrapper) -> UIAWrapper:
     """Find the filename Edit in a Windows native Open/Save dialog.
 
@@ -928,20 +985,21 @@ def save_manifest_via_native_dialog(
     # name of the filename ComboBox label.
     filename_edit.iface_value.SetValue(str(target_path))
     # 0.8s gives the native Save dialog time to validate the filename and
-    # enable its OK button. On the desktop session 0.2s was enough; CI
-    # runners are slower and at 0.2s Enter occasionally landed before
+    # enable its action button. On the desktop session 0.2s was enough;
+    # CI runners are slower and at 0.2s the Save attempt landed before
     # validation completed.
     time.sleep(0.8)
-    # Re-assert foreground on the save dialog right before send_keys. On
-    # the runner the foreground window can drift away from the dialog
-    # during the validation sleep (the runner shell or another process
-    # taking foreground briefly). ``send_keys`` delivers Enter to whatever
-    # is foreground globally — without this, Enter goes to the wrong
-    # window and the Save dialog stays open. Locally the dialog is
-    # already foreground so ``_focus`` (post-#126) returns immediately
-    # without perturbing state.
+    # Click Save by structure, not by Enter. ``send_keys`` delivers
+    # globally to whatever Windows says is foreground, and on the
+    # GitHub-hosted ``windows-latest`` runner the foreground intermittently
+    # isn't the dialog — Enter then misses and the dialog stays open.
+    # Identifying the button by bottom-row position is locale-independent
+    # (so this still works on zh-TW where the button reads "存檔") and
+    # ``click_input`` delivers a real synthesized click that doesn't
+    # depend on foreground state staying glued to the dialog.
+    save_btn = _find_native_dialog_action_button(save_dlg)
     _focus(save_dlg)
-    send_keys("{ENTER}")
+    save_btn.click_input()
 
     # Poll until one of three end states. The success signal is the
     # ARTIFACT existing on disk (not just the dialog closing) — Qt's

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -968,12 +968,18 @@ def save_manifest_via_native_dialog(
     2. Set its value via UIA's ValuePattern.SetValue — bypasses keyboard
        (so IMEs like bopomofo can't intercept) and bypasses the
        locale-specific ComboBox label name.
-    3. Press Enter to invoke Save.
-    4. Wait briefly for "Save Manifest Error" critical dialog. Success
-       returns silently — caller verifies via status bar / file existence.
-    """
-    from pywinauto.keyboard import send_keys
+    3. Click the action button (Save/OK), located by bottom-row
+       structure (locale-independent).
+    4. Poll for the artifact appearing on disk (success), a "Save
+       Manifest Error" dialog (raise), or timeout (raise diagnostic).
 
+    Known limitation (#129): this helper does not work on the
+    GitHub-hosted ``windows-latest`` runner because the native
+    IFileSaveDialog modal loop only pumps COM messages and the runner
+    does not deliver real synthesized mouse / keyboard input. Locally
+    with a real desktop session it works fine; ``s12_save_manifest``
+    is the canonical scenario exercising this path.
+    """
     save_hwnd = wait_for_dialog(pid, "Save Manifest Decisions", timeout=dialog_timeout)
     save_dlg = connect_by_handle(save_hwnd)
     _focus(save_dlg)
@@ -984,140 +990,29 @@ def save_manifest_via_native_dialog(
     # Avoids both IME interception (bopomofo, etc.) and the locale-specific
     # name of the filename ComboBox label.
     filename_edit.iface_value.SetValue(str(target_path))
-    # 0.8s gives the native Save dialog time to validate the filename and
-    # enable its action button. On the desktop session 0.2s was enough;
-    # CI runners are slower and at 0.2s the Save attempt landed before
-    # validation completed.
+    # 0.8s gives the native Save dialog time to validate the filename
+    # and enable its action button. On a desktop session 0.2s was
+    # enough; CI runners are slower and at 0.2s the Save click landed
+    # before validation completed.
     time.sleep(0.8)
-
-    # Diagnostic: read back what the filename Edit actually contains
-    # post-SetValue + the action button's enabled state. Tells us
-    # whether SetValue took effect AND whether the dialog believes the
-    # filename is valid (action button enabled === valid).
-    try:
-        current_val = filename_edit.iface_value.CurrentValue
-        print(f"  filename_edit_value={current_val!r}", flush=True)
-    except Exception as exc:
-        print(f"  filename_edit_value: read failed: {exc!r}", flush=True)
-    # Click Save by structure, not by Enter. ``send_keys`` delivers
-    # globally to whatever Windows says is foreground, and on the
-    # GitHub-hosted ``windows-latest`` runner the foreground intermittently
-    # isn't the dialog — Enter then misses and the dialog stays open.
-    # Identifying the button by bottom-row position is locale-independent
-    # (so this still works on zh-TW where the button reads "存檔") and
-    # ``click_input`` delivers a real synthesized click that doesn't
-    # depend on foreground state staying glued to the dialog.
-    # Diagnostic: dialog rect + every Button + the picked button. Removed
-    # once CI is reliably green; until then, this is invaluable when the
-    # bottom-row heuristic picks the wrong control.
-    try:
-        dr = save_dlg.rectangle()
-        print(
-            f"  save_dlg_rect=({dr.left},{dr.top},{dr.right},{dr.bottom})",
-            flush=True,
-        )
-        for b in save_dlg.descendants(control_type="Button"):
-            try:
-                br = b.rectangle()
-                t = (b.window_text() or "").strip()
-                print(
-                    f"    btn title={t!r} "
-                    f"rect=({br.left},{br.top},{br.right},{br.bottom})",
-                    flush=True,
-                )
-            except Exception:
-                continue
-    except Exception:
-        pass
-    save_btn = _find_native_dialog_action_button(save_dlg)
-    try:
-        sr = save_btn.rectangle()
-        st = (save_btn.window_text() or "").strip()
-        print(
-            f"  picked save_btn: title={st!r} "
-            f"rect=({sr.left},{sr.top},{sr.right},{sr.bottom})",
-            flush=True,
-        )
-    except Exception:
-        pass
-    # Multi-strategy click. Three fallbacks because each fails in a
-    # different environment and we need at least one to land:
+    # Click the action button by structure (locale-independent — works
+    # whether the button reads "Save" or "存檔"). Click rather than
+    # send_keys("{ENTER}") because send_keys delivers globally to
+    # whatever Windows says is foreground; on a real desktop the dialog
+    # IS foreground but on the GitHub-hosted windows-latest runner that
+    # invariant doesn't hold and the Enter misses.
     #
-    #   1. Win32 ``PostMessage(BM_CLICK)`` to the button's window
-    #      procedure. Bypasses foreground / mouse / UIA entirely; this
-    #      is how Windows itself fires button actions internally.
-    #      ``PostMessage`` (not ``SendMessage``) so we don't block
-    #      waiting for the receiver to pump the message — the modal
-    #      dialog has its own event loop and a synchronous Send was
-    #      hanging the driver indefinitely on the runner.
-    #   2. UIA ``Invoke`` pattern. Sometimes a no-op on native Common
-    #      Item Dialog buttons (returns success but doesn't fire the
-    #      action) so it's the second-choice fallback, not the first.
-    #   3. ``click_input`` (synthesized mouse) — historical desktop-
-    #      session path, kept as a last resort.
-    # Multi-strategy fire. Each option fails differently; we need any
-    # of them to actually trigger the Save action.
-    BM_CLICK = 0x00F5
-    WM_KEYDOWN = 0x0100
-    WM_KEYUP = 0x0101
-    VK_RETURN = 0x0D
-
-    btn_hwnd = 0
-    btn_enabled = "?"
-    try:
-        btn_hwnd = save_btn.handle or 0
-    except Exception:
-        pass
-    try:
-        btn_enabled = "yes" if save_btn.is_enabled() else "no"
-    except Exception as exc:
-        btn_enabled = f"?({exc!r})"
-    print(f"  save_btn_hwnd={btn_hwnd} enabled={btn_enabled}", flush=True)
-
-    fired = False
-
-    # Strategy 1: BM_CLICK via PostMessage if the button has a real HWND.
-    # Common Item Dialog buttons SOMETIMES expose a Win32 BUTTON; when
-    # they do this is the cleanest fire path.
-    if btn_hwnd:
-        try:
-            ctypes.windll.user32.PostMessageW(btn_hwnd, BM_CLICK, 0, 0)
-            fired = True
-            print("  fire: PostMessage(BM_CLICK)", flush=True)
-        except Exception as exc:
-            print(f"  BM_CLICK post failed: {exc!r}", flush=True)
-
-    # Strategy 2: post VK_RETURN directly to the dialog. Native dialogs
-    # treat Enter as activate-default-button regardless of foreground or
-    # focus state, and the queued WM_KEY messages don't depend on mouse
-    # synthesis. Use this whenever BM_CLICK didn't fire OR as a belt-and-
-    # braces (always run when fired==True too — the dialog is idempotent
-    # against duplicate Save clicks once the file is written).
-    try:
-        dlg_hwnd = save_dlg.handle
-        if dlg_hwnd:
-            ctypes.windll.user32.PostMessageW(dlg_hwnd, WM_KEYDOWN, VK_RETURN, 0)
-            ctypes.windll.user32.PostMessageW(dlg_hwnd, WM_KEYUP, VK_RETURN, 0)
-            fired = True
-            print("  fire: PostMessage(WM_KEYDOWN/UP, VK_RETURN) to dialog", flush=True)
-    except Exception as exc:
-        print(f"  VK_RETURN post failed: {exc!r}", flush=True)
-
-    # Strategy 3: UIA Invoke pattern.
-    if not fired:
-        try:
-            save_btn.iface_invoke.Invoke()
-            fired = True
-            print("  fire: iface_invoke.Invoke", flush=True)
-        except Exception as exc:
-            print(f"  iface_invoke fallback failed: {exc!r}", flush=True)
-
-    # Strategy 4: synthesized mouse click. Last resort; doesn't always
-    # land on the runner but is the historical desktop-session path.
-    if not fired:
-        _focus(save_dlg)
-        save_btn.click_input()
-        print("  fire: click_input", flush=True)
+    # CI caveat (#129): this still fails on ``windows-latest`` runners
+    # specifically. The native Save dialog is a Windows IFileSaveDialog
+    # whose modal loop only pumps COM messages, and the runner doesn't
+    # deliver real synthesized mouse / keyboard input either.
+    # PostMessage(BM_CLICK), PostMessage(WM_KEYDOWN, VK_RETURN), and
+    # UIA Invoke all return success on the runner but the dialog never
+    # closes. Locally with a real desktop session ``click_input`` works
+    # fine and s12 passes.
+    save_btn = _find_native_dialog_action_button(save_dlg)
+    _focus(save_dlg)
+    save_btn.click_input()
 
     # Poll until one of three end states. The success signal is the
     # ARTIFACT existing on disk (not just the dialog closing) — Qt's

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -928,11 +928,19 @@ def save_manifest_via_native_dialog(
     # name of the filename ComboBox label.
     filename_edit.iface_value.SetValue(str(target_path))
     # 0.8s gives the native Save dialog time to validate the filename and
-    # enable its OK button before we press Enter. CI runners are noticeably
-    # slower at this validation than a desktop session — at 0.2s the Enter
-    # was occasionally landing on a still-disabled button and the save
-    # silently no-op'd. Local impact is +0.6s on s12 only; net trivial.
+    # enable its OK button. On the desktop session 0.2s was enough; CI
+    # runners are slower and at 0.2s Enter occasionally landed before
+    # validation completed.
     time.sleep(0.8)
+    # Re-assert foreground on the save dialog right before send_keys. On
+    # the runner the foreground window can drift away from the dialog
+    # during the validation sleep (the runner shell or another process
+    # taking foreground briefly). ``send_keys`` delivers Enter to whatever
+    # is foreground globally — without this, Enter goes to the wrong
+    # window and the Save dialog stays open. Locally the dialog is
+    # already foreground so ``_focus`` (post-#126) returns immediately
+    # without perturbing state.
+    _focus(save_dlg)
     send_keys("{ENTER}")
 
     # Poll until one of three end states. The success signal is the

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -1030,22 +1030,34 @@ def save_manifest_via_native_dialog(
         )
     except Exception:
         pass
-    # Try UIA Invoke pattern first — doesn't synthesize mouse events,
-    # which the GitHub runner doesn't reliably deliver to a real
-    # window. Fall back to click_input for environments where Invoke
-    # isn't supported on the button (and on a real desktop session
-    # both work; click_input there has been the historical path).
-    invoked = False
+    # Multi-strategy click. Three fallbacks because each fails in a
+    # different environment and we need at least one to land:
+    #
+    #   1. Win32 ``SendMessage(BM_CLICK)`` directly to the button's
+    #      window procedure. Bypasses foreground / mouse / UIA entirely;
+    #      this is how Windows itself fires button actions internally.
+    #      Most reliable on CI runners where mouse input is blackholed.
+    #   2. UIA ``Invoke`` pattern. Sometimes a no-op on native Common
+    #      Item Dialog buttons (returns success but doesn't fire the
+    #      action) so it's the second-choice fallback, not the first.
+    #   3. ``click_input`` (synthesized mouse) — historical desktop-
+    #      session path, kept as a last resort.
+    BM_CLICK = 0x00F5
+    fired = False
     try:
-        save_btn.iface_invoke.Invoke()
-        invoked = True
+        hwnd = save_btn.handle
+        if hwnd:
+            ctypes.windll.user32.SendMessageW(hwnd, BM_CLICK, 0, 0)
+            fired = True
     except Exception as exc:
-        print(
-            f"  iface_invoke unavailable on save_btn ({exc!r}); "
-            f"falling back to click_input",
-            flush=True,
-        )
-    if not invoked:
+        print(f"  BM_CLICK send failed: {exc!r}", flush=True)
+    if not fired:
+        try:
+            save_btn.iface_invoke.Invoke()
+            fired = True
+        except Exception as exc:
+            print(f"  iface_invoke fallback failed: {exc!r}", flush=True)
+    if not fired:
         _focus(save_dlg)
         save_btn.click_input()
 

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -21,6 +21,7 @@ import ctypes
 import ctypes.wintypes
 import time
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Iterable
 
 from pywinauto import Application
@@ -934,16 +935,24 @@ def save_manifest_via_native_dialog(
     time.sleep(0.8)
     send_keys("{ENTER}")
 
-    # Success path no longer raises a "Save Manifest" QMessageBox — the
-    # status bar reports success via "Saved N decisions". The error path
-    # still surfaces a "Save Manifest Error" critical dialog. Poll briefly:
-    # if an Error dialog appears, dismiss + raise; otherwise return after a
-    # short grace window (the save handler runs synchronously, so 3s is
-    # plenty of time for the error to surface if it's going to).
-    grace = min(3.0, dialog_timeout)
+    # Poll until one of three end states. The success signal is the
+    # ARTIFACT existing on disk (not just the dialog closing) — Qt's
+    # save handler writes the file after the dialog returns from
+    # getSaveFileName, so a dialog-close-only check can return before
+    # the write completes and leave callers seeing a missing file.
+    #
+    #   1. The target file appears on disk → Save fully completed.
+    #   2. "Save Manifest Error" appears → raise with the body text.
+    #   3. Neither, within the grace window → diagnose: if the Save
+    #      dialog is still open, Enter was lost; otherwise the save
+    #      attempt was accepted but produced no file (shouldn't happen).
+    target_p = Path(target_path)
+    grace = min(5.0, dialog_timeout)
     deadline = time.time() + grace
     error_hwnd = None
     while time.time() < deadline:
+        if target_p.exists():
+            return  # save fully completed; file is on disk
         for hwnd, _cls, t in list_process_windows(pid):
             if t == "Save Manifest Error":
                 error_hwnd = hwnd
@@ -952,7 +961,18 @@ def save_manifest_via_native_dialog(
             break
         time.sleep(0.2)
     if error_hwnd is None:
-        return  # success — caller verifies via status bar / file existence
+        titles_now = [t for _, _, t in list_process_windows(pid)]
+        if "Save Manifest Decisions" in titles_now:
+            raise RuntimeError(
+                f"Save Manifest dialog still open after {grace}s — Enter "
+                "likely missed the dialog (focus drift) or the OK button "
+                "never enabled (filename validation timing)"
+            )
+        raise RuntimeError(
+            f"Save Manifest dialog closed but {target_p} did not appear "
+            f"within {grace}s after Enter — save attempt was accepted "
+            "but produced no file"
+        )
 
     error_dlg = connect_by_handle(error_hwnd)
     for label in error_dlg.descendants(control_type="Text"):

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -1033,10 +1033,13 @@ def save_manifest_via_native_dialog(
     # Multi-strategy click. Three fallbacks because each fails in a
     # different environment and we need at least one to land:
     #
-    #   1. Win32 ``SendMessage(BM_CLICK)`` directly to the button's
-    #      window procedure. Bypasses foreground / mouse / UIA entirely;
-    #      this is how Windows itself fires button actions internally.
-    #      Most reliable on CI runners where mouse input is blackholed.
+    #   1. Win32 ``PostMessage(BM_CLICK)`` to the button's window
+    #      procedure. Bypasses foreground / mouse / UIA entirely; this
+    #      is how Windows itself fires button actions internally.
+    #      ``PostMessage`` (not ``SendMessage``) so we don't block
+    #      waiting for the receiver to pump the message — the modal
+    #      dialog has its own event loop and a synchronous Send was
+    #      hanging the driver indefinitely on the runner.
     #   2. UIA ``Invoke`` pattern. Sometimes a no-op on native Common
     #      Item Dialog buttons (returns success but doesn't fire the
     #      action) so it's the second-choice fallback, not the first.
@@ -1047,10 +1050,13 @@ def save_manifest_via_native_dialog(
     try:
         hwnd = save_btn.handle
         if hwnd:
-            ctypes.windll.user32.SendMessageW(hwnd, BM_CLICK, 0, 0)
+            # PostMessage queues the message and returns immediately.
+            # The dialog's own message pump will deliver BM_CLICK to
+            # the button when next idle.
+            ctypes.windll.user32.PostMessageW(hwnd, BM_CLICK, 0, 0)
             fired = True
     except Exception as exc:
-        print(f"  BM_CLICK send failed: {exc!r}", flush=True)
+        print(f"  BM_CLICK post failed: {exc!r}", flush=True)
     if not fired:
         try:
             save_btn.iface_invoke.Invoke()

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -1045,27 +1045,64 @@ def save_manifest_via_native_dialog(
     #      action) so it's the second-choice fallback, not the first.
     #   3. ``click_input`` (synthesized mouse) — historical desktop-
     #      session path, kept as a last resort.
+    # Multi-strategy fire. Each option fails differently; we need any
+    # of them to actually trigger the Save action.
     BM_CLICK = 0x00F5
-    fired = False
+    WM_KEYDOWN = 0x0100
+    WM_KEYUP = 0x0101
+    VK_RETURN = 0x0D
+
+    btn_hwnd = 0
     try:
-        hwnd = save_btn.handle
-        if hwnd:
-            # PostMessage queues the message and returns immediately.
-            # The dialog's own message pump will deliver BM_CLICK to
-            # the button when next idle.
-            ctypes.windll.user32.PostMessageW(hwnd, BM_CLICK, 0, 0)
+        btn_hwnd = save_btn.handle or 0
+    except Exception:
+        pass
+    print(f"  save_btn_hwnd={btn_hwnd}", flush=True)
+
+    fired = False
+
+    # Strategy 1: BM_CLICK via PostMessage if the button has a real HWND.
+    # Common Item Dialog buttons SOMETIMES expose a Win32 BUTTON; when
+    # they do this is the cleanest fire path.
+    if btn_hwnd:
+        try:
+            ctypes.windll.user32.PostMessageW(btn_hwnd, BM_CLICK, 0, 0)
             fired = True
+            print("  fire: PostMessage(BM_CLICK)", flush=True)
+        except Exception as exc:
+            print(f"  BM_CLICK post failed: {exc!r}", flush=True)
+
+    # Strategy 2: post VK_RETURN directly to the dialog. Native dialogs
+    # treat Enter as activate-default-button regardless of foreground or
+    # focus state, and the queued WM_KEY messages don't depend on mouse
+    # synthesis. Use this whenever BM_CLICK didn't fire OR as a belt-and-
+    # braces (always run when fired==True too — the dialog is idempotent
+    # against duplicate Save clicks once the file is written).
+    try:
+        dlg_hwnd = save_dlg.handle
+        if dlg_hwnd:
+            ctypes.windll.user32.PostMessageW(dlg_hwnd, WM_KEYDOWN, VK_RETURN, 0)
+            ctypes.windll.user32.PostMessageW(dlg_hwnd, WM_KEYUP, VK_RETURN, 0)
+            fired = True
+            print("  fire: PostMessage(WM_KEYDOWN/UP, VK_RETURN) to dialog", flush=True)
     except Exception as exc:
-        print(f"  BM_CLICK post failed: {exc!r}", flush=True)
+        print(f"  VK_RETURN post failed: {exc!r}", flush=True)
+
+    # Strategy 3: UIA Invoke pattern.
     if not fired:
         try:
             save_btn.iface_invoke.Invoke()
             fired = True
+            print("  fire: iface_invoke.Invoke", flush=True)
         except Exception as exc:
             print(f"  iface_invoke fallback failed: {exc!r}", flush=True)
+
+    # Strategy 4: synthesized mouse click. Last resort; doesn't always
+    # land on the runner but is the historical desktop-session path.
     if not fired:
         _focus(save_dlg)
         save_btn.click_input()
+        print("  fire: click_input", flush=True)
 
     # Poll until one of three end states. The success signal is the
     # ARTIFACT existing on disk (not just the dialog closing) — Qt's

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -989,6 +989,16 @@ def save_manifest_via_native_dialog(
     # CI runners are slower and at 0.2s the Save attempt landed before
     # validation completed.
     time.sleep(0.8)
+
+    # Diagnostic: read back what the filename Edit actually contains
+    # post-SetValue + the action button's enabled state. Tells us
+    # whether SetValue took effect AND whether the dialog believes the
+    # filename is valid (action button enabled === valid).
+    try:
+        current_val = filename_edit.iface_value.CurrentValue
+        print(f"  filename_edit_value={current_val!r}", flush=True)
+    except Exception as exc:
+        print(f"  filename_edit_value: read failed: {exc!r}", flush=True)
     # Click Save by structure, not by Enter. ``send_keys`` delivers
     # globally to whatever Windows says is foreground, and on the
     # GitHub-hosted ``windows-latest`` runner the foreground intermittently
@@ -1053,11 +1063,16 @@ def save_manifest_via_native_dialog(
     VK_RETURN = 0x0D
 
     btn_hwnd = 0
+    btn_enabled = "?"
     try:
         btn_hwnd = save_btn.handle or 0
     except Exception:
         pass
-    print(f"  save_btn_hwnd={btn_hwnd}", flush=True)
+    try:
+        btn_enabled = "yes" if save_btn.is_enabled() else "no"
+    except Exception as exc:
+        btn_enabled = f"?({exc!r})"
+    print(f"  save_btn_hwnd={btn_hwnd} enabled={btn_enabled}", flush=True)
 
     fired = False
 


### PR DESCRIPTION
## Summary

Adds [.github/workflows/qa-batch.yml](.github/workflows/qa-batch.yml). Runs `python -m qa.scenarios._batch` on PRs that touch UI / scanner / qa surface so driver-vs-app label drift and state-transition regressions are caught at PR time instead of "next time someone runs the batch locally". Closes [#74](https://github.com/jackal998/photo-manager/issues/74).

## Final state

| Environment | Result |
|---|---|
| Full 21-scenario local batch (Windows zh-TW) | **21/21 green** |
| Full 21-scenario CI batch (windows-latest) | **20/21 green** — s12_save_manifest known-blocked, see [#129](https://github.com/jackal998/photo-manager/issues/129) |
| pytest CI | 544 passed, 2 skipped (unchanged) |

The qa-batch CI job will be **honestly red** until [#129](https://github.com/jackal998/photo-manager/issues/129) resolves — no skip, no `continue-on-error`. The job summary names which scenario failed; the other 20 pass green every run, so a new red on s01–s11 / s13–s21 is a real signal that something drifted.

## What's in this PR

- `.github/workflows/qa-batch.yml` — the workflow itself: windows-latest, Python 3.12, choco exiftool, pinned DPI, per-scenario rc summary, full log uploaded as 7-day artifact, defensive `taskkill` cleanup, `permissions: contents: read`.
- `qa/scenarios/_batch.py:23` — switch hardcoded `.venv/Scripts/python.exe` to `sys.executable` (was the iteration-1 blocker; CI doesn't have a `.venv`). Same path locally.
- `qa/scenarios/_batch.py:run_one` — `subprocess.TimeoutExpired` now surfaces partial stdout/stderr instead of dropping them. Made the iteration-7 hang debuggable.
- `qa/scenarios/_uia.py`:
  - new `_find_dialog_button(dlg, title)` — picks the bottom-most match to disambiguate against locale-specific title-bar buttons that share names ("Close" on en-US). Fixed s02 / s13 / s14 on en-US runners.
  - new `_find_native_dialog_action_button(dlg)` — locale-tolerant Save/Open/OK button finder (2nd-from-rightmost in the bottom row).
  - `save_manifest_via_native_dialog` now uses click_input on the structurally-located action button + polls for the artifact appearing on disk (the actual success signal — Qt writes the file after the dialog closes, so dialog-close polling can return before the write completes).
  - docstring + inline comment document the [#129](https://github.com/jackal998/photo-manager/issues/129) limitation so the next reader doesn't re-iterate.
- [docs/testing.md](docs/testing.md) — new "Known CI limitations" section documenting `s12_save_manifest` on CI.

## What got rejected during iteration (and why)

| Strategy | Outcome on CI |
|---|---|
| `send_keys("{ENTER}")` after `_focus(save_dlg)` | Foreground drifted; Enter missed the dialog |
| `SendMessage(BM_CLICK)` to button HWND | Hung the driver indefinitely (cross-thread Send blocks on COM modal loop) |
| `PostMessage(BM_CLICK)` to button HWND | Posts succeeds but Save action never fires |
| `PostMessage(WM_KEYDOWN/UP, VK_RETURN)` to dialog HWND | Same |
| UIA `iface_invoke.Invoke()` | Returns success but no-op |
| `click_input` (synthesized mouse) | Runner doesn't deliver mouse input to IFileSaveDialog |

Root cause is the Windows IFileSaveDialog COM modal loop only pumping COM messages + the runner not delivering real synthesized input. None of the standard hammers fit. Documented in #129 with the full diagnostic data.

## Test plan

- [x] pytest (CI) — 544 passed, 2 skipped, per-file 70% gate clears
- [x] Local full 21-scenario batch — 21/21 green
- [x] CI full 21-scenario batch — 20/21 green (s12 known-blocked per [#129](https://github.com/jackal998/photo-manager/issues/129))
- [x] Verified `_find_dialog_button` doesn't break local zh-TW behavior — only one Close match locally, helper picks the same one
- [x] Verified `_find_native_dialog_action_button` picks the correct button on both en-US (CI logs) and zh-TW (local)

## Followups

- [#129](https://github.com/jackal998/photo-manager/issues/129) — s12 native-Save-dialog CI fix (alternatives evaluated; current state is the documented "known-blocked")
- After ≥10 consecutive non-s12 green runs accumulate, the workflow can be promoted to a required status check via branch protection (per [#74](https://github.com/jackal998/photo-manager/issues/74) acceptance criteria)
- Node.js 20 deprecation notice on `actions/checkout@v4`, `actions/setup-python@v5`, `actions/upload-artifact@v4` — actions need to migrate to Node.js 24 by 2026-09. Not urgent, separate concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)