### PR TITLE
fix(qa): drive QFileDialog via Qt non-native widget on hosted CI

### DIFF
--- a/.github/workflows/qa-batch.yml
+++ b/.github/workflows/qa-batch.yml
@@ -79,6 +79,13 @@ jobs:
           PYTHONUNBUFFERED: '1'
           # Unicode arrows / ellipsis in driver output: avoid cp1252 encode errors.
           PYTHONIOENCODING: 'utf-8'
+          # Switch QFileDialog to Qt's non-native widget on hosted runners
+          # (#129). The Windows native IFileSaveDialog modal loop only pumps
+          # COM messages, so synthesized input from pywinauto / UIA is
+          # silently dropped on windows-latest. Qt's non-native dialog
+          # responds to UIA normally, so s12_save_manifest can drive it
+          # end-to-end here. Local users still get the native dialog.
+          PHOTO_MANAGER_QT_FILE_DIALOG: '1'
         run: |
           python -m qa.scenarios._batch 2>&1 | Tee-Object -FilePath qa-batch.log
           # Forward the batch's exit code; PowerShell pipes default to the

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -221,32 +221,34 @@ in `qa/scenarios/`.
 
 ---
 
-## Known CI limitations
+## CI dialog-driving — `PHOTO_MANAGER_QT_FILE_DIALOG` ([#129](https://github.com/jackal998/photo-manager/issues/129))
 
-### `s12_save_manifest` fails on GitHub-hosted runners ([#129](https://github.com/jackal998/photo-manager/issues/129))
+The native Windows `IFileSaveDialog` / `IFileOpenDialog` modal loop
+only pumps COM messages — not regular `WM_*` — and GitHub-hosted
+Windows runners don't deliver synthesized mouse or keyboard input to
+it. So `PostMessage(BM_CLICK)`, `PostMessage(WM_KEYDOWN, VK_RETURN)`,
+UIA `Invoke`, and `click_input` all return success on the runner but
+the Save / Open action never fires (full iteration history in
+[#128](https://github.com/jackal998/photo-manager/pull/128)).
 
-The qa-batch workflow runs all 21 scenarios on `windows-latest` and
-**always reports `s12_save_manifest` as failing**. This is honest
-signalling, not a regression: the failure has a known root cause that
-hosted-runner constraints make unfixable without changing the app.
+**Resolution.** The `qa-batch` workflow sets
+`PHOTO_MANAGER_QT_FILE_DIALOG=1`. When that env var is `1`,
+`main.py` applies `Qt.AA_DontUseNativeDialogs` before constructing
+`QApplication`, so every `QFileDialog` in the process becomes Qt's
+widget-based dialog — which responds to UIA normally. Local users
+get the native dialog as before (env var unset → no behavior change).
 
-What's going on: the File → Save Manifest Decisions… flow opens a
-native Windows `IFileSaveDialog`. That dialog uses a COM modal loop
-which only pumps COM messages — not regular `WM_*` messages — and the
-hosted runner additionally doesn't deliver real synthesized mouse or
-keyboard input. So `PostMessage(BM_CLICK)`, `PostMessage(WM_KEYDOWN,
-VK_RETURN)`, UIA `Invoke`, and `click_input` all return success on
-the runner but the Save action never fires. See [#129](https://github.com/jackal998/photo-manager/issues/129)
-for the full diagnostic data and the alternatives evaluated.
+**Cross-platform value.** The same env var works for future macOS
+hosted-runner CI: the analogous `NSSavePanel` synthesized-input
+limitation lifts the same way — one switch, every platform. No
+per-OS QA-helper rewrite needed.
 
-Locally on a real Windows desktop session, `s12` runs green as part
-of the full 21-scenario batch — its drift coverage is intact.
-
-The PR-time CI signal works correctly for the other 20 scenarios:
-when a label or a state-transition shifts under any of those, the
-qa-batch job goes red on the relevant scenario and the workflow
-summary names it. Until [#129](https://github.com/jackal998/photo-manager/issues/129)
-resolves, treat a qa-batch failure on s12 alone as expected.
+The `_uia.py` filename-Edit and action-button locators carry parallel
+branches for both tree shapes — native Common Item Dialog
+(`ComboBox > Edit`, 2nd-from-rightmost bottom-row button) and Qt
+`QDialogButtonBox` (standalone `QLineEdit`, topmost button in the
+buttonBox). See `_find_filename_edit` and
+`_find_native_dialog_action_button` docstrings.
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 import sys
 
+from PySide6.QtCore import Qt
 from PySide6.QtGui import QImageReader
 from PySide6.QtWidgets import QApplication
 from loguru import logger
@@ -39,6 +40,15 @@ def _parse_default_sort(settings: JsonSettings) -> list[tuple[str, bool]]:
 def main() -> int:
     init_logging()
     settings = JsonSettings(CONFIG_HOME / "settings.json")
+
+    # Cross-platform QA / hosted-CI escape hatch (#129): the Windows native
+    # IFileSaveDialog and equivalent macOS NSSavePanel cannot be driven by
+    # synthesized input on hosted runners, but Qt's widget-based file dialog
+    # responds to UIA / AX normally. Setting this attribute before
+    # QApplication is constructed switches every QFileDialog in the process
+    # to the non-native variant — one switch, every platform.
+    if os.environ.get("PHOTO_MANAGER_QT_FILE_DIALOG") == "1":
+        QApplication.setAttribute(Qt.AA_DontUseNativeDialogs)
 
     app = QApplication(sys.argv)
 

--- a/qa/scenarios/AUTHORING.md
+++ b/qa/scenarios/AUTHORING.md
@@ -134,20 +134,32 @@ sat queued forever and the driver hung for the full subprocess
 timeout. Use `PostMessageW` if you must, but see the next item — for
 native Common Item Dialogs it doesn't help anyway.
 
-### ❌ Driving native Windows Common Item Dialog on CI
+### ⚠️ Driving native Windows Common Item Dialog on CI — use the env-var escape hatch
 
 `QFileDialog.getSaveFileName` / `getOpenFileName` open a Windows
 `IFileSaveDialog` / `IFileOpenDialog` whose modal loop only pumps COM
 messages, AND the GitHub-hosted runner doesn't deliver synthesized
 mouse / keyboard input. `PostMessage(BM_CLICK)`, `PostMessage(WM_KEYDOWN,
 VK_RETURN)`, UIA `Invoke`, and `click_input` all return success but
-the dialog never closes. See [#129](https://github.com/jackal998/photo-manager/issues/129)
-for the full diagnostic.
+the dialog never closes. Iteration history in
+[#128](https://github.com/jackal998/photo-manager/pull/128) confirms
+every input hammer fails on hosted runners.
 
-If your scenario must drive a native dialog: locally it'll work; on
-CI it won't. Document the asymmetry in the helper docstring + in
-`docs/testing.md`'s "Known CI limitations" section. Don't try to
-defeat the platform.
+**Resolution ([#129](https://github.com/jackal998/photo-manager/issues/129)):**
+the `qa-batch` workflow sets `PHOTO_MANAGER_QT_FILE_DIALOG=1`. When
+that env var is set, `main.py` applies `Qt.AA_DontUseNativeDialogs`
+before constructing `QApplication` so every `QFileDialog` becomes
+Qt's non-native widget — which responds to UIA normally. Local users
+get the native dialog as before (env var unset → no change). The
+same flip works on macOS hosted runners (analogous `NSSavePanel`
+limitation).
+
+The `_find_filename_edit` and `_find_native_dialog_action_button`
+helpers in `_uia.py` handle both tree shapes — native Common Item
+Dialog and Qt `QDialogButtonBox` — so any new file-dialog-driving
+scenario inherits the dual support automatically. Don't try to drive
+the native dialog directly on CI; the platform isn't going to
+cooperate.
 
 ### ❌ Assuming `setCellWidget`'d Qt controls show up in UIA
 
@@ -218,9 +230,6 @@ When a scenario fails on CI but passes locally:
   Sometimes the next scenario's `menu_path(win, MENU_FILE, ...)` can't
   open the popup because the previous teardown didn't fully release
   foreground. Retry once before declaring a real failure.
-- **`s12_save_manifest` on CI** ([#129](https://github.com/jackal998/photo-manager/issues/129)).
-  Known-blocked by IFileSaveDialog limitation; locally green. Not a
-  regression.
 
 ## When you commit
 

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -885,29 +885,60 @@ def _find_dialog_button(dlg: UIAWrapper, title: str) -> UIAWrapper:
 
 
 def _find_native_dialog_action_button(native_dlg: UIAWrapper) -> UIAWrapper:
-    """Locate the action button (Save/Open/OK) of a native Common Item Dialog.
+    """Locate the action button (Save/Open/OK) of a Save dialog.
 
-    Locale-independent: identifies by structure, not visible text. Windows
-    Common Item Dialog's bottom row contains the action button + Cancel,
-    plus sometimes a navigation-pane toggle ("Hide Folders" / "Browse
-    Folders") on the far left.
+    Handles two tree shapes:
 
-    Layout (right-to-left): Cancel (rightmost), action button (Save /
-    Open / OK), [optional] navigation toggle. So among the bottom-row
-    buttons, the action button is the **2nd-from-rightmost**.
+    * **Windows native Common Item Dialog**: bottom row contains the
+      action button + Cancel, sometimes plus a navigation-pane toggle
+      ("Hide Folders" / "Browse Folders") on the far left. Layout
+      (right-to-left): Cancel (rightmost), action button, [optional]
+      toggle — so the action button is **2nd-from-rightmost**.
+
+    * **Qt non-native QFileDialog** (``AA_DontUseNativeDialogs``, see
+      #129): buttons live inside a ``QDialogButtonBox`` and may be
+      laid out **vertically** (Save above Cancel) or horizontally.
+      Qt orders the AcceptRole button first, so the topmost-leftmost
+      ``QPushButton`` inside the buttonBox is the action button —
+      locale-independent for either orientation.
+
+    Locale-independent: identifies by structure, not visible text.
 
     Why not press Enter via ``send_keys``? On the GitHub-hosted
     ``windows-latest`` runner foreground semantics differ from a real
     desktop session; ``send_keys`` delivers globally to whatever is
-    foreground and intermittently misses the dialog, leaving the Save
-    unfired. ``click_input`` on a structurally-located button is
-    locale-independent and doesn't rely on foreground staying glued
-    to the dialog.
+    foreground and intermittently misses the dialog. ``click_input``
+    on a structurally-located button is locale-independent and doesn't
+    rely on foreground staying glued to the dialog.
 
-    Raises ``RuntimeError`` (with a diagnostic listing every Button)
-    when the bottom row contains fewer than 2 buttons (no Cancel
-    pair to disambiguate against).
+    Raises ``RuntimeError`` with a full descendant tree dump (written
+    to a temp file to bypass console truncation) when neither pattern
+    yields the action button.
     """
+    # Qt branch: look for QDialogButtonBox (a control_type="Group" with
+    # class_name="QDialogButtonBox"). If present, the AcceptRole button
+    # is the first QPushButton inside it — topmost in vertical layout,
+    # leftmost in horizontal.
+    for grp in native_dlg.descendants(control_type="Group"):
+        try:
+            if (grp.element_info.class_name or "") != "QDialogButtonBox":
+                continue
+        except Exception:
+            continue
+        qt_buttons: list[tuple[int, int, UIAWrapper]] = []
+        for b in grp.descendants(control_type="Button"):
+            try:
+                if (b.element_info.class_name or "") != "QPushButton":
+                    continue
+                r = b.rectangle()
+                qt_buttons.append((r.top, r.left, b))
+            except Exception:
+                continue
+        if qt_buttons:
+            qt_buttons.sort(key=lambda c: (c[0], c[1]))
+            return qt_buttons[0][2]
+
+    # Native Common Item Dialog: 2nd-from-rightmost button in bottom 80px.
     dlg_rect = native_dlg.rectangle()
     candidates: list[tuple[int, int, UIAWrapper]] = []
     for b in native_dlg.descendants(control_type="Button"):
@@ -918,20 +949,38 @@ def _find_native_dialog_action_button(native_dlg: UIAWrapper) -> UIAWrapper:
         except Exception:
             continue
     if len(candidates) < 2:
-        all_btns: list[str] = []
-        for b in native_dlg.descendants(control_type="Button"):
-            try:
-                r = b.rectangle()
-                t = (b.window_text() or "").strip()
-                all_btns.append(
-                    f"title={t!r} rect=({r.left},{r.top},{r.right},{r.bottom})"
-                )
-            except Exception:
-                continue
+        # Dump the FULL descendant tree to a file (stdout truncates on
+        # Chinese chars in the qa-batch subprocess pipeline). Caller can
+        # cat /tmp/qa_dialog_tree.txt to triage.
+        import tempfile
+        dump_lines: list[str] = []
+        dump_lines.append(f"dlg_rect={dlg_rect!r} dlg_class={native_dlg.element_info.class_name!r}")
+        try:
+            for d in native_dlg.descendants():
+                try:
+                    r = d.rectangle()
+                    ct = d.element_info.control_type
+                    t = (d.window_text() or "").strip()
+                    aid = d.element_info.automation_id or ""
+                    cls = d.element_info.class_name or ""
+                    dump_lines.append(
+                        f"{ct} class={cls!r} title={t!r} aid={aid!r} "
+                        f"rect=({r.left},{r.top},{r.right},{r.bottom})"
+                    )
+                except Exception as ex:
+                    dump_lines.append(f"<descendant-error: {ex!r}>")
+                    continue
+        except Exception as ex:
+            dump_lines.append(f"<top-level-error: {ex!r}>")
+        dump_path = Path(tempfile.gettempdir()) / "qa_dialog_tree.txt"
+        try:
+            dump_path.write_text("\n".join(dump_lines), encoding="utf-8")
+        except Exception:
+            pass
         raise RuntimeError(
             f"native dialog: expected >= 2 bottom-row buttons "
             f"(action + Cancel), got {len(candidates)}; "
-            f"dlg_rect={dlg_rect!r}; all_buttons={all_btns!r}"
+            f"dlg_rect={dlg_rect!r}; full tree dumped to {dump_path}"
         )
     # Sort descending by ``left`` (rightmost first). Cancel is the
     # rightmost in every Common Item Dialog variant; the action button
@@ -942,13 +991,26 @@ def _find_native_dialog_action_button(native_dlg: UIAWrapper) -> UIAWrapper:
 
 
 def _find_filename_edit(native_dlg: UIAWrapper) -> UIAWrapper:
-    """Find the filename Edit in a Windows native Open/Save dialog.
+    """Find the filename Edit in a Save dialog — native or Qt non-native.
 
-    Returns the only Edit nested inside a ComboBox descendant. The native
-    dialog has two ComboBoxes: filename (with editable Edit) and "Save as
-    type:" / "Files of type:" (no Edit). Picking by structure makes the
-    lookup locale-independent — works regardless of OS display language.
+    Two tree shapes are possible:
+
+    * **Windows native IFileSaveDialog**: filename is the only Edit nested
+      inside a ComboBox descendant. The native dialog has two ComboBoxes —
+      filename (editable) and "Save as type:" (no Edit). Picking by structure
+      makes the lookup locale-independent.
+
+    * **Qt non-native QFileDialog** (when ``AA_DontUseNativeDialogs`` is set,
+      e.g. via ``PHOTO_MANAGER_QT_FILE_DIALOG=1`` for hosted CI runners that
+      can't drive the native COM modal — see #129): filename is a standalone
+      ``QLineEdit`` not nested in any ComboBox. The Look-in / file-type
+      ComboBoxes are siblings.
+
+    Strategy: try the native pattern first; if no ComboBox > Edit found,
+    fall back to "the only Edit not nested in a ComboBox" — that's Qt's
+    fileNameEdit. If neither yields a candidate, dump the tree for triage.
     """
+    # Native pattern: ComboBox > Edit
     for combo in native_dlg.descendants(control_type="ComboBox"):
         try:
             edits = combo.descendants(control_type="Edit")
@@ -956,29 +1018,86 @@ def _find_filename_edit(native_dlg: UIAWrapper) -> UIAWrapper:
                 return edits[0]
         except Exception:
             continue
-    raise RuntimeError("filename Edit (ComboBox > Edit) not found in native dialog")
+
+    # Qt fallback: standalone Edit (not nested in any ComboBox).
+    combo_edits: set[int] = set()
+    for combo in native_dlg.descendants(control_type="ComboBox"):
+        try:
+            for e in combo.descendants(control_type="Edit"):
+                combo_edits.add(e.handle or id(e))
+        except Exception:
+            continue
+    standalone: list[UIAWrapper] = []
+    for e in native_dlg.descendants(control_type="Edit"):
+        try:
+            key = e.handle or id(e)
+            if key not in combo_edits:
+                standalone.append(e)
+        except Exception:
+            continue
+    if len(standalone) == 1:
+        return standalone[0]
+    if len(standalone) > 1:
+        # Qt usually has exactly one fileNameEdit, but dialogs with extra
+        # search/filter inputs could surface multiples. Prefer the one whose
+        # auto_id contains "fileName" (Qt's auto-id for QFileDialog's
+        # filename input), else fall through to diagnostic dump.
+        for e in standalone:
+            try:
+                if "filename" in (e.element_info.automation_id or "").lower():
+                    return e
+            except Exception:
+                continue
+
+    # Diagnostic dump — neither shape matched. Dump every Edit and every
+    # ComboBox so we know what tree we're dealing with.
+    dump: list[str] = []
+    try:
+        for c in native_dlg.descendants(control_type="ComboBox"):
+            try:
+                aid = c.element_info.automation_id or ""
+                t = (c.window_text() or "").strip()
+                dump.append(f"ComboBox aid={aid!r} text={t!r}")
+            except Exception:
+                continue
+        for e in native_dlg.descendants(control_type="Edit"):
+            try:
+                aid = e.element_info.automation_id or ""
+                t = (e.window_text() or "").strip()
+                dump.append(f"Edit aid={aid!r} text={t!r}")
+            except Exception:
+                continue
+    except Exception:
+        pass
+    raise RuntimeError(
+        "filename Edit not found in dialog (tried native ComboBox>Edit and "
+        f"Qt standalone-Edit patterns); tree: {dump!r}"
+    )
 
 
 def save_manifest_via_native_dialog(
     pid: int, target_path: str, dialog_timeout: float = 10
 ) -> None:
-    """Drive the native QFileDialog opened by File > Save Manifest Decisions….
+    """Drive the QFileDialog opened by File > Save Manifest Decisions….
 
-    1. Locate the filename Edit (ComboBox > Edit, locale-independent).
+    1. Locate the filename Edit (native: ComboBox > Edit; Qt non-native:
+       standalone QLineEdit). Both shapes handled by ``_find_filename_edit``.
     2. Set its value via UIA's ValuePattern.SetValue — bypasses keyboard
        (so IMEs like bopomofo can't intercept) and bypasses the
        locale-specific ComboBox label name.
-    3. Click the action button (Save/OK), located by bottom-row
-       structure (locale-independent).
+    3. Click the action button (Save/OK), located by structure (native:
+       2nd-from-rightmost in bottom row; Qt: topmost in QDialogButtonBox).
+       Locale-independent for both.
     4. Poll for the artifact appearing on disk (success), a "Save
        Manifest Error" dialog (raise), or timeout (raise diagnostic).
 
-    Known limitation (#129): this helper does not work on the
-    GitHub-hosted ``windows-latest`` runner because the native
-    IFileSaveDialog modal loop only pumps COM messages and the runner
-    does not deliver real synthesized mouse / keyboard input. Locally
-    with a real desktop session it works fine; ``s12_save_manifest``
-    is the canonical scenario exercising this path.
+    CI dialog-driving (#129): hosted Windows runners cannot drive the
+    native IFileSaveDialog (COM modal loop doesn't pump WM_*; no real
+    synthesized input). The ``qa-batch`` workflow sets
+    ``PHOTO_MANAGER_QT_FILE_DIALOG=1`` so ``main.py`` opts the entire
+    process into Qt's non-native widget dialog, which responds to UIA
+    normally. Locally, env var unset → native dialog as users see it.
+    Same scenario, both platforms.
     """
     save_hwnd = wait_for_dialog(pid, "Save Manifest Decisions", timeout=dialog_timeout)
     save_dlg = connect_by_handle(save_hwnd)
@@ -1000,16 +1119,10 @@ def save_manifest_via_native_dialog(
     # send_keys("{ENTER}") because send_keys delivers globally to
     # whatever Windows says is foreground; on a real desktop the dialog
     # IS foreground but on the GitHub-hosted windows-latest runner that
-    # invariant doesn't hold and the Enter misses.
-    #
-    # CI caveat (#129): this still fails on ``windows-latest`` runners
-    # specifically. The native Save dialog is a Windows IFileSaveDialog
-    # whose modal loop only pumps COM messages, and the runner doesn't
-    # deliver real synthesized mouse / keyboard input either.
-    # PostMessage(BM_CLICK), PostMessage(WM_KEYDOWN, VK_RETURN), and
-    # UIA Invoke all return success on the runner but the dialog never
-    # closes. Locally with a real desktop session ``click_input`` works
-    # fine and s12 passes.
+    # invariant doesn't hold and the Enter misses. See #129 for the
+    # full diagnostic of why the native-dialog path fails on hosted
+    # runners and why the ``PHOTO_MANAGER_QT_FILE_DIALOG`` env var is
+    # the canonical fix for CI.
     save_btn = _find_native_dialog_action_button(save_dlg)
     _focus(save_dlg)
     save_btn.click_input()

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -505,6 +505,121 @@ class TestSaveManifestDecisions:
 
         mock_info.assert_called_once()
 
+    @patch("PySide6.QtWidgets.QMessageBox.information")
+    def test_dialog_uses_canonical_title(self, _mock, tmp_path):
+        """The Save Manifest dialog must open with caption 'Save Manifest Decisions'.
+
+        Drift in this literal at file_operations.py would silently break QA
+        scenario s12 (which finds the dialog by exact title) and confuse users
+        who see a renamed title. Asserts the call args of getSaveFileName so
+        the title literal can't drift unnoticed (#129 — replacement coverage
+        for s12 which cannot run on hosted Windows runners).
+        """
+        recs = [_rec("/a.jpg")]
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=recs)])
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
+        handler, _, _ = _make_handler(vm, str(db))
+
+        with patch(
+            "PySide6.QtWidgets.QFileDialog.getSaveFileName",
+            return_value=("", ""),  # cancel; we only care about call args
+        ) as mock_dlg:
+            handler.save_manifest_decisions()
+
+        mock_dlg.assert_called_once()
+        title = mock_dlg.call_args.args[1]
+        assert title == "Save Manifest Decisions", (
+            f"dialog title drift: expected 'Save Manifest Decisions', got {title!r}"
+        )
+
+
+# ── load → decide → save round-trip ────────────────────────────────────────
+
+
+class TestSaveManifestLoadRoundTrip:
+    """Real sqlite -> ManifestRepository.load() -> save_manifest_decisions ->
+    real sqlite. Catches drift between the load and save sides that synthetic
+    SimpleNamespace fixtures miss — covers the end-to-end signal s12 catches
+    on a local desktop but cannot run on CI due to the IFileSaveDialog
+    limitation (#129)."""
+
+    @staticmethod
+    def _seed_grouped_manifest(tmp_path: Path) -> Path:
+        """Build a real grouped manifest with two rows in one near-duplicate group.
+
+        Mirrors the shape ManifestLoadWorker sees in production: one
+        REVIEW_DUPLICATE row + one Ref-tier row (MOVE) sharing a group_id.
+        Singletons would be filtered out by load(), so the pair is required.
+        """
+        from PIL import Image
+        cand = tmp_path / "cand.jpg"
+        ref = tmp_path / "ref.jpg"
+        for p in (cand, ref):
+            Image.new("RGB", (16, 16), (128, 64, 32)).save(p, "JPEG")
+        db = tmp_path / "src.sqlite"
+        with sqlite3.connect(db) as conn:
+            conn.executescript(_DDL)
+            gid = "/group/a"
+            conn.execute(
+                "INSERT INTO migration_manifest "
+                "(source_path, source_label, action, hamming_distance, "
+                "group_id, reason) VALUES (?, 'src', 'REVIEW_DUPLICATE', 5, ?, 'nd')",
+                (str(cand), gid),
+            )
+            conn.execute(
+                "INSERT INTO migration_manifest "
+                "(source_path, source_label, action, group_id, reason) "
+                "VALUES (?, 'src', 'MOVE', ?, 'unique')",
+                (str(ref), gid),
+            )
+            conn.commit()
+        return db
+
+    @patch("PySide6.QtWidgets.QMessageBox.information")
+    def test_load_decide_save_roundtrip(self, _mock, tmp_path):
+        from collections import defaultdict
+        from infrastructure.manifest_repository import ManifestRepository
+
+        src_db = self._seed_grouped_manifest(tmp_path)
+
+        # Load via the real repository — exercises auto-migration, group
+        # filtering, and PhotoRecord construction from real DB rows.
+        records = list(ManifestRepository().load(str(src_db)))
+        assert len(records) == 2, (
+            f"expected 2 grouped records from load(), got {len(records)}"
+        )
+
+        # Re-group by group_number so save sees real PhotoGroup objects
+        # whose items came out of the load path (not hand-built fixtures).
+        by_gn: dict[int, list] = defaultdict(list)
+        for rec in records:
+            by_gn[rec.group_number].append(rec)
+        groups = [
+            PhotoGroup(group_number=gn, items=items)
+            for gn, items in by_gn.items()
+        ]
+
+        # Inject decisions on the loaded records.
+        cand_rec = next(r for r in records if r.file_path.endswith("cand.jpg"))
+        ref_rec = next(r for r in records if r.file_path.endswith("ref.jpg"))
+        cand_rec.user_decision = "delete"
+        ref_rec.user_decision = "keep"
+
+        # Save to a NEW path via the real handler (dialog mocked).
+        new_path = str(tmp_path / "exported.sqlite")
+        vm = SimpleNamespace(groups=groups)
+        handler, _, _ = _make_handler(vm, str(src_db))
+        with patch(
+            "PySide6.QtWidgets.QFileDialog.getSaveFileName",
+            return_value=(new_path, ""),
+        ):
+            handler.save_manifest_decisions()
+
+        # Verify the loaded -> decided -> saved chain preserved decisions.
+        assert _read_decision(Path(new_path), cand_rec.file_path) == "delete"
+        assert _read_decision(Path(new_path), ref_rec.file_path) == "keep"
+        assert handler._manifest_path == new_path
+
 
 # ── batch SQL verification ─────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Sets `PHOTO_MANAGER_QT_FILE_DIALOG=1` in `qa-batch.yml`; `main.py` honors it via `Qt.AA_DontUseNativeDialogs` so every `QFileDialog` in the QA process becomes Qt's widget-based dialog on hosted Windows runners. Local users (env var unset) still get the native dialog — zero UX change.
- `_uia.py` filename-Edit and action-button locators carry parallel branches for both tree shapes (native: `ComboBox > Edit` + 2nd-from-rightmost; Qt: standalone `QLineEdit` + topmost in `QDialogButtonBox`).
- Same env var will unblock macOS `NSSavePanel` on future hosted-runner CI — one switch, every platform.
- Adds belt-and-braces unit tests for save-manifest signals that don't require driving a dialog: dialog title literal drift + load→save round-trip with real `ManifestRepository.load()` output.

Closes #129.

## Test plan

- [x] Local Windows full qa-batch with env var: 21/21 green (s12 + s16 both driving Qt non-native dialog)
- [x] Local pytest: 546 passed, 2 skipped (no regressions)
- [x] GitHub Actions `windows-latest` qa-batch on this branch via workflow_dispatch: **21/21 green** in 6m42s — see [run 25390434418](https://github.com/jackal998/photo-manager/actions/runs/25390434418)
- [x] s12_save_manifest passes on hosted runner (was the lone red scenario per #129; PR #128 burned 9 iterations confirming every input hammer is a no-op against the native dialog there)
- [ ] PR-open auto-trigger of qa-batch passes (2nd green run toward #74's "≥10 consecutive flake-free runs" promotion clock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)