### PR TITLE
chore(qa): untrack qa/settings.json drift; document #129 escape hatch in skill

### DIFF
--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -272,6 +272,21 @@ widgets (everything inside the main window, scan dialog, message
 boxes) keep their English names because those come from
 photo-manager's source — locale-translation only hits the OS dialogs.
 
+**Hosted CI uses Qt's non-native QFileDialog ([#129](https://github.com/jackal998/photo-manager/issues/129)).**
+The qa-batch workflow sets `PHOTO_MANAGER_QT_FILE_DIALOG=1`, which
+makes `main.py` apply `Qt.AA_DontUseNativeDialogs` before constructing
+`QApplication` so every `QFileDialog` becomes Qt's widget-based dialog.
+Qt's dialog responds to UIA normally; the native dialog's COM modal
+loop on hosted runners silently drops synthesized input. The
+`_find_filename_edit` and `_find_native_dialog_action_button` helpers
+in `_uia.py` carry parallel branches for both tree shapes — native
+(`ComboBox > Edit` + 2nd-from-rightmost bottom-row button) and Qt
+(standalone `QLineEdit` + topmost button inside `QDialogButtonBox`) —
+so new file-dialog scenarios inherit dual support automatically.
+Local users get the native dialog as before; the env var only flips
+under qa-batch. The same flip will unblock macOS `NSSavePanel` on
+future hosted macOS CI — one switch, every platform.
+
 **Setting Edit values: prefer UIA `ValuePattern.SetValue` over typing.**
 Two reasons:
 1. **IMEs intercept keystrokes.** `pywinauto.keyboard.send_keys("hello")`

--- a/.gitignore
+++ b/.gitignore
@@ -88,12 +88,15 @@ logs/
 .env.*
 !.env.example
 
-# Local settings — machine-specific paths, not committed
+# Local settings — machine-specific paths, not committed.
+# qa/settings.json is also ignored: qa.scenarios.configure rewrites it
+# on every batch run, so committing it created perpetual drift. The
+# canonical seed lives at qa/settings.json.example — copy it to
+# qa/settings.json on a fresh clone if you want to launch main.py
+# directly with PHOTO_MANAGER_HOME=qa. Batch runs (qa.scenarios._batch)
+# don't need the seed; configure.py creates settings.json from scratch.
 settings.json
 settings.local.json
-# Exception: qa/settings.json is the QA-isolated config — committed
-# intentionally, only references qa/sandbox/ paths, no PII.
-!qa/settings.json
 
 # Databases
 *.sqlite

--- a/qa/settings.json.example
+++ b/qa/settings.json.example
@@ -1,5 +1,5 @@
 {
-  "_comment": "Auto-written by qa.scenarios.configure for s01_happy_path.",
+  "_comment": "Seed for qa/settings.json. The QA batch runner (qa.scenarios.configure) rewrites qa/settings.json on every scenario, so this seed is only for direct main.py launches with PHOTO_MANAGER_HOME=qa on a fresh clone. Copy this file to qa/settings.json — JsonSettings already tolerates a missing file (returns empty dict), so this seed is purely for dev convenience.",
   "thumbnail_size": 256,
   "thumbnail_mem_cache": 128,
   "thumbnail_disk_cache_dir": "qa/.thumb-cache",
@@ -13,14 +13,6 @@
   },
   "sources": {
     "list": [
-      {
-        "path": "qa/sandbox/huge",
-        "recursive": true
-      },
-      {
-        "path": "qa/sandbox/near-duplicates",
-        "recursive": true
-      },
       {
         "path": "qa/sandbox/unique",
         "recursive": true


### PR DESCRIPTION
Two small QA-hygiene cleanups noticed during #131. Independent of #131; merge order doesn't matter.

## Summary

**Commit 1 — `chore(qa): untrack qa/settings.json (perpetual batch-runner drift)`**

`qa.scenarios.configure` rewrites `qa/settings.json` on every batch-runner scenario start, so committing it created perpetual `M`-status noise (there's even a prior commit titled `On feature/s15-context-menu: qa/settings.json batch-runner drift`). Removes the `!qa/settings.json` exception from `.gitignore` so the file is now ignored, and renames it to `qa/settings.json.example` as a documentation seed for fresh clones that want to launch `main.py` directly with `PHOTO_MANAGER_HOME=qa`. CI impact: none — `_batch.py` invokes `configure.py` before launching `main.py`, and `JsonSettings.__init__` already tolerates a missing file (returns empty dict).

**Commit 2 — `docs(qa): note PHOTO_MANAGER_QT_FILE_DIALOG escape hatch in qa-explore skill`**

#131 added the env-var-gated `AA_DontUseNativeDialogs` path. The `qa-explore` skill (what future Claude sessions actually read when running QA) only described the native `ComboBox > Edit` pattern, so it was stale. Adds a short paragraph after the locale-translation note explaining the env var, the dual-tree-shape support in `_find_filename_edit` / `_find_native_dialog_action_button`, and the cross-platform value (same flip lifts macOS `NSSavePanel` on future hosted-runner macOS CI).

## Test plan

- [x] `git status` after commits is clean
- [x] `qa/settings.json.example` exists with a sane seed; new clones can `cp` it to `qa/settings.json` if needed
- [ ] qa-batch run on this branch confirms `_batch.py` → `configure.py` → fresh `qa/settings.json` → green (auto-triggered when this PR opens)
- [ ] Skill update is visible to future `/qa-explore` runs (will land when merged into master)

## Notes

- Depends on #131 only conceptually (the SKILL.md note references the env var #131 introduces). Doesn't touch the same files; merge order is independent.
- `qa/settings.json.example` keeps the same shape as the runtime file — schema drift between this seed and the real config is caught by `configure.py` writing the real file from a Python dict at runtime, not from this seed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)