### PR TITLE
docs(qa): refresh qa-explore skill stale references after #133

### DIFF
--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -379,8 +379,10 @@ For each scenario:
      invisible to pywinauto. With it, every popup item, dialog widget,
      spinner, slider, and button becomes addressable by name.
 
-   Wait ~3 seconds before invoking the driver — the window takes a
-   moment to appear.
+   Wait ~2 seconds before invoking the driver — the window takes a
+   moment to appear. (The batch runner uses a ctypes EnumWindows poll
+   instead of a fixed sleep; for one-off manual launches, a brief
+   sleep is fine.)
 
 3. **Run the scenario driver as a Python module** (so its imports
    resolve relative to the repo root):
@@ -629,11 +631,14 @@ in one go, use `qa.scenarios._batch`:
 ```
 
 For each scenario it: configures `qa/settings.json` → launches
-`main.py` → waits 3.5 s → runs the driver → closes the window →
-waits for the subprocess to exit → moves to the next. Prints a final
-SUMMARY table with rc per scenario. The whole batch (21 scenarios)
-typically finishes in ~120–200 seconds. Each app launch is still a
-real launch — get the user's "yes batch" once before starting.
+`main.py` → polls (ctypes `EnumWindows`) until the main window is
+visible (max 8 s; typically <2 s) → runs the driver → closes the
+window → waits for the subprocess to exit → moves to the next.
+Prints a final SUMMARY table with rc per scenario. The whole batch
+(21 scenarios) typically finishes in ~5–7 minutes (5m19s on
+`windows-latest` after the #133 poll change). Each app launch is
+still a real launch — get the user's "yes batch" once before
+starting.
 
 **Optional optimization — skip the per-run Bash prompt.** Add this
 to `.allow` in `.claude/settings.json` so driver runs don't prompt:


### PR DESCRIPTION
Tiny cleanup spotted while auditing project SKILL.md files for stale references after this session's three merged PRs (#131, #132, #133).

## Summary

Two references in `.claude/skills/qa-explore/SKILL.md` were left over from before #133's window-poll change:

- "Wait ~3 seconds before invoking the driver" → trimmed to ~2 seconds, with a note that the batch runner uses a ctypes `EnumWindows` poll (not a fixed sleep). Manual one-off launches still benefit from a brief sleep, so kept the guidance.
- "waits 3.5 s" + "typically finishes in ~120-200 seconds" → updated to describe the poll mechanism and the post-#133 timing observed on `windows-latest` (5m19s for 21 scenarios).

Spot-checked `impact-map` and `update-docs` SKILL.md as well — neither references the patterns touched by #131/#132/#133.

## Test plan

- [x] `git diff` shows only the three intended sentences changed
- [ ] No CI verification needed — the SKILL.md is read by Claude sessions running `/qa-explore`, not by any tooling

🤖 Generated with [Claude Code](https://claude.com/claude-code)