### PR TITLE
fix(scan): confirm before re-scan overwrites pending decisions (#142)

### DIFF
--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -565,6 +565,7 @@ running.
 | 19 | Right-click context menu → Open Folder (explorer.exe /select integration) | `qa.scenarios.s19_context_menu_open_folder` | ✓ ready |
 | 20 | Right-click multi-selection → Remove from List (file-multi / group + file) | `qa.scenarios.s20_multi_remove_from_list` | ✓ ready |
 | 21 | List menu → Remove from List (no-selection / single / multi) | `qa.scenarios.s21_list_menu_remove` | ✓ ready |
+| 27 | Re-scan with pending decisions → confirmation prompt (#142) | `qa.scenarios.s27_rescan_confirm` | ✓ ready |
 
 Several drivers also call cross-scenario invariant probes from
 `qa/scenarios/_invariants.py` — they assert that the status bar matches

--- a/app/viewmodels/main_vm.py
+++ b/app/viewmodels/main_vm.py
@@ -107,3 +107,20 @@ class MainVM:
     def group_count(self) -> int:
         """Number of groups currently loaded."""
         return len(self.groups)
+
+    @property
+    def pending_decision_count(self) -> int:
+        """Number of records with a non-default ``user_decision``.
+
+        Used by the re-scan confirmation flow (#142) to detect when a
+        user has acted on the loaded manifest and should be warned
+        before a re-scan replaces it. ``user_decision`` is empty string
+        by default (see ``core.models.PhotoRecord``); any non-empty
+        value (``delete`` / ``keep`` / etc.) means the user has acted.
+        """
+        return sum(
+            1
+            for group in self.groups
+            for record in group.items
+            if record.user_decision
+        )

--- a/app/views/dialogs/scan_dialog.py
+++ b/app/views/dialogs/scan_dialog.py
@@ -319,6 +319,7 @@ class ScanDialog(QDialog):
         settings,                          # JsonSettings instance
         on_scan_complete: Callable[[str], None] | None = None,
         parent: QWidget | None = None,
+        should_proceed: Callable[[], bool] | None = None,
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Scan Sources")
@@ -326,6 +327,13 @@ class ScanDialog(QDialog):
         self.setMinimumHeight(600)
         self.settings = settings
         self._on_complete = on_scan_complete
+        # Optional gate fired right before the scan worker starts. Returns
+        # True to proceed, False to cancel. Defaults to always-proceed so
+        # callers (and tests) that don't care can omit it.
+        # See photo-manager#142 — used by MainWindow to prompt when the
+        # currently-loaded manifest has pending user decisions that would
+        # be replaced by a re-scan.
+        self._should_proceed = should_proceed or (lambda: True)
         self._worker: ScanWorker | None = None
         self.manifest_path: str | None = None
 
@@ -561,6 +569,13 @@ class ScanDialog(QDialog):
             QMessageBox.warning(
                 self, "No output", "Please specify an output path for the manifest."
             )
+            return
+
+        # Gate (#142): host can prompt if the loaded manifest has pending
+        # decisions that this scan would replace. Default callback always
+        # returns True so freshly-launched / unconnected dialogs are
+        # unchanged.
+        if not self._should_proceed():
             return
 
         self._save_to_settings()

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -255,8 +255,42 @@ class MainWindow(QMainWindow):
             settings=self._settings,
             on_scan_complete=self._load_manifest_from_path,
             parent=self,
+            should_proceed=self._confirm_no_pending_decisions,
         )
         dlg.exec()
+
+    def _confirm_no_pending_decisions(self) -> bool:
+        """Prompt before a re-scan replaces a manifest with pending decisions.
+
+        Issue #142: a re-scan replaces the in-memory manifest (and may
+        overwrite the on-disk file if the output path matches) without
+        warning. If the user has acted on rows since loading, that work is
+        silently lost.
+
+        Returns ``True`` to proceed with the scan, ``False`` to cancel.
+        Returns ``True`` immediately when there's nothing at risk
+        (no manifest loaded, or no decisions made yet), so this is also
+        the right behaviour for first-time scans.
+        """
+        pending = self._vm.pending_decision_count
+        if pending == 0:
+            return True
+
+        reply = QMessageBox.question(
+            self,
+            "Discard pending decisions?",
+            f"You have {pluralize(pending, 'pending decision')} on the loaded "
+            "manifest.\n\n"
+            "Re-scanning will replace the loaded manifest. If the scan output "
+            "path matches the loaded manifest path, those decisions will be "
+            "permanently lost on disk; otherwise the previous manifest is "
+            "preserved on disk but no longer visible in this window.\n\n"
+            "Save first via File → Save Manifest Decisions… if you want to "
+            "keep them.\n\nProceed with the re-scan?",
+            QMessageBox.Yes | QMessageBox.No,
+            QMessageBox.No,
+        )
+        return reply == QMessageBox.Yes
 
     def _load_manifest_from_path(self, manifest_path: str) -> None:
         """Load a manifest directly (called after scan completes or from Open Manifest)."""

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -50,6 +50,7 @@ ALL_SCENARIOS = [
     "s19_context_menu_open_folder",
     "s20_multi_remove_from_list",
     "s21_list_menu_remove",
+    "s27_rescan_confirm",
 ]
 
 

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -39,6 +39,8 @@ SCENARIO_SOURCES: dict[str, list[str]] = {
     "s19_context_menu_open_folder": ["qa/sandbox/near-duplicates"],
     "s20_multi_remove_from_list":   ["qa/sandbox/near-duplicates", "qa/sandbox/format-dup"],
     "s21_list_menu_remove":         ["qa/sandbox/near-duplicates"],
+    # s27 (#142) — re-scan with pending decisions triggers confirmation prompt.
+    "s27_rescan_confirm":           ["qa/sandbox/near-duplicates"],
 }
 
 

--- a/qa/scenarios/s27_rescan_confirm.py
+++ b/qa/scenarios/s27_rescan_confirm.py
@@ -1,0 +1,261 @@
+"""Scenario 27 — Re-scan while manifest has pending decisions: confirmation prompt (#142).
+
+Required source: qa/sandbox/near-duplicates (5 files, basenames neardup_NN_qXX.jpg).
+
+Drives the re-scan-with-pending-decisions confirmation flow end-to-end:
+  scan → close & load → set decision on row 0 →
+  open scan dialog → click Start Scan →
+  (a) verify "Discard pending decisions?" dialog appears, click No →
+      verify scan did NOT run (log empty, original manifest intact);
+  (b) close scan dialog, set another decision, re-open scan dialog →
+      click Start Scan → click Yes on the prompt →
+      verify scan ran (Done. in log) and manifest re-built.
+
+Catches drift in: ScanDialog.should_proceed callback wiring;
+MainWindow._confirm_no_pending_decisions detection logic; the prompt's
+Yes/No button shape; scan-launch-cancellation behaviour.
+
+Note: this scenario does NOT verify the (separate) case where no
+decisions are pending — that's the default ScanDialog behaviour and is
+covered by every other scan-running scenario in the batch (s01, s10,
+s17, etc.). If they pass, we know the gate doesn't fire spuriously.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+from pywinauto.application import Application
+
+from qa.scenarios import _uia
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO / "qa" / "run-manifest.sqlite"
+
+ROW_FIRST = "neardup_00_q95.jpg"
+ROW_SECOND = "neardup_01_q88.jpg"
+
+PROMPT_TITLE = "Discard pending decisions?"
+
+
+def _read_decision_count() -> int:
+    """Return the number of rows in the manifest with non-empty user_decision."""
+    if not MANIFEST_PATH.exists():
+        return 0
+    conn = sqlite3.connect(str(MANIFEST_PATH))
+    try:
+        (n,) = conn.execute(
+            "SELECT COUNT(*) FROM migration_manifest "
+            "WHERE user_decision IS NOT NULL AND user_decision != ''"
+        ).fetchone()
+    finally:
+        conn.close()
+    return n
+
+
+def _wait_for_prompt(pid: int, timeout: float = 5) -> int:
+    """Block until the 'Discard pending decisions?' QMessageBox appears.
+    Returns the prompt window's hwnd. Raises TimeoutError on miss."""
+    return _uia.wait_for_dialog(pid, PROMPT_TITLE, timeout=timeout)
+
+
+def _click_prompt_button(prompt_hwnd: int, button_title: str) -> None:
+    """Click Yes or No on the open prompt and wait for it to dismiss."""
+    prompt = _uia.connect_by_handle(prompt_hwnd)
+    _uia._focus(prompt)
+    time.sleep(0.2)
+    btn = prompt.child_window(title=button_title, control_type="Button")
+    btn.click_input()
+    time.sleep(0.4)
+
+
+def _scan_dialog_log_text(scan_dlg) -> str:
+    """Return current text content of the ScanDialog log widget."""
+    log_edit = scan_dlg.child_window(
+        auto_id=_uia.SCAN_AID_LOG, control_type="Edit"
+    )
+    return log_edit.window_text() or ""
+
+
+def main() -> int:
+    print("scenario: s27_rescan_confirm")
+    app, win = _uia.connect_main()
+    pid = win.process_id()
+    print(f"connected: pid={pid} title={win.window_text()!r}")
+
+    # ── Initial scan + load ──────────────────────────────────────────────
+    print("step: initial_scan")
+    dlg, _ = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    _uia.close_and_load_manifest(dlg)
+    _, win = _uia.connect_main()
+
+    if _read_decision_count() != 0:
+        print(f"FAIL: post-load decision count expected 0, got {_read_decision_count()}")
+        return 1
+
+    # ── Set a decision on row 0 ───────────────────────────────────────────
+    print("step: set_first_decision")
+    print(f"  target={ROW_FIRST!r} action=delete")
+    _uia.left_click_tree_row(win, ROW_FIRST)
+    _uia.right_click_tree_row(win, ROW_FIRST)
+    _uia.select_popup_menu_path(pid, [_uia.CTX_SET_ACTION, _uia.CTX_DELETE])
+    decisions_before_branch_a = _read_decision_count()
+    print(f"  decision_count={decisions_before_branch_a}")
+    if decisions_before_branch_a != 1:
+        print(f"FAIL: expected 1 pending decision, got {decisions_before_branch_a}")
+        return 1
+
+    failures: list[str] = []
+
+    # ── Branch A: prompt appears, click No, scan does NOT run ────────────
+    print("step: branch_a_cancel_via_no")
+    dlg_a, _ = _uia.open_scan_dialog(win)
+    # Click Start Scan — expect prompt rather than a scan kicking off.
+    start_btn = dlg_a.child_window(
+        title=_uia.SCAN_BTN_START, control_type="Button"
+    )
+    _uia._focus(dlg_a)
+    start_btn.invoke()
+    try:
+        prompt_hwnd = _wait_for_prompt(pid, timeout=5)
+        prompt = _uia.connect_by_handle(prompt_hwnd)
+        # Verify Yes and No buttons both exist (shape check).
+        btn_titles = sorted(
+            (b.window_text() or "").strip()
+            for b in prompt.descendants(control_type="Button")
+            if (b.window_text() or "").strip() in {"Yes", "No"}
+        )
+        print(f"  prompt_buttons={btn_titles}")
+        if btn_titles != ["No", "Yes"]:
+            failures.append(
+                f"branch_a: prompt buttons mismatch — expected [No, Yes], "
+                f"got {btn_titles}"
+            )
+        # Verify the body mentions the count.
+        body_texts = [
+            (t.window_text() or "")
+            for t in prompt.descendants(control_type="Text")
+        ]
+        full_body = " ".join(body_texts)
+        if "1 pending decision" not in full_body:
+            failures.append(
+                f"branch_a: prompt body missing pluralised count; "
+                f"body={full_body!r}"
+            )
+        else:
+            print(f"  body_includes_count=True")
+    except TimeoutError:
+        failures.append("branch_a: prompt did not appear within 5s of Start Scan")
+        prompt_hwnd = None
+
+    if prompt_hwnd is not None:
+        _click_prompt_button(prompt_hwnd, "No")
+        # Scan dialog should remain open with empty log (no scan ran).
+        time.sleep(0.5)
+        log_text = _scan_dialog_log_text(dlg_a)
+        print(f"  log_after_no_len={len(log_text)}")
+        if "Done." in log_text or "Indexed in manifest" in log_text:
+            failures.append(
+                f"branch_a: scan appears to have run despite No click; "
+                f"log fragment: {log_text[:200]!r}"
+            )
+        decisions_after_no = _read_decision_count()
+        print(f"  decisions_after_no={decisions_after_no}")
+        if decisions_after_no != 1:
+            failures.append(
+                f"branch_a: decision count changed after No click; "
+                f"expected 1, got {decisions_after_no}"
+            )
+
+    # Close the scan dialog (still open; click the regular Close).
+    print("step: close_scan_dialog_after_branch_a")
+    _uia.close_scan_dialog_via_close_button(dlg_a)
+    time.sleep(0.5)
+    _, win = _uia.connect_main()
+
+    # ── Branch B: prompt appears, click Yes, scan runs ────────────────────
+    print("step: branch_b_proceed_via_yes")
+    # Add another decision to make the test more realistic.
+    print(f"  set additional decision on {ROW_SECOND!r}")
+    _uia.left_click_tree_row(win, ROW_SECOND)
+    _uia.right_click_tree_row(win, ROW_SECOND)
+    _uia.select_popup_menu_path(pid, [_uia.CTX_SET_ACTION, _uia.CTX_DELETE])
+    decisions_before_branch_b = _read_decision_count()
+    print(f"  decision_count_before_branch_b={decisions_before_branch_b}")
+    if decisions_before_branch_b != 2:
+        failures.append(
+            f"branch_b setup: expected 2 pending decisions, "
+            f"got {decisions_before_branch_b}"
+        )
+
+    dlg_b, _ = _uia.open_scan_dialog(win)
+    start_btn = dlg_b.child_window(
+        title=_uia.SCAN_BTN_START, control_type="Button"
+    )
+    _uia._focus(dlg_b)
+    start_btn.invoke()
+    try:
+        prompt_hwnd_b = _wait_for_prompt(pid, timeout=5)
+        prompt_b = _uia.connect_by_handle(prompt_hwnd_b)
+        # Body should now reflect the higher count.
+        body_texts_b = [
+            (t.window_text() or "")
+            for t in prompt_b.descendants(control_type="Text")
+        ]
+        full_body_b = " ".join(body_texts_b)
+        if "2 pending decisions" not in full_body_b:
+            failures.append(
+                f"branch_b: prompt body should pluralise to '2 pending "
+                f"decisions'; body={full_body_b!r}"
+            )
+        else:
+            print(f"  body_includes_plural_count=True")
+        _click_prompt_button(prompt_hwnd_b, "Yes")
+    except TimeoutError:
+        failures.append("branch_b: prompt did not appear within 5s of Start Scan")
+
+    # After Yes, the scan should run. Wait for the log to show "Done."
+    # via the same helper used by run_scan_and_wait.
+    print("step: wait_for_scan_completion_after_yes")
+    log_edit = dlg_b.child_window(
+        auto_id=_uia.SCAN_AID_LOG, control_type="Edit"
+    )
+    try:
+        _uia.wait_for_text_in(log_edit, ["Done.", "Error", "Failed"], timeout=30)
+        print("  scan_ran_after_yes=True")
+    except TimeoutError:
+        failures.append("branch_b: scan did not complete within 30s of Yes click")
+
+    # Manifest got rebuilt → all decisions cleared (the destructive
+    # behaviour the user just opted in to).
+    decisions_after_yes = _read_decision_count()
+    print(f"  decisions_after_yes={decisions_after_yes}")
+    if decisions_after_yes != 0:
+        failures.append(
+            f"branch_b: re-scan should reset decisions to 0 (manifest "
+            f"replaced), got {decisions_after_yes}"
+        )
+
+    # Close the dialog cleanly via Close & Load to leave the app in a
+    # tidy state for the next batch scenario.
+    try:
+        _uia.close_and_load_manifest(dlg_b)
+    except Exception as exc:
+        print(f"  cleanup close_and_load: {exc!r}")
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    print("scenario: s27_rescan_confirm DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_main_vm.py
+++ b/tests/test_main_vm.py
@@ -197,3 +197,69 @@ class TestGroupCount:
     def test_reflects_loaded_groups(self):
         vm = _load(_rec("/a.jpg", 1), _rec("/b.jpg", 2), _rec("/c.jpg", 3))
         assert vm.group_count == 3
+
+
+# ── pending_decision_count (#142 — re-scan confirmation gate) ─────────────
+
+
+class TestPendingDecisionCount:
+    """Counter used by MainWindow._confirm_no_pending_decisions to decide
+    whether to prompt before letting a re-scan replace the loaded
+    manifest.
+
+    Empty user_decision = default (untouched). Any non-empty string
+    counts as "user has acted on this row".
+    """
+
+    def test_zero_before_load(self):
+        vm = MainVM()
+        assert vm.pending_decision_count == 0
+
+    def test_zero_when_all_records_undecided(self):
+        vm = _load(
+            _rec("/a.jpg", 1, user_decision=""),
+            _rec("/b.jpg", 1, user_decision=""),
+            _rec("/c.jpg", 2, user_decision=""),
+        )
+        assert vm.pending_decision_count == 0
+
+    def test_counts_delete_decisions(self):
+        vm = _load(
+            _rec("/a.jpg", 1, user_decision="delete"),
+            _rec("/b.jpg", 1, user_decision=""),
+        )
+        assert vm.pending_decision_count == 1
+
+    def test_counts_keep_decisions(self):
+        vm = _load(
+            _rec("/a.jpg", 1, user_decision="keep"),
+            _rec("/b.jpg", 1, user_decision=""),
+        )
+        assert vm.pending_decision_count == 1
+
+    def test_counts_mixed_decision_kinds(self):
+        vm = _load(
+            _rec("/a.jpg", 1, user_decision="delete"),
+            _rec("/b.jpg", 1, user_decision="keep"),
+            _rec("/c.jpg", 2, user_decision=""),
+            _rec("/d.jpg", 2, user_decision="delete"),
+        )
+        assert vm.pending_decision_count == 3
+
+    def test_counts_across_multiple_groups(self):
+        vm = _load(
+            _rec("/g1a.jpg", 1, user_decision="delete"),
+            _rec("/g2a.jpg", 2, user_decision="delete"),
+            _rec("/g3a.jpg", 3, user_decision="delete"),
+        )
+        assert vm.pending_decision_count == 3
+
+    def test_treats_any_non_empty_string_as_decided(self):
+        """Defensive: if a future decision kind is added (e.g. 'review',
+        'move'), the gate still fires. Only the empty string means
+        'untouched'."""
+        vm = _load(
+            _rec("/a.jpg", 1, user_decision="review"),
+            _rec("/b.jpg", 1, user_decision="move"),
+        )
+        assert vm.pending_decision_count == 2

--- a/tests/test_scan_dialog.py
+++ b/tests/test_scan_dialog.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -439,6 +440,132 @@ class TestPostScanCloseFocus:
         dlg._btn_scan.setEnabled(False)
         dlg._on_failed("simulated pipeline error")
         assert dlg._btn_scan.isEnabled()
+
+
+class TestStartScanShouldProceed:
+    """#142 — the ``should_proceed`` callback gates the scan worker launch.
+
+    MainWindow injects a callback that returns False when the loaded
+    manifest has pending decisions and the user clicks No on the
+    confirmation prompt. ScanDialog must respect that and abort before
+    ``ScanWorker.start()`` is reached.
+
+    These tests verify the gating contract independent of MainWindow's
+    actual prompt logic — they pass a deterministic lambda for ``should_proceed``.
+    """
+
+    def _make_dialog(self, qapp, tmp_path, should_proceed):
+        from app.views.dialogs.scan_dialog import ScanDialog, _SourceEntry
+        from infrastructure.settings import JsonSettings
+
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text('{"sources":{}}', encoding="utf-8")
+        dlg = ScanDialog(
+            JsonSettings(settings_path), should_proceed=should_proceed
+        )
+        # Satisfy input validation so we reach the gate.
+        dlg._source_list.set_entries(
+            [_SourceEntry(path=str(tmp_path), recursive=True)]
+        )
+        dlg._output_field.setText(str(tmp_path / "out.sqlite"))
+        return dlg
+
+    def test_default_should_proceed_is_always_true(self, qapp, tmp_path):
+        """Constructor default — caller didn't pass should_proceed — must
+        not block any existing flow."""
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text('{"sources":{}}', encoding="utf-8")
+        dlg = ScanDialog(JsonSettings(settings_path))
+        # Default callback is the always-True lambda; calling it must not raise.
+        assert dlg._should_proceed() is True
+
+    def test_should_proceed_false_aborts_before_worker_start(
+        self, qapp, tmp_path, monkeypatch
+    ):
+        """When the gate returns False (user clicked No on the prompt),
+        ScanWorker must not be instantiated at all."""
+        worker_constructed = []
+
+        def fake_worker_init(self, *a, **kw):
+            worker_constructed.append((a, kw))
+            # Block actual subprocess; let __init__ "succeed" so we'd see
+            # the failure if the gate didn't fire.
+            self.start = lambda: None
+
+        from app.views.dialogs import scan_dialog as sd
+        monkeypatch.setattr(sd.ScanWorker, "__init__", fake_worker_init)
+
+        called = []
+        dlg = self._make_dialog(
+            qapp, tmp_path, should_proceed=lambda: (called.append(True), False)[1]
+        )
+        dlg._start_scan()
+
+        assert called == [True], "should_proceed must be called"
+        assert worker_constructed == [], (
+            "ScanWorker must not be constructed when should_proceed is False"
+        )
+
+    def test_should_proceed_true_proceeds_to_worker_start(
+        self, qapp, tmp_path, monkeypatch
+    ):
+        """When the gate returns True (user clicked Yes or no manifest
+        loaded), the scan worker is constructed and started as before."""
+        worker_started = []
+
+        class FakeWorker:
+            def __init__(self, *a, **kw):
+                self._args = (a, kw)
+                # Provide the signal attributes _start_scan connects to.
+                self.progress = MagicMock()
+                self.failed = MagicMock()
+                self.finished = MagicMock()
+                self.completed_empty = MagicMock()
+
+            def start(self):
+                worker_started.append(True)
+
+        from app.views.dialogs import scan_dialog as sd
+        monkeypatch.setattr(sd, "ScanWorker", FakeWorker)
+
+        dlg = self._make_dialog(
+            qapp, tmp_path, should_proceed=lambda: True
+        )
+        dlg._start_scan()
+
+        assert worker_started == [True], (
+            "ScanWorker.start must be called when should_proceed is True"
+        )
+
+    def test_validation_failures_short_circuit_before_should_proceed(
+        self, qapp, tmp_path, monkeypatch
+    ):
+        """If the source list is empty or output path missing, the
+        validation message fires FIRST and should_proceed is never called.
+        This keeps the prompt from interrupting users who haven't even
+        configured a valid scan yet."""
+        from PySide6.QtWidgets import QMessageBox
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        # Suppress the warning dialog popup.
+        monkeypatch.setattr(QMessageBox, "warning", lambda *a, **k: None)
+
+        called = []
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text('{"sources":{}}', encoding="utf-8")
+        dlg = ScanDialog(
+            JsonSettings(settings_path),
+            should_proceed=lambda: (called.append(True), True)[1],
+        )
+        # Don't add any source entries — should fail the "no sources"
+        # validation BEFORE reaching should_proceed.
+        dlg._start_scan()
+
+        assert called == [], "should_proceed must not fire on validation failure"
 
 
 class TestPathFieldEntry:


### PR DESCRIPTION
Fixes #142.

## Summary

Re-scanning while a manifest with pending decisions is loaded now prompts before proceeding. Previously the scan ran silently, the in-memory state was replaced, and (if the scan output path matched the loaded manifest path) on-disk decisions were destroyed without warning. Users could lose 30 minutes of review work just by clicking Start Scan in the dialog.

The fix adds a small gate: ScanDialog now accepts an optional ``should_proceed: Callable[[], bool]`` callback fired between input validation and worker launch. MainWindow injects ``_confirm_no_pending_decisions``, which counts rows with a non-empty ``user_decision`` and shows a ``QMessageBox.question`` (Yes/No, default No — same shape as the existing destructive confirmation in ExecuteActionDialog) when the count is non-zero.

When nothing is at risk (no manifest loaded or no decisions set), the prompt is skipped entirely — no behaviour change for first-time scans.

## Approach

- ``MainVM.pending_decision_count`` — pure property, easy unit test.
- ``ScanDialog`` constructor gains optional ``should_proceed`` kwarg, default lambda returns ``True`` (preserves existing tests / callers that don't pass it).
- ``MainWindow.on_scan_sources`` wires its new ``_confirm_no_pending_decisions`` method as the callback.
- Two-button prompt only. \"Save first\" is one cancel + ``File → Save Manifest Decisions…`` + retry — keeps the change small. Auto-backup and versioned output paths from the issue body's other options are deferred as separate work.

## Tests

- **``TestPendingDecisionCount``** (7 tests, ``tests/test_main_vm.py``) — pure count logic, no Qt. Covers no-load, all-undecided, single-decision, multi-decision, mixed-kinds, plus a defensive test that any non-empty string counts as decided.
- **``TestStartScanShouldProceed``** (4 tests, ``tests/test_scan_dialog.py``) — default callback is always-True, gate-False short-circuits before ``ScanWorker`` construction, gate-True proceeds, and input-validation failures short-circuit BEFORE the gate so users with empty source lists never see a confused prompt.
- **``qa/scenarios/s27_rescan_confirm.py``** (new) — layer-3 driver. Scans ``near-duplicates``, sets a decision, re-opens the Scan dialog. Branch A: clicks No → scan log stays empty + decision count unchanged. Branch B: adds a second decision, re-prompts (body now pluralises to \"2 pending decisions\"), clicks Yes → scan runs to ``Done.`` + decision count resets to 0 (manifest replaced as user opted in). Wired into ``_batch.py``, ``_config.py``, and the qa-explore SKILL.md scenario table.

## Verification

| Check | Result |
|---|---|
| ``pytest tests/`` | 606 passed, 2 skipped (was 594), 89.87% coverage (was 89.16%) |
| Live ``qa.scenarios.s27_rescan_confirm`` | PASS against running app — both branches behave correctly |
| Existing scan scenarios (s01, s10, s17 etc.) | Unaffected — they don't set decisions before re-scanning, so the gate returns True silently |

## Test plan

- [ ] Run full test suite locally: ``.venv/Scripts/python.exe -m pytest tests/``
- [ ] Run new scenario: ``.venv/Scripts/python.exe -m qa.scenarios._batch s27_rescan_confirm``
- [ ] Manual: load a manifest, mark some files for delete, open File → Scan Sources…, click Start Scan, verify the prompt fires with the correct count, click No → stays in dialog with empty log, click Yes → scan runs and replaces manifest

🤖 Generated with [Claude Code](https://claude.com/claude-code)