### PR TITLE
chore(qa): add optional symlink fixture for s09 walker-exclusions check

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -119,6 +119,13 @@ settings.local.json
 # disposable — never commit their contents.
 qa/sandbox/_disposable/
 
+# Optional symlink fixture for s09. Created by scripts/make_qa_sandbox.py
+# when the platform allows (Linux, macOS, Windows with Developer Mode);
+# silently skipped otherwise. Must NOT be tracked by Git — Windows clones
+# without core.symlinks=true would de-symlink it to a plain text file
+# containing the target path, silently breaking the test.
+qa/sandbox/walker-exclusions/symlink_to_real.jpg
+
 # Temporary files
 tmp/
 temp/

--- a/qa/scenarios/s09_walker_exclusions.py
+++ b/qa/scenarios/s09_walker_exclusions.py
@@ -2,13 +2,23 @@
 
 Required sources: qa/sandbox/walker-exclusions
 Probes: only the 2 real photos appear; sidecar.json, Thumbs.db, desktop.ini
-correctly skipped.
+correctly skipped. When the fixture also contains a symlink (created at
+fixture-build time on platforms that permit it — see
+``scripts/make_qa_sandbox._ensure_walker_symlink``), additionally probes
+that the walker's symlink-skip guard fires end-to-end through the GUI
+scan worker.
 """
 from __future__ import annotations
 
 import sys
+from pathlib import Path
 
 from qa.scenarios import _uia
+
+REPO = Path(__file__).resolve().parents[2]
+SYMLINK_FIXTURE = (
+    REPO / "qa" / "sandbox" / "walker-exclusions" / "symlink_to_real.jpg"
+)
 
 
 def main() -> int:
@@ -53,6 +63,33 @@ def main() -> int:
     for ex in excluded:
         present = any(ex in r.cells[1] if len(r.cells) > 1 else False for r in rows)
         print(f"  excluded_file_present: {ex}={present}")
+
+    # Optional symlink probe — fires only when the fixture builder was able
+    # to create symlink_to_real.jpg (i.e. the dev box / runner has the
+    # SeCreateSymbolicLink privilege on Windows, or is on Linux/macOS).
+    # When the symlink IS present, assert it does NOT appear in result
+    # rows — the walker's is_symlink() guard at scanner/walker.py should
+    # have skipped it. This is the layer-3 companion to test_walker.py
+    # tests at lines 50/75 (which themselves skip on Windows-without-
+    # elevation but run on the windows-latest CI runner).
+    print("step: probe_symlink_exclusion")
+    if SYMLINK_FIXTURE.is_symlink():
+        symlink_name = SYMLINK_FIXTURE.name
+        leaked = any(
+            symlink_name in r.cells[1] if len(r.cells) > 1 else False
+            for r in rows
+        )
+        print(f"  symlink_fixture_present=True name={symlink_name!r}")
+        print(f"  symlink_in_results={leaked}")
+        if leaked:
+            print(f"FAIL: walker leaked symlink {symlink_name!r} into result rows")
+            return 1
+    else:
+        # Fall through silently — fixture not creatable on this platform.
+        # The layer-1 mock test (test_skips_files_when_path_reports_as_symlink)
+        # covers the same code branch via monkeypatched is_symlink().
+        print(f"  symlink_fixture_present=False (path={SYMLINK_FIXTURE})")
+        print("  symlink_check=skipped (fixture not creatable on this platform)")
 
     print("scenario: s09_walker_exclusions DONE")
     return 0

--- a/scripts/make_qa_sandbox.py
+++ b/scripts/make_qa_sandbox.py
@@ -19,6 +19,8 @@ Subdirs and contents:
   multi-source-a/    — 2 JPEGs (used with multi-source-b for priority test)
   multi-source-b/    — 3 JPEGs: 1 byte-identical to a/, 1 near-dup, 1 unique
   walker-exclusions/ — 2 JPEGs + sidecar.json + Thumbs.db + desktop.ini
+                       (+ optional symlink_to_real.jpg when permitted —
+                       see _ensure_walker_symlink)
                        (probes walker skip rules)
   videos/            — 2 minimal video stub files: dummy.mp4, dummy.mov
                        (just an ftyp box; SHA-256 + extension routing only —
@@ -72,7 +74,19 @@ def _ensure_dir(name: str) -> Path:
 
 
 def _content_files(p: Path) -> list[Path]:
-    return [f for f in p.iterdir() if f.is_file() and f.name != ".gitkeep"]
+    """Regular (non-symlink) files in the fixture dir, excluding .gitkeep.
+
+    Symlinks are intentionally excluded from this tally so they don't
+    inflate the per-fixture EXPECTED_COUNTS check. Currently only
+    walker-exclusions/ uses a symlink, and it's optional (depends on
+    platform privileges — see ``_ensure_walker_symlink``).
+    """
+    return [
+        f for f in p.iterdir()
+        if f.is_file()
+        and not f.is_symlink()
+        and f.name != ".gitkeep"
+    ]
 
 
 def _is_complete(name: str) -> bool:
@@ -83,7 +97,15 @@ def _is_complete(name: str) -> bool:
 
 
 def _clear(p: Path) -> None:
-    for f in _content_files(p):
+    """Remove every artifact under ``p`` except ``.gitkeep``.
+
+    Iterates ``iterdir()`` directly (not ``_content_files``) so symlinks
+    are also unlinked — ``--force`` should produce a clean slate, not
+    leave stale symlinks pointing at deleted-and-regenerated targets.
+    """
+    for f in p.iterdir():
+        if f.name == ".gitkeep":
+            continue
         f.unlink()
 
 
@@ -326,7 +348,11 @@ def make_walker_exclusions(force: bool) -> None:
     name = "walker-exclusions"
     p = _ensure_dir(name)
     if not force and _is_complete(name):
-        print(f"  {name}/ -> already complete (5 files), skipping")
+        print(f"  {name}/ -> already complete (5 files), skipping base regen")
+        # Even when the 5 base files are intact, the optional symlink may
+        # be absent (gitignored, missing on a fresh clone, removed by an
+        # earlier --force). Try to add it idempotently.
+        _ensure_walker_symlink(p)
         return
     _clear(p)
 
@@ -345,6 +371,53 @@ def make_walker_exclusions(force: bool) -> None:
         "[.ShellClassInfo]\nIconFile=icon.ico\n", encoding="utf-8")
     print(f"  {name}/ -> 5 files (2 photos + .json sidecar "
           "+ Thumbs.db + desktop.ini)")
+    _ensure_walker_symlink(p)
+
+
+def _ensure_walker_symlink(p: Path) -> None:
+    """Create ``walker-exclusions/symlink_to_real.jpg`` → ``real_photo_a.jpg``
+    if not already present and the platform permits symlink creation.
+
+    This is the layer-3 companion to ``tests/test_walker.py`` lines 50/75 —
+    those layer-1 tests verify ``scan_sources()`` skips symlinks directly;
+    this fixture lets ``s09_walker_exclusions`` verify the same behaviour
+    end-to-end through the GUI scan worker.
+
+    Symlink creation requires SeCreateSymbolicLink on Windows (Developer
+    Mode or admin-elevated shell). When unavailable we silently fall
+    through; s09 detects the symlink's absence at scan time and skips
+    that branch of its assertion list. CI on ``windows-latest`` runners
+    has the privilege by default — verified via the layer-1 tests passing
+    on CI without the local skip we see on dev machines.
+
+    The symlink is gitignored — Git stores symlinks as text files
+    containing the target path on Windows clones unless ``core.symlinks``
+    is enabled, which would silently de-symlink the fixture for some
+    contributors and break the test. Generating it at fixture time
+    avoids that class of confusion entirely.
+    """
+    link = p / "symlink_to_real.jpg"
+    target = p / "real_photo_a.jpg"
+    if link.is_symlink() or link.exists():
+        return  # already present, idempotent
+    if not target.is_file():
+        # Base fixture not yet built — caller must run --force first.
+        return
+    try:
+        # Relative target so the link works regardless of where the
+        # checkout lives on disk.
+        link.symlink_to(target.name)
+    except OSError as exc:
+        # Most common cause: Windows without SeCreateSymbolicLink.
+        # Other possibilities: read-only filesystem, broken target.
+        # All are non-fatal for fixture build — s09 falls back to
+        # asserting only the name-based exclusions.
+        print(f"  walker-exclusions/symlink_to_real.jpg -> "
+              f"could not create symlink ({exc.__class__.__name__}); "
+              "layer-3 symlink check will be skipped on this machine")
+        return
+    print(f"  walker-exclusions/symlink_to_real.jpg -> "
+          "created symlink to real_photo_a.jpg")
 
 
 def _minimal_mp4_box(brand: bytes) -> bytes:


### PR DESCRIPTION
## Summary

Closes the layer-3 coverage gap I surfaced during the ignored-unit-tests audit: \`tests/test_walker.py:50\` and \`:75\` verify \`scan_sources()\` skips symlinks at the unit layer, but no \`qa-explore\` scenario exercises the same behaviour end-to-end through the GUI scan worker. \`qa/sandbox/walker-exclusions/\` contained only \`Thumbs.db\` / \`desktop.ini\` / \`sidecar.json\` / 2 real photos — no symlink for the walker's \`is_symlink()\` guard to fire against.

This PR adds an **optional** symlink to the walker-exclusions fixture, generated at fixture-build time and silently skipped where platform privilege is missing.

## Approach

* \`scripts/make_qa_sandbox.py\` gets \`_ensure_walker_symlink(p)\` — creates \`symlink_to_real.jpg\` → \`real_photo_a.jpg\` when permitted, falls through with a clear message otherwise.
* \`s09_walker_exclusions.py\` checks \`SYMLINK_FIXTURE.is_symlink()\` at scan time:
  * Symlink present → assert it does NOT appear in result rows; fail the scenario if it leaks.
  * Symlink absent → print \"skipped (fixture not creatable on this platform)\" and continue. The same code branch is still exercised by the layer-1 mock test (\`test_walker.py:99\`) which monkeypatches \`Path.is_symlink\`.
* \`.gitignore\` the symlink artifact — Git stores symlinks as text files containing the target path on Windows clones without \`core.symlinks=true\`, which would silently de-symlink the fixture and break the test for some contributors.

## Helper changes (small, scoped)

* \`_content_files()\` now excludes symlinks from the per-fixture expected-count tally — otherwise a present-or-absent symlink would constantly toggle \`_is_complete\` and trigger needless regeneration.
* \`_clear()\` iterates \`p.iterdir()\` directly (not via \`_content_files\`) so \`--force\` strips symlinks too. \`--force\` should yield a true clean slate.

## Platform behaviour matrix

| Platform | Symlink fixture creatable? | layer-1 (test_walker.py:50/75) | layer-3 (s09) |
|---|---|---|---|
| Linux / macOS | yes | runs, passes | runs, asserts |
| GitHub \`windows-latest\` runners | yes (has SeCreateSymbolicLink) | runs, passes | runs, asserts |
| Windows dev machine without Developer Mode | no | skipped (\`pytest.skip()\`) | falls through with diagnostic |

The \"falls-through\" branch on dev machines is verified locally — \`make_qa_sandbox.py\` printed the expected fallback message and exited 0, and the s09 driver imports cleanly with the new \`SYMLINK_FIXTURE\` constant.

## Verification

| Check | Result |
|---|---|
| \`python scripts/make_qa_sandbox.py\` (this Windows-no-elevation box) | symlink fallback message printed, no error, exit 0 |
| \`pytest tests/\` | 606 passed, 2 skipped (unchanged baseline) |
| \`git status\` after regen | clean — symlink either absent or gitignored |
| s09 module import | OK |
| CI (\`windows-latest\` runner) | will create symlink + assert exclusion |
| Re-run safety / idempotence | \`_ensure_walker_symlink\` short-circuits if already present |

## Test plan

- [ ] CI qa-batch on PR — s09 must pass, and its log should show \`symlink_fixture_present=True\` (not the fallback path) since the runner has the privilege
- [ ] Local: \`python scripts/make_qa_sandbox.py --force\` — verify the symlink-skip path prints the fallback and exit 0
- [ ] Local on Linux / WSL / Developer-Mode-on Windows: verify the symlink IS created and s09 asserts the exclusion

🤖 Generated with [Claude Code](https://claude.com/claude-code)