### PR TITLE
fix(dialogs): set ApplicationModal on Execute and Action dialogs (#139)

### DIFF
--- a/app/views/dialogs/execute_action_dialog.py
+++ b/app/views/dialogs/execute_action_dialog.py
@@ -28,6 +28,16 @@ class ExecuteActionDialog(QDialog):
         super().__init__(parent)
         self.setWindowTitle("Execute Actions — Review")
         self.setMinimumSize(900, 560)
+        # #139 — QDialog.exec() sets WA_ShowModal but leaves windowModality
+        # at the QWidget default (Qt.NonModal). Without explicit modality,
+        # Qt does NOT set the OS-level owner relationship or disable the
+        # parent on Windows, so a real mouse click on the parent's menu
+        # bar steals foreground and opens the menu while this dialog is
+        # mid-review. ApplicationModal blocks input to all windows in
+        # the app until this dialog is dismissed; this is the right
+        # choice for a destructive-confirmation review modal where any
+        # menu-bar action could create inconsistent state.
+        self.setWindowModality(Qt.ApplicationModal)
         self._groups = groups
         self._manifest_path = manifest_path
         self.deleted_paths: list[str] = []

--- a/app/views/dialogs/select_dialog.py
+++ b/app/views/dialogs/select_dialog.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from PySide6.QtCore import Signal
+from PySide6.QtCore import Qt, Signal
 from PySide6.QtWidgets import (
     QComboBox,
     QDialog,
@@ -35,6 +35,11 @@ class ActionDialog(QDialog):
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle("Set Action by Field/Regex")
+        # #139 — explicit ApplicationModal so OS-level click events on
+        # the parent (e.g. main window menu bar) are blocked while this
+        # dialog is up. QDialog.exec() alone doesn't do this; see the
+        # ExecuteActionDialog comment for the full reasoning.
+        self.setWindowModality(Qt.ApplicationModal)
         self._fields = list(fields)
         self._row_values = dict(row_values or {})
 

--- a/tests/test_execute_action_dialog.py
+++ b/tests/test_execute_action_dialog.py
@@ -72,6 +72,19 @@ class TestDialogState:
         dlg = ExecuteActionDialog(groups, manifest_path=None)
         assert dlg._tree.model() is not None
 
+    def test_window_modality_is_application_modal(self, qapp):
+        """#139 — QDialog.exec() alone leaves windowModality at NonModal,
+        which means Qt does NOT set OS-level WS_DISABLED on the parent
+        on Windows. Real mouse clicks on the parent window's menu bar
+        then steal foreground and open menus while this dialog is mid-
+        review. Pin ApplicationModal explicitly so the OS-level owner
+        relationship and WS_DISABLED are both established."""
+        from PySide6.QtCore import Qt
+        from app.views.dialogs.execute_action_dialog import ExecuteActionDialog
+        groups = [_group(_rec("/a.jpg", "delete"))]
+        dlg = ExecuteActionDialog(groups, manifest_path=None)
+        assert dlg.windowModality() == Qt.ApplicationModal
+
     def test_empty_groups_tree_still_created(self, qapp):
         from app.views.dialogs.execute_action_dialog import ExecuteActionDialog
         dlg = ExecuteActionDialog([], manifest_path=None)

--- a/tests/test_select_dialog.py
+++ b/tests/test_select_dialog.py
@@ -30,6 +30,19 @@ class TestInitialField:
         assert dlg.combo.currentText() == "File Name"
 
 
+class TestModality:
+    def test_window_modality_is_application_modal(self, qapp):
+        """#139 — same root cause as ExecuteActionDialog: QDialog.exec()
+        without explicit windowModality leaves Qt at NonModal at the OS
+        level, allowing real mouse clicks on the main window's menu bar
+        to steal foreground while this dialog is up. ApplicationModal is
+        what actually establishes WS_DISABLED on the parent on Windows."""
+        from PySide6.QtCore import Qt
+        from app.views.dialogs.select_dialog import ActionDialog
+        dlg = ActionDialog(fields=["Similarity", "File Name", "Folder"])
+        assert dlg.windowModality() == Qt.ApplicationModal
+
+
 class TestSetActionSignal:
     def test_set_action_emits_signal_with_delete(self, qapp):
         from app.views.dialogs.select_dialog import ActionDialog


### PR DESCRIPTION
Fixes #139.

## Summary

\`QDialog.exec()\` sets \`WA_ShowModal\` but leaves \`windowModality\` at the QWidget default (\`Qt.NonModal\`). On Windows, Qt then does **not** establish the OS-level modality relationship — \`GW_OWNER\` returns 0 on the dialog, and \`WS_DISABLED\` is never set on the parent. A real mouse click on the parent's menu bar steals foreground and opens menus while a "modal" dialog is up.

The fix: explicitly call \`setWindowModality(Qt.ApplicationModal)\` in both \`ExecuteActionDialog\` and \`ActionDialog\`. \`ApplicationModal\` blocks input to all top-level windows in the app, which is the right strength for destructive-confirmation modals where a menu action could create inconsistent state (e.g. opening a different manifest mid-execute).

## Empirical evidence

Verified at OS level via \`GetWindow(hwnd, GW_OWNER)\` and \`GetWindowLong(hwnd, GWL_STYLE)\` while the Execute dialog was open:

| State | exec_dlg owner | main WS_DISABLED | mouse.click on File coords |
|---|---|---|---|
| **Before fix** | \`0\` (no owner) | \`False\` | popup spawns, foreground shifts to main |
| **After fix** | matches main_win hwnd | \`True\` | no popup, foreground stays on exec dialog |

The pre-fix \"the user could pick Scan Sources… while the Execute dialog is mid-review\" claim from the issue body was accurate — verified by synthesizing a real \`SendInput\` mouse click via \`pywinauto.mouse.click(coords=...)\`. (UIA's \`click_input()\` happened to mask this in the original probe because it goes through Qt's invocation pipeline, which respects \`WA_ShowModal\` even when OS-level modality is missing.)

## Why ApplicationModal vs WindowModal

\`WindowModal\` only blocks the parent window. For these dialogs the parent is the main window, so on the surface either would work. But \`ApplicationModal\` is the right strength here because:

* The dialogs are reviewing/committing destructive state (delete files, set actions across multiple rows). Any other top-level window action — even a hypothetical future error dialog popping over the main — should not be reachable in parallel.
* Empirically on this Qt version, only \`ApplicationModal\` produced \`WS_DISABLED\` reliably. \`WindowModal\` did NOT (verified live in the same probe iteration).

## Tests

- \`test_execute_action_dialog.py::TestDialogState::test_window_modality_is_application_modal\`
- \`test_select_dialog.py::TestModality::test_window_modality_is_application_modal\`

Both assert \`windowModality() == Qt.ApplicationModal\` at construction time. Pure flag read — the OS-level \`WS_DISABLED\` behaviour was verified end-to-end via the Win32 probe; layer 1 just pins the explicit flag against accidental future regressions.

## Verification

| Check | Result |
|---|---|
| \`pytest tests/\` | **608 passed** (was 606 + 2 new), 2 skipped, **89.88%** coverage |
| Live mouse-click probe (after fix) | no popup, foreground stays on dialog |
| Live mouse-click probe (before fix) | popup spawns, foreground shifts to main window |

## Test plan

- [ ] CI \`pytest\` job — must stay green
- [ ] CI \`qa-batch\` job — s13 / s14 / s15 / s27 still pass (Execute and Action dialogs are exercised by these scenarios)
- [ ] Manual: open Execute Action dialog, drag it aside, click File menu in main window — File menu must NOT open

🤖 Generated with [Claude Code](https://claude.com/claude-code)