### PR TITLE
qa(s23): scan dialog settings persist across app restart (#122)

### DIFF
--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -565,6 +565,8 @@ running.
 | 19 | Right-click context menu → Open Folder (explorer.exe /select integration) | `qa.scenarios.s19_context_menu_open_folder` | ✓ ready |
 | 20 | Right-click multi-selection → Remove from List (file-multi / group + file) | `qa.scenarios.s20_multi_remove_from_list` | ✓ ready |
 | 21 | List menu → Remove from List (no-selection / single / multi) | `qa.scenarios.s21_list_menu_remove` | ✓ ready |
+| 23a | Scan dialog: GUI mutates settings, persists via Start Scan (#122) | `qa.scenarios.s23a_set_settings` | ✓ ready |
+| 23b | Scan dialog: fresh launch reloads what s23a wrote (#122) | `qa.scenarios.s23b_verify_settings` | ✓ ready |
 | 25 | Right-click on empty area / menu bar / unselected row → no Qt popup (#124) | `qa.scenarios.s25_empty_area_context_menu` | ✓ ready |
 | 27 | Re-scan with pending decisions → confirmation prompt (#142) | `qa.scenarios.s27_rescan_confirm` | ✓ ready |
 

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -50,6 +50,10 @@ ALL_SCENARIOS = [
     "s19_context_menu_open_folder",
     "s20_multi_remove_from_list",
     "s21_list_menu_remove",
+    # s23 is split A/B so the cross-launch boundary is an explicit batch step.
+    # Order matters: s23b reads what s23a's GUI mutations persisted to disk.
+    "s23a_set_settings",
+    "s23b_verify_settings",
     "s25_empty_area_context_menu",
     "s27_rescan_confirm",
 ]

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -14,7 +14,14 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 SETTINGS_PATH = REPO_ROOT / "qa" / "settings.json"
 
 # Source folder lists per scenario. Keys are module names under qa.scenarios.
-SCENARIO_SOURCES: dict[str, list[str]] = {
+#
+# Sentinel: a value of ``None`` means "preserve the existing qa/settings.json".
+# Used when a scenario needs to read back state that a previous scenario
+# wrote via the GUI (e.g. s23b reads what s23a persisted through
+# ScanDialog._save_to_settings). The configure step becomes a no-op for
+# such scenarios; the batch ordering in _batch.py is what guarantees the
+# previous scenario ran first.
+SCENARIO_SOURCES: dict[str, list[str] | None] = {
     "s01_happy_path":      ["qa/sandbox/huge", "qa/sandbox/near-duplicates", "qa/sandbox/unique"],
     "s02_empty_folder":    ["qa/sandbox/empty"],
     "s03_cancel_scan":     ["qa/sandbox/near-duplicates", "qa/sandbox/huge", "qa/sandbox/unique"],
@@ -39,6 +46,13 @@ SCENARIO_SOURCES: dict[str, list[str]] = {
     "s19_context_menu_open_folder": ["qa/sandbox/near-duplicates"],
     "s20_multi_remove_from_list":   ["qa/sandbox/near-duplicates", "qa/sandbox/format-dup"],
     "s21_list_menu_remove":         ["qa/sandbox/near-duplicates"],
+    # s23 (#122) — scan dialog settings round-trip across app restart.
+    # Split into two scenarios so the cross-launch boundary is an
+    # explicit batch step. s23a writes via GUI; s23b launches fresh
+    # and reads back. The ``None`` sentinel on s23b tells configure
+    # to preserve what s23a persisted.
+    "s23a_set_settings":            ["qa/sandbox/unique"],
+    "s23b_verify_settings":         None,
     # s25 (#124) — right-click on empty area / menu bar / unselected row
     # must NOT spawn a Qt context menu.
     "s25_empty_area_context_menu":  ["qa/sandbox/near-duplicates"],
@@ -47,14 +61,18 @@ SCENARIO_SOURCES: dict[str, list[str]] = {
 }
 
 
-def build_settings(scenario_name: str) -> dict:
-    """Return the settings.json dict for a scenario."""
-    sources = SCENARIO_SOURCES.get(scenario_name)
-    if sources is None:
+def build_settings(scenario_name: str) -> dict | None:
+    """Return the settings.json dict for a scenario, or ``None`` to mean
+    "preserve the existing settings.json on disk" (see SCENARIO_SOURCES
+    sentinel docstring above)."""
+    if scenario_name not in SCENARIO_SOURCES:
         raise KeyError(
             f"unknown scenario {scenario_name!r}; "
             f"known: {sorted(SCENARIO_SOURCES)}"
         )
+    sources = SCENARIO_SOURCES[scenario_name]
+    if sources is None:
+        return None  # preserve existing settings.json
     return {
         "_comment": f"Auto-written by qa.scenarios.configure for {scenario_name}.",
         "thumbnail_size": 256,
@@ -70,5 +88,7 @@ def build_settings(scenario_name: str) -> dict:
 
 def write_settings(scenario_name: str) -> Path:
     cfg = build_settings(scenario_name)
+    if cfg is None:
+        return SETTINGS_PATH  # preserve — caller's previous scenario already wrote
     SETTINGS_PATH.write_text(json.dumps(cfg, indent=2), encoding="utf-8")
     return SETTINGS_PATH

--- a/qa/scenarios/configure.py
+++ b/qa/scenarios/configure.py
@@ -23,8 +23,15 @@ def main() -> int:
     except KeyError as e:
         print(f"error: {e}")
         return 1
-    print(f"wrote {path}")
-    print(f"sources={SCENARIO_SOURCES[name]}")
+    sources = SCENARIO_SOURCES[name]
+    if sources is None:
+        # Preserve sentinel — settings.json was NOT rewritten. The scenario
+        # reads back what a previous scenario in the batch wrote via the GUI.
+        print(f"preserved settings at {path}")
+        print("sources=<preserved from previous scenario>")
+    else:
+        print(f"wrote {path}")
+        print(f"sources={sources}")
     return 0
 
 

--- a/qa/scenarios/s23a_set_settings.py
+++ b/qa/scenarios/s23a_set_settings.py
@@ -1,0 +1,137 @@
+"""Scenario 23a — Set scan dialog settings via GUI, persist to qa/settings.json (#122).
+
+Required source: qa/sandbox/unique (initial 1-source list — driver will mutate
+to 2 sources via the dialog).
+
+Pairs with ``s23b_verify_settings``: s23a opens the scan dialog, mutates the
+source list / output path / row recursive flag, triggers a scan to fire
+``ScanDialog._save_to_settings``, then exits. s23b launches a fresh app
+(``SCENARIO_SOURCES[s23b] is None`` so configure preserves what s23a wrote)
+and reads back the dialog state to verify the round-trip.
+
+Why split: ``ScanDialog._save_to_settings`` is only called from
+``_start_scan`` (verified at app/views/dialogs/scan_dialog.py:581). Closing
+the dialog without scanning does NOT persist. We trigger a scan as the
+canonical save path; the scan's side effect (a manifest at
+qa/sandbox/_disposable/s23_test.sqlite) is acceptable noise.
+
+Why two scenarios in the batch instead of one driver with internal restart:
+the batch runner already restarts the app between scenarios. Splitting
+into s23a/s23b makes the cross-launch boundary an explicit batch step,
+which is also what would happen if a developer ran each driver standalone
+in sequence.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from qa.scenarios import _uia
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Mutations applied by this scenario. s23b reads these back from the
+# fresh-launch dialog and asserts they round-tripped through
+# qa/settings.json correctly.
+SECOND_SOURCE_REL = "qa/sandbox/near-duplicates"
+TARGET_OUTPUT = "qa/sandbox/_disposable/s23_test.sqlite"
+
+
+def main() -> int:
+    print("scenario: s23a_set_settings")
+    app, win = _uia.connect_main()
+    pid = win.process_id()
+    print(f"connected: pid={pid} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, _ = _uia.open_scan_dialog(win)
+    initial = _uia.read_source_paths(dlg)
+    print(f"  initial_sources={initial}")
+    if len(initial) != 1:
+        print(f"FAIL: expected 1 initial source from configure, got {len(initial)}")
+        return 1
+
+    # ── Mutation 1: add a second source via path-field ──────────────────
+    print("step: add_second_source")
+    second_abs = str((REPO / SECOND_SOURCE_REL).resolve())
+    print(f"  adding={second_abs!r}")
+    _uia.add_source_via_path_field(dlg, second_abs)
+    after_add = _uia.read_source_paths(dlg)
+    print(f"  sources_after_add={after_add}")
+    if len(after_add) != 2:
+        print(f"FAIL: expected 2 sources after add, got {len(after_add)}")
+        return 1
+
+    # ── Mutation 2: toggle Recursive on row 0 (default True → False) ────
+    print("step: toggle_recursive_row_0")
+    _uia.toggle_source_row_recursive(dlg, 0)
+
+    # ── Mutation 3: change output path ──────────────────────────────────
+    print("step: set_output_path")
+    output_field = dlg.child_window(
+        auto_id=_uia.SCAN_AID_OUTPUT_PATH, control_type="Edit"
+    )
+    output_field.iface_value.SetValue(TARGET_OUTPUT)
+    rendered = output_field.window_text()
+    print(f"  output_field_now={rendered!r}")
+    if rendered != TARGET_OUTPUT:
+        print(f"FAIL: expected output={TARGET_OUTPUT!r}, got {rendered!r}")
+        return 1
+
+    # ── Persist via Start Scan (the only path that calls _save_to_settings) ─
+    print("step: trigger_save_via_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+
+    # ── Close & Load to leave the app in a tidy state ───────────────────
+    print("step: close_and_load")
+    _uia.close_and_load_manifest(dlg)
+
+    # ── Smoke-check: settings.json on disk reflects the mutations ───────
+    # This is the layer-3 confirmation that _save_to_settings did its job
+    # before the scan worker started. s23b's value-add is verifying the
+    # LOAD path — that the next launch reads these values back correctly.
+    print("step: verify_settings_json_on_disk")
+    settings_path = REPO / "qa" / "settings.json"
+    saved = json.loads(settings_path.read_text(encoding="utf-8"))
+    saved_sources = saved.get("sources", {})
+    saved_list = saved_sources.get("list", [])
+    saved_output = saved_sources.get("output")
+    print(f"  on_disk_sources={saved_list}")
+    print(f"  on_disk_output={saved_output!r}")
+
+    failures: list[str] = []
+    if len(saved_list) != 2:
+        failures.append(
+            f"settings.json has {len(saved_list)} sources, expected 2"
+        )
+    if saved_output != TARGET_OUTPUT:
+        failures.append(
+            f"settings.json output={saved_output!r}, expected {TARGET_OUTPUT!r}"
+        )
+    # Recursive flag round-trip: row 0 should be False (we toggled), row 1
+    # should still be True (default for newly-added sources).
+    if saved_list:
+        if saved_list[0].get("recursive") is not False:
+            failures.append(
+                f"settings.json row 0 recursive={saved_list[0].get('recursive')!r}, "
+                f"expected False (we toggled it)"
+            )
+        if len(saved_list) > 1 and saved_list[1].get("recursive") is not True:
+            failures.append(
+                f"settings.json row 1 recursive={saved_list[1].get('recursive')!r}, "
+                f"expected True (default for new sources)"
+            )
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    print("scenario: s23a_set_settings DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s23b_verify_settings.py
+++ b/qa/scenarios/s23b_verify_settings.py
@@ -1,0 +1,122 @@
+"""Scenario 23b — Verify scan dialog reloads settings persisted by s23a (#122).
+
+Required configure: ``SCENARIO_SOURCES["s23b_verify_settings"] is None`` —
+the configure step preserves the qa/settings.json that s23a's GUI
+mutations wrote. A fresh app launch then reads that file via
+``ScanDialog._load_from_settings``.
+
+Pairs with ``s23a_set_settings``: see that file's docstring for the split
+rationale. This scenario MUST run AFTER s23a in the batch order; the
+batch runner enforces this via ALL_SCENARIOS list ordering.
+
+What's verified at layer 3:
+  * Source list count + paths round-trip through settings.json
+  * Output path round-trip
+  * pHash and color slider values are at their defaults (10, 30) — they
+    are intentionally NOT persisted (see scan_dialog.py:518 — the
+    ``_save_to_settings`` body only writes ``sources.list`` and
+    ``sources.output``). If a future change adds slider persistence,
+    the assertion below would fail and force a conscious update.
+
+What's NOT verified here (covered elsewhere):
+  * The recursive flag on each row — Qt's setCellWidget'd checkbox is
+    not exposed in the UIA tree (see ``read_source_paths`` docstring).
+    s23a's settings.json smoke check covers the WRITE side; full WRITE +
+    READ round-trip would need a non-recursive scan to assert behaviorally
+    (recursive=False would not descend into subdirs). That's an
+    enhancement for a future scenario.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+from qa.scenarios import _uia
+
+REPO = Path(__file__).resolve().parents[2]
+
+# Mirrored from s23a_set_settings — must stay in sync.
+EXPECTED_OUTPUT = "qa/sandbox/_disposable/s23_test.sqlite"
+EXPECTED_SOURCE_COUNT = 2
+EXPECTED_PHASH_DEFAULT = 10
+EXPECTED_COLOR_DEFAULT = 30
+
+
+def main() -> int:
+    print("scenario: s23b_verify_settings")
+    app, win = _uia.connect_main()
+    pid = win.process_id()
+    print(f"connected: pid={pid} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, _ = _uia.open_scan_dialog(win)
+
+    print("step: read_persisted_state")
+    sources_in_dialog = _uia.read_source_paths(dlg)
+    output_field = dlg.child_window(
+        auto_id=_uia.SCAN_AID_OUTPUT_PATH, control_type="Edit"
+    )
+    output_value = output_field.window_text() or ""
+    print(f"  reloaded_sources={sources_in_dialog}")
+    print(f"  reloaded_output={output_value!r}")
+
+    print("step: read_slider_defaults")
+    spinner_texts = [
+        (s.window_text() or "").strip()
+        for s in dlg.descendants(control_type="Spinner")
+    ]
+    spinner_ints: list[int] = []
+    for v in spinner_texts:
+        try:
+            spinner_ints.append(int(v))
+        except ValueError:
+            pass
+    print(f"  spinner_values={spinner_texts}")
+
+    failures: list[str] = []
+
+    # Sources: count + presence (paths can be normalized differently across
+    # platforms, so we compare-in rather than ==).
+    if len(sources_in_dialog) != EXPECTED_SOURCE_COUNT:
+        failures.append(
+            f"sources count: expected {EXPECTED_SOURCE_COUNT}, "
+            f"got {len(sources_in_dialog)} (paths={sources_in_dialog})"
+        )
+
+    # Output path
+    if output_value != EXPECTED_OUTPUT:
+        failures.append(
+            f"output path: expected {EXPECTED_OUTPUT!r}, got {output_value!r}"
+        )
+
+    # Slider defaults — confirms intentional non-persistence
+    if EXPECTED_PHASH_DEFAULT not in spinner_ints:
+        failures.append(
+            f"pHash spinner default: expected {EXPECTED_PHASH_DEFAULT} "
+            f"in spinner values, got {spinner_ints}"
+        )
+    if EXPECTED_COLOR_DEFAULT not in spinner_ints:
+        failures.append(
+            f"color spinner default: expected {EXPECTED_COLOR_DEFAULT} "
+            f"in spinner values, got {spinner_ints}"
+        )
+
+    # Tidy up — close the scan dialog without scanning. The batch runner
+    # then closes the main window between scenarios.
+    print("step: close_dialog_via_close_button")
+    try:
+        _uia.close_scan_dialog_via_close_button(dlg)
+    except Exception as exc:
+        print(f"  close_button_fallback: {exc!r}")
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    print("scenario: s23b_verify_settings DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #122.

## Summary

Pins the layer-3 cross-launch round-trip for scan dialog settings. Layer 1 covers \`JsonSettings\` get/set/save; nothing previously verified that a GUI mutation in the scan dialog survives close + relaunch. Every prior scan-dialog scenario reads the *initial* settings written by \`configure\`, never a value the user themselves set inside the dialog.

## Split shape

| Scenario | What it does |
|---|---|
| **s23a_set_settings** | Launches with one configured source. Opens scan dialog → adds second source via \`+ Add\` → toggles recursive on row 0 (default True → False) → changes output path → runs Start Scan (the only path that fires \`ScanDialog._save_to_settings\`, verified at \`scan_dialog.py:581\`) → Close & Load → smoke-checks \`qa/settings.json\` on disk. |
| **s23b_verify_settings** | Launches fresh (configure step is a no-op via the new None sentinel — see below). Opens scan dialog → reads reloaded source list, output path, and slider values → asserts they match s23a's mutations and that sliders are at defaults (intentional non-persistence). |

The batch runner already restarts the app between scenarios, so the cross-launch is naturally an explicit batch step.

## New: \`None\` sentinel in \`SCENARIO_SOURCES\`

s23b needs the configure step to preserve what s23a wrote, not overwrite it. Solution: \`SCENARIO_SOURCES[\"s23b_verify_settings\"] = None\`. \`build_settings\` and \`write_settings\` now treat None as "preserve existing settings.json on disk". Documented inline in \`_config.py\`. The batch runner doesn't need to change — configure just becomes a no-op for sentinel scenarios.

## Verified round-trip

Local batch (s23a → s23b): both pass.

\`\`\`
s23a on-disk after Start Scan:
  sources=[{'path': 'qa/sandbox/unique', 'recursive': False},
           {'path': 'C:\\...\\near-duplicates', 'recursive': True}]
  output='qa/sandbox/_disposable/s23_test.sqlite'

s23b reloaded dialog state:
  sources=['qa/sandbox/unique', 'C:\\...\\near-duplicates']
  output='qa/sandbox/_disposable/s23_test.sqlite'
  spinner_values=['10', '30']   ← sliders intentionally don't persist
\`\`\`

## What's NOT covered

The recursive flag round-trip is asserted only via settings.json on disk (s23a's smoke check), not via dialog reload — Qt's \`setCellWidget'd\` Recursive checkbox is not exposed in the UIA tree (see \`read_source_paths\` docstring). Full behavioural verification would need a non-recursive scan + file-count check; deferred as a future enhancement.

The pHash/color slider non-persistence is **pinned** in s23b — if a future change adds slider persistence, the assertion fails and forces a conscious test update. That's the right shape: changes in persistence behaviour shouldn't slip through silently.

## Verification

| Check | Result |
|---|---|
| \`pytest tests/\` | 608 passed (unchanged), 89.88% coverage |
| Live: \`-m qa.scenarios._batch s23a_set_settings s23b_verify_settings\` | 2/2 OK |
| Configure preserve-sentinel | \`preserved settings at C:\\...\\settings.json\` printed; file mtime unchanged |
| Module imports | both clean |

## Files

- \`qa/scenarios/_config.py\` — None sentinel, SCENARIO_SOURCES entries
- \`qa/scenarios/configure.py\` — prints "preserved settings" for None
- \`qa/scenarios/_batch.py\` — s23a/s23b adjacent after s21
- \`qa/scenarios/s23a_set_settings.py\` (new)
- \`qa/scenarios/s23b_verify_settings.py\` (new)
- \`.claude/skills/qa-explore/SKILL.md\` — scenario table updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)