### PR TITLE
fix(menus): add Alt-key mnemonics to top-level menus (#135)

### DIFF
--- a/app/views/components/menu_controller.py
+++ b/app/views/components/menu_controller.py
@@ -26,11 +26,17 @@ class MenuController:
         self.actions: dict[str, QAction] = {}
 
     def setup_menus(self) -> dict[str, QAction]:
-        """Create all menus and return action references."""
+        """Create all menus and return action references.
+
+        #135 — top-level menu titles use Qt's ``&`` mnemonic prefix so
+        Alt+letter opens each menu without a mouse. List and Log both
+        start with L; List wins ``Alt+L`` (more frequently used —
+        Remove from List), Log uses ``Alt+G`` (``Lo&g``).
+        """
         menubar = QMenuBar(self.window)
 
-        # File Menu
-        file_menu = menubar.addMenu("File")
+        # File Menu — Alt+F
+        file_menu = menubar.addMenu("&File")
         self.actions["scan_sources"] = file_menu.addAction("Scan Sources…")
         file_menu.addSeparator()
         self.actions["open_manifest"] = file_menu.addAction("Open Manifest…")
@@ -39,23 +45,23 @@ class MenuController:
         file_menu.addSeparator()
         self.actions["exit"] = file_menu.addAction("Exit")
 
-        # Action Menu
-        action_menu = menubar.addMenu("Action")
+        # Action Menu — Alt+A
+        action_menu = menubar.addMenu("&Action")
         self.actions["action_by_regex"] = action_menu.addAction("Set Action by Field/Regex…")
         action_menu.addSeparator()
         self.actions["execute_action"] = action_menu.addAction("Execute Action…")
         self.actions["execute_action"].setEnabled(False)
 
-        # List Menu
-        list_menu = menubar.addMenu("List")
+        # List Menu — Alt+L
+        list_menu = menubar.addMenu("&List")
         self.actions["remove_from_list"] = list_menu.addAction("Remove from List")
         # Disabled until a manifest loads — gives the user a visible-but-greyed
         # entry instead of a menu that appears empty / no-op before any data is
         # present. Re-enabled in MainWindow._load_manifest_from_path.
         self.actions["remove_from_list"].setEnabled(False)
 
-        # Log Menu
-        log_menu = menubar.addMenu("Log")
+        # Log Menu — Alt+G ("Lo&g") — L is taken by List
+        log_menu = menubar.addMenu("Lo&g")
         self.actions["open_latest_log"] = log_menu.addAction("Open Latest Log")
         self.actions["open_latest_delete_log"] = log_menu.addAction("Open Latest Delete Log")
         log_menu.addSeparator()

--- a/tests/test_menu_controller_manifest_actions.py
+++ b/tests/test_menu_controller_manifest_actions.py
@@ -152,3 +152,89 @@ def test_get_all_actions_returns_a_copy(qapp):
     snapshot = mc.get_all_actions()
     snapshot["sentinel"] = "intruder"
     assert "sentinel" not in mc.actions, "get_all_actions must return a copy, not the live dict"
+
+
+# ── #135: top-level menus must declare Alt+letter mnemonics ────────────────
+
+def test_top_level_menus_have_mnemonic_prefixes(qapp):
+    """#135 — every top-level menu title contains a Qt ``&`` mnemonic
+    prefix so Alt+letter opens it without a mouse. Without this, UIA's
+    AccessKey property is empty for these QActions and the keyboard-
+    nav scenario (#125) cannot test mnemonic-driven menu opens.
+
+    Pin both that the titles include ``&`` AND that the mnemonics are
+    pairwise unique — Qt's QMenuBar resolves ambiguous mnemonics in
+    insertion order, which would silently shadow whichever menu came
+    second on a collision. List + Log both start with L; this test
+    guards against an unconscious regression that flips List from
+    ``Alt+L`` to ``Lo&g`` (or vice versa) and accidentally collides.
+    """
+    from PySide6.QtWidgets import QMainWindow
+
+    win = QMainWindow()
+    mc = MenuController(win)
+    mc.setup_menus()
+
+    menubar = win.menuBar()
+    titles = [a.menu().title() for a in menubar.actions() if a.menu() is not None]
+    assert titles, "no top-level menus were registered"
+
+    # Each title must contain a single ``&`` followed by a letter.
+    mnemonics: list[str] = []
+    for title in titles:
+        idx = title.find("&")
+        assert idx != -1, (
+            f"menu {title!r} has no Alt mnemonic; add a '&' before the "
+            f"intended Alt letter"
+        )
+        # Reject the ``&&`` literal-ampersand escape, which has no mnemonic.
+        assert title[idx + 1:idx + 2] != "&", (
+            f"menu {title!r} starts an escaped '&&'; intended mnemonic "
+            f"missing"
+        )
+        letter = title[idx + 1:idx + 2].upper()
+        assert letter, f"menu {title!r} has '&' at the end with no letter after"
+        mnemonics.append(letter)
+
+    duplicates = {m for m in mnemonics if mnemonics.count(m) > 1}
+    assert not duplicates, (
+        f"top-level menu mnemonics collide: {sorted(duplicates)}; "
+        f"titles={titles}"
+    )
+
+
+def test_top_level_menus_specific_mnemonic_assignment(qapp):
+    """Pin the deliberate List=Alt+L / Log=Alt+G choice so a future
+    refactor that "obviously" assigns Alt+L to Log (alphabetical) or
+    swaps the two breaks loudly — that swap would change muscle memory
+    for users who already learned the layout.
+    """
+    from PySide6.QtWidgets import QMainWindow
+
+    win = QMainWindow()
+    mc = MenuController(win)
+    mc.setup_menus()
+
+    menubar = win.menuBar()
+    title_by_first_word = {
+        a.menu().title().lstrip("&").split()[0].rstrip("…").rstrip(":")
+        .replace("&", "").lower(): a.menu().title()
+        for a in menubar.actions() if a.menu() is not None
+    }
+    # Expected: File→F, Action→A, List→L, Log→G
+    expected = {
+        "file": "&File",
+        "action": "&Action",
+        "list": "&List",
+        "log": "Lo&g",
+    }
+    for name, want in expected.items():
+        # Match by mnemonic-stripped lowercase (so the test still works
+        # if a future change adds extra title decoration like
+        # ``&File (Recent)``).
+        candidates = [t for t in title_by_first_word.values()
+                      if t.replace("&", "").lower().startswith(name)]
+        assert candidates, f"no menu starting with {name!r} found in {title_by_first_word}"
+        assert want in candidates, (
+            f"expected {want!r} for {name!r} mnemonic; got {candidates!r}"
+        )


### PR DESCRIPTION
Closes #135.

## Summary

Top-level menus had no Alt-key mnemonics — UIA \`AccessKey\` was empty for \`File\`/\`Action\`/\`List\`/\`Log\`, so Alt+F (and friends) did nothing and keyboard-only navigation through the menu bar was impossible.

## Fix

Added Qt's \`&\` mnemonic prefix to each top-level title in \`MenuController.setup_menus\`:

| Menu title | Mnemonic |
|---|---|
| \`&File\` | Alt+F |
| \`&Action\` | Alt+A |
| \`&List\` | Alt+L |
| \`Lo&g\` | Alt+G |

\`L\` is shared between List and Log; List wins \`Alt+L\` because Remove-from-List is the more frequently-used action, Log gets \`Alt+G\` as the most distinctive remaining letter.

Verified live via UIA's \`AccessKey\` property:

\`\`\`
MENU title='File'    AccessKey='Alt+F'
MENU title='Action'  AccessKey='Alt+A'
MENU title='List'    AccessKey='Alt+L'
MENU title='Log'     AccessKey='Alt+G'
\`\`\`

## Backward-compat

UIA accessible names for the menu items are **unchanged** — Qt strips the \`&\` from the accessible Name property before reporting it. So existing \`child_window(title=\"File\", control_type=\"MenuItem\")\` calls and the \`MENU_FILE = \"File\"\` constants in \`qa/scenarios/_uia.py\` keep working without changes; verified live that each menu still resolves by its plain-text name.

## Tests

Two new unit tests:

| Test | Pins |
|---|---|
| \`test_top_level_menus_have_mnemonic_prefixes\` | Every top-level menu has a \`&\` prefix; mnemonics are pairwise unique (catches the L collision) |
| \`test_top_level_menus_specific_mnemonic_assignment\` | List=Alt+L / Log=Alt+G specifically — guards against an "alphabetical" refactor that swaps the two and silently breaks user muscle memory |

## Verification

| Check | Result |
|---|---|
| \`pytest tests/\` | 610 passed (was 608 + 2 new), 89.88% coverage |
| Live: AccessKey populated for all 4 menus | ✓ |
| Live: \`child_window(title=\"File\", ...)\` still resolves | ✓ |

## Unblocks

Step 5 of #125's planned \`s26_keyboard_navigation\` scenario depends on Alt+F mnemonic working. With this fix landed, that scenario can now be built end-to-end.

## Test plan

- [ ] CI \`pytest\` job — must stay green (mnemonic test catches future regressions)
- [ ] CI \`qa-batch\` job — every existing scenario uses the menu lookups; must stay green to confirm the backward-compat claim above
- [ ] Manual: launch app, press Alt+F, Alt+A, Alt+L, Alt+G — each opens its respective menu

🤖 Generated with [Claude Code](https://claude.com/claude-code)