### PR TITLE
qa: scenarios for exit-dirty prompt (s28) + deferred bulk remove (s29)

### DIFF
--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -59,6 +59,14 @@ ALL_SCENARIOS = [
     "s25_empty_area_context_menu",
     "s26_keyboard_navigation",
     "s27_rescan_confirm",
+    # s28 — dirty-flag exit prompt. Run AFTER s27 so any test order
+    # change still puts s28 next to its closest neighbour (manifest
+    # state-mutation scenarios). Self-cleans by exiting the app with
+    # "Leave"; the next scenario relaunches.
+    "s28_exit_dirty_prompt",
+    # s29 — bulk regex remove-from-list as a deferred decision. Sister
+    # to s14 (bulk regex delete) but with the deferred-remove action.
+    "s29_remove_from_list_by_regex",
 ]
 
 

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -70,6 +70,13 @@ SCENARIO_SOURCES: dict[str, list[str] | None] = {
     "s26_keyboard_navigation":      ["qa/sandbox/near-duplicates"],
     # s27 (#142) — re-scan with pending decisions triggers confirmation prompt.
     "s27_rescan_confirm":           ["qa/sandbox/near-duplicates"],
+    # s28 — exit-dirty prompt. Runs a small scan + sets a decision to
+    # dirty the manifest; the prompt assertions follow.
+    "s28_exit_dirty_prompt":        ["qa/sandbox/near-duplicates"],
+    # s29 — bulk regex "remove from list" deferred decision. Same fixture
+    # as s14 so the regex partition (q[89]\d) keeps producing 3 matches
+    # / 2 unchanged.
+    "s29_remove_from_list_by_regex": ["qa/sandbox/near-duplicates"],
 }
 
 

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -47,6 +47,14 @@ VIEW_LANG_ENGLISH = "English"
 VIEW_LANG_ZH_TW = "繁體中文"
 LANGUAGE_CONFIRM_TITLE = "Switch language?"
 
+# Exit-dirty prompt — fired by MainWindow.closeEvent when there are
+# unsaved decisions. Title and button accessible names come from
+# translations/en.yml under the `exit.*` namespace.
+EXIT_CONFIRM_TITLE = "Unsaved Changes"
+EXIT_BTN_SAVE_LEAVE = "Save & leave"   # source has "Save && leave"; UIA strips one &
+EXIT_BTN_LEAVE = "Leave"
+EXIT_BTN_BACK = "Back"
+
 # File menu items
 FILE_SCAN_SOURCES = "Scan Sources…"
 FILE_OPEN_MANIFEST = "Open Manifest…"

--- a/qa/scenarios/s28_exit_dirty_prompt.py
+++ b/qa/scenarios/s28_exit_dirty_prompt.py
@@ -1,0 +1,195 @@
+"""Scenario 28 — closeEvent fires the 3-button "Unsaved Changes" prompt
+when the user has unsaved decisions, and Back / Leave each behave as
+labelled.
+
+Required source: ``qa/sandbox/near-duplicates`` (5 files; we set a
+single decision via the regex flow to dirty the manifest).
+
+The exit prompt is layer-3 territory because it depends on:
+  * MainWindow.closeEvent intercepting the user's close request,
+  * QMessageBox rendering with Save/Leave/Back buttons exposed via
+    UIA accessible names,
+  * the dirty-flag transitions wired across set_decision and
+    save_manifest_decisions_silent.
+
+Layer 1 covers each piece in isolation
+(``test_set_decision_marks_dirty``, ``test_silent_save_clears_dirty``,
+``test_initial_state_is_clean``); this scenario pins the
+end-to-end UX.
+
+What's verified:
+  1. Setting any decision flips the dirty flag, so closing the window
+     fires the "Unsaved Changes" QMessageBox titled exactly that.
+  2. The dialog exposes "Back" — clicking it cancels the close and
+     leaves the app running with the dirty flag intact.
+  3. A second close attempt re-fires the same dialog.
+  4. Clicking "Leave" exits the app cleanly without saving — the
+     manifest's user_decision values stay as they were already
+     auto-persisted (decisions auto-write on set, so "Leave" doesn't
+     actually lose data).
+
+What's NOT verified here (covered elsewhere):
+  * "Save & leave" → silent save → exit. Layer 1's
+    ``test_silent_save_clears_dirty`` proves the save-on-close path;
+    rather than wire a SQLite read against this scenario's manifest,
+    we trust that mechanism and exercise the more user-visible
+    dialog-routing branches here.
+"""
+from __future__ import annotations
+
+import sys
+import time
+from pathlib import Path
+
+from pywinauto.keyboard import send_keys
+
+from qa.scenarios import _uia
+
+REPO = Path(__file__).resolve().parents[2]
+
+
+def _photo_manager_visible(pid: int) -> bool:
+    """Return True if any visible top-level window of *pid* still
+    exists. Used after Leave/Save & leave to confirm the app exited."""
+    try:
+        return any(
+            t and "Photo Manager" in t
+            for _hwnd, _cls, t in _uia.list_process_windows(pid)
+        )
+    except Exception:
+        return False
+
+
+def main() -> int:
+    print("scenario: s28_exit_dirty_prompt")
+    app, win = _uia.connect_main()
+    pid = win.process_id()
+    print(f"connected: pid={pid} title={win.window_text()!r}")
+
+    # ── Setup: scan the fixture and load the manifest ──────────────────
+    print("step: scan_and_load")
+    dlg, _ = _uia.open_scan_dialog(win)
+    _, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    _uia.close_and_load_manifest(dlg)
+    _, win = _uia.connect_main()
+
+    # ── Dirty the manifest via a bulk regex decision ───────────────────
+    print("step: dirty_via_regex_delete")
+    _uia.mark_all_via_regex_standalone(
+        win, field="File Name", regex=".*", action_label="delete"
+    )
+    _, win = _uia.connect_main()
+
+    failures: list[str] = []
+
+    # ── First close attempt: prompt should appear, click Back ─────────
+    print("step: alt_f4_first_attempt")
+    _uia._focus(win)  # noqa: SLF001 — _focus is the project-internal helper
+    send_keys("%{F4}")
+
+    try:
+        exit_hwnd = _uia.wait_for_dialog(pid, _uia.EXIT_CONFIRM_TITLE, timeout=3)
+    except Exception as exc:
+        failures.append(
+            f"Exit prompt did not appear after Alt+F4 with dirty manifest: {exc!r}"
+        )
+        # Best-effort: kill the dialog if it appeared late, then close.
+        _force_close_app(win, pid)
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    exit_dlg = _uia.connect_by_handle(exit_hwnd)
+    button_titles = {
+        b.window_text() for b in exit_dlg.descendants(control_type="Button")
+    }
+    print(f"  exit_buttons={sorted(button_titles)!r}")
+    expected_buttons = {_uia.EXIT_BTN_SAVE_LEAVE, _uia.EXIT_BTN_LEAVE, _uia.EXIT_BTN_BACK}
+    missing = expected_buttons - button_titles
+    if missing:
+        failures.append(
+            f"Exit prompt missing expected buttons: {sorted(missing)!r} "
+            f"(saw {sorted(button_titles)!r})"
+        )
+
+    print("step: click_back")
+    try:
+        back_btn = exit_dlg.child_window(title=_uia.EXIT_BTN_BACK, control_type="Button")
+        back_btn.click_input()
+    except Exception as exc:
+        failures.append(f"Could not click Back button: {exc!r}")
+    time.sleep(0.5)
+
+    if not _photo_manager_visible(pid):
+        failures.append(
+            "Photo Manager window disappeared after clicking Back — Back "
+            "must cancel the close, not accept it."
+        )
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    # ── Second close attempt: prompt should fire again, click Leave ──
+    print("step: alt_f4_second_attempt")
+    _, win = _uia.connect_main()
+    _uia._focus(win)  # noqa: SLF001
+    send_keys("%{F4}")
+
+    try:
+        exit_hwnd = _uia.wait_for_dialog(pid, _uia.EXIT_CONFIRM_TITLE, timeout=3)
+    except Exception as exc:
+        failures.append(
+            f"Exit prompt did not re-appear on second close attempt: {exc!r}"
+        )
+        _force_close_app(win, pid)
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    exit_dlg = _uia.connect_by_handle(exit_hwnd)
+    print("step: click_leave")
+    try:
+        leave_btn = exit_dlg.child_window(title=_uia.EXIT_BTN_LEAVE, control_type="Button")
+        leave_btn.click_input()
+    except Exception as exc:
+        failures.append(f"Could not click Leave button: {exc!r}")
+    time.sleep(1.0)
+
+    if _photo_manager_visible(pid):
+        failures.append(
+            "Photo Manager window still visible after clicking Leave — "
+            "Leave must accept the close."
+        )
+        _force_close_app(win, pid)
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    print("scenario: s28_exit_dirty_prompt DONE")
+    return 0
+
+
+def _force_close_app(win, pid: int) -> None:
+    """Best-effort cleanup if the prompt path went sideways. Sends Esc
+    to dismiss any modal, then closes the window. Avoids leaving the
+    batch with an orphaned Photo Manager process and a visible dialog
+    that the next ``_close_window()`` can't dismiss."""
+    try:
+        send_keys("{ESC}")
+        time.sleep(0.3)
+    except Exception:
+        pass
+    try:
+        win.close()
+    except Exception:
+        pass
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s29_remove_from_list_by_regex.py
+++ b/qa/scenarios/s29_remove_from_list_by_regex.py
@@ -1,0 +1,157 @@
+"""Scenario 29 — bulk regex "remove from list" sets a deferred decision
+(no immediate removal), mirroring the bulk-delete UX.
+
+Required source: ``qa/sandbox/near-duplicates`` (5 files; we partition
+them with a regex that matches some, leaves the rest unchanged).
+
+Why this scenario exists:
+
+The bulk "remove from list" path used to be IMMEDIATE — clicking
+Apply with that action triggered a confirmation prompt and dropped
+the matched rows from the review tree right away. The user pointed
+out the asymmetry vs. delete/keep (those are set-only; remove was
+set+execute) and we changed it: bulk regex remove now writes
+``user_decision='remove_from_list'`` on each matched row and waits
+for the user to commit via Execute Action — same UX as bulk delete.
+
+Layer 1 covers the dispatch (file_operations.set_decision_by_regex
+recognises the sentinel and writes the deferred decision). This
+scenario pins the layer-3 invariants: the dialog is wired, the
+manifest gets the right column update, and the rows stay visible
+in the tree afterwards.
+
+What's verified:
+  * Action menu → Set Action by Field/Regex… → action="remove from list"
+    Apply → matched rows have user_decision='remove_from_list' in
+    SQLite; non-matched rows are unchanged.
+  * No file is actually removed from the manifest's review-set yet
+    (the user_decision is the *deferred* marker; remove_from_review
+    only fires at Execute time).
+
+What's NOT verified here (covered elsewhere):
+  * The Execute path that actually drops the rows. Layer 1's
+    ``test_on_execute_handles_remove_from_list_decision`` exercises
+    the _on_execute branch with a real SQLite manifest. A separate
+    layer-3 scenario would need a fixture, a known starting
+    decision, and Execute click — out of scope for this driver.
+  * Single-row right-click "remove from list" (immediate path) —
+    that flow has its own confirmation prompt and stays as-is.
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+from qa.scenarios import _invariants, _uia
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO / "qa" / "run-manifest.sqlite"
+FIXTURE_NAME_GLOB = "neardup_"
+
+# Same partition as s14 to keep the test signal predictable across
+# the two scenarios — q95/q88/q80 match (3 rows), q72/q65 don't.
+FIELD = "File Name"
+REGEX = r"q[89]\d"
+ACTION_LABEL = "remove from list"
+
+
+def _read_decisions() -> dict[str, str]:
+    if not MANIFEST_PATH.exists():
+        raise RuntimeError(f"manifest not found at {MANIFEST_PATH}")
+    conn = sqlite3.connect(str(MANIFEST_PATH))
+    try:
+        rows = conn.execute(
+            "SELECT source_path, user_decision FROM migration_manifest "
+            "WHERE source_path LIKE ?",
+            (f"%{FIXTURE_NAME_GLOB}%",),
+        ).fetchall()
+    finally:
+        conn.close()
+    return {Path(p).name: (d or "") for p, d in rows}
+
+
+def main() -> int:
+    print("scenario: s29_remove_from_list_by_regex")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, _ = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+    _, win = _uia.connect_main()
+
+    print("step: snapshot_pre_decisions")
+    pre = _read_decisions()
+    if not pre:
+        print("FAIL: no fixture rows found in manifest after scan")
+        return 1
+    print(f"  pre_total={len(pre)}")
+
+    print("step: apply_regex_via_menu")
+    rx = re.compile(REGEX, re.IGNORECASE)
+    expected_match = sorted(name for name in pre if rx.search(name))
+    expected_unchanged = sorted(name for name in pre if not rx.search(name))
+    print(f"  field={FIELD!r} regex={REGEX!r} action={ACTION_LABEL!r}")
+    print(f"  expected_match={expected_match}")
+    print(f"  expected_unchanged={expected_unchanged}")
+    _uia.mark_all_via_regex_standalone(
+        win, field=FIELD, regex=REGEX, action_label=ACTION_LABEL
+    )
+
+    print("step: invariant_status_bar")
+    _, win = _uia.connect_main()
+    if not _invariants.assert_status_bar_matches(win, r"Decision set", within_s=2.0):
+        print("WARN: status bar did not echo 'Decision set' (may have cleared on timeout)")
+
+    print("step: verify_decisions_after_apply")
+    post = _read_decisions()
+    if set(post) != set(pre):
+        print(f"FAIL: row set changed; pre={sorted(pre)} post={sorted(post)}")
+        return 1
+
+    failures: list[str] = []
+    # Matched rows: user_decision must be the deferred marker. NOT
+    # 'removed' — that's the value remove_from_review writes at Execute
+    # time, which this scenario deliberately does not exercise.
+    for name in expected_match:
+        if post[name] != "remove_from_list":
+            failures.append(
+                f"{name}: expected 'remove_from_list' decision, got {post[name]!r}"
+            )
+    for name in expected_unchanged:
+        if post[name] != pre[name]:
+            failures.append(
+                f"{name}: expected unchanged ({pre[name]!r}), got {post[name]!r}"
+            )
+
+    matched_rows = sum(
+        1 for name in expected_match if post[name] == "remove_from_list"
+    )
+    unchanged_rows = sum(
+        1 for name in expected_unchanged if post[name] == pre[name]
+    )
+    print(f"  matched_rows={matched_rows} expected={len(expected_match)}")
+    print(f"  unchanged_rows={unchanged_rows} expected={len(expected_unchanged)}")
+    for name in sorted(post):
+        print(f"  row: name={name} pre={pre[name]!r} post={post[name]!r}")
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    print("scenario: s29_remove_from_list_by_regex DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
> **Stacked on #158** (remove-from-list redesign + dirty-flag exit prompt) — base branch is `feature/remove-from-list-redesign`. Merge after #158 lands.

## Summary

Layer-3 coverage for the two UX changes shipped in #158.

### s28_exit_dirty_prompt
- Drives: scan + load → bulk regex sets a decision (dirties the manifest) → Alt+F4 → asserts the 'Unsaved Changes' QMessageBox appears with `{Save & leave, Leave, Back}` buttons → clicks Back, verifies app stays → second Alt+F4 → clicks Leave, verifies app exits.
- Catches: `closeEvent` regression where the prompt fails to fire on dirty state, button-label drift between `en.yml` and the dialog, Back not actually cancelling close.
- The 'Save & leave' silent-save path is layer-1 covered by `test_silent_save_clears_dirty`; this scenario doesn't re-verify it to keep the run focused.

### s29_remove_from_list_by_regex
- Sister to s14 (bulk regex delete) but with `action='remove from list'`.
- Same fixture (`qa/sandbox/near-duplicates`), same regex (`q[89]\d`) → 3 matches / 2 unchanged. Verifies post-Apply rows have `user_decision='remove_from_list'` (deferred) — **NOT** `'removed'` (the post-Execute value, deliberately out of scope).
- Catches: the deferred-decision wiring regressing back to immediate removal, dropdown action label drift, the regex flow accidentally taking the single-row right-click's confirm path.

### Wiring
- `_uia.py`: `EXIT_CONFIRM_TITLE` + button accessible names. The `test_uia_label_coupling` layer-1 test scans these against `translations/*.yml` at PR time.
- `_batch.py` + `_config.py`: register both scenarios.

## Test plan

- [x] Layer 1 (`pytest`): 652 tests still green, 89.78% global coverage, all 37 files clear the 70% per-file floor
- [ ] Layer 3: `python -m qa.scenarios._batch s28_exit_dirty_prompt s29_remove_from_list_by_regex`
- [ ] Full QA batch: `python -m qa.scenarios._batch` (catches any cross-scenario interaction with the new dirty-flag clean-up step)

🤖 Generated with [Claude Code](https://claude.com/claude-code)