### PR TITLE
docs: sync README + testing.md with PRs #157–#160

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,9 +156,20 @@ The tree shows all files loaded from the manifest.
 
 **Setting decisions:**
 
-- *Per file*: right-click a file → **Set Action → delete** or **keep**.
+- *Per file*: right-click a file → **Set Action → delete** / **keep** /
+  **remove from list**.
 - *By highlight*: click or multi-select rows in the tree, then
-  **Action › Set Action to Activated Files › delete** (or **keep**).
+  **Action › Set Action to Activated Files › delete** (or **keep** /
+  **remove from list**).
+- *In bulk*: **Action › Set Action by Field/Regex…** — pick a column,
+  type a regex, choose an action (`delete`, `keep`, or
+  `remove from list`). The "remove from list" action is a deferred
+  decision: matched rows are flagged and dropped on save, no files are
+  moved or deleted.
+
+If you close the app with unsaved decisions a prompt appears with
+**Save & leave** / **Leave** / **Back**, so you don't lose work
+accidentally.
 
 ### Step 3 — Save decisions
 
@@ -345,6 +356,7 @@ photo-manager/
 │   │   ├── media_utils.py         # Media type helpers for the views layer
 │   │   ├── components/
 │   │   │   ├── menu_controller.py      # Menu creation + "Set Action" submenu
+│   │   │   ├── status_messages.py      # Centralized status-bar copy formatter
 │   │   │   └── tree_controller.py      # Tree view interactions
 │   │   ├── handlers/
 │   │   │   ├── file_operations.py      # set_decision, execute_action
@@ -375,6 +387,7 @@ photo-manager/
 │   ├── manifest_repository.py   # load/save/batch_update_decisions; mark_executed()
 │   ├── delete_service.py         # Recycle-bin deletion + audit CSV logging
 │   ├── image_service.py          # Thumbnail loading; disk + memory LRU cache
+│   ├── i18n.py                   # YAML translator catalog + t() lookup helper
 │   ├── logging.py                # loguru configuration and file rotation
 │   ├── settings.py               # settings.json loader
 │   └── utils.py                  # Shared utilities
@@ -382,9 +395,14 @@ photo-manager/
 ├── scripts/
 │   └── make_qa_images.py    # Generates controlled near-dup test images for QA
 │
+├── translations/            # Locale catalogs — single source of truth for UI strings
+│   ├── en.yml
+│   ├── zh_TW.yml
+│   └── README.md
+│
 ├── settings.json            # User configuration (source paths, thumbnail cache, …)
 │
-└── tests/                   # 391 tests — scanner, infra, viewmodel, GUI handlers
+└── tests/                   # 650+ tests — scanner, infra, viewmodel, GUI handlers
     ├── conftest.py              # Shared fixtures (qapp)
     ├── test_dedup.py
     ├── test_hasher.py
@@ -398,13 +416,20 @@ photo-manager/
     ├── test_scanner_manifest.py
     ├── test_scanner_media.py    # magic-byte detection, Takeout filename parsing
     ├── test_main_vm.py
-    ├── test_file_operations.py  # set_decision, execute_action
+    ├── test_file_operations.py  # set_decision, execute_action, regex remove-from-list
     ├── test_sort_service.py
     ├── test_execute_action_dialog.py
     ├── test_context_menu.py
     ├── test_manifest_load_worker.py
     ├── test_scan_dialog.py      # _auto_label, _SourceListWidget, ScanDialog settings
-    └── test_select_dialog.py    # initial_field, Set Action signal, settable decision options
+    ├── test_scan_worker.py
+    ├── test_select_dialog.py    # initial_field, Set Action signal, settable decision options
+    ├── test_status_messages.py  # Pins status-bar copy so qa-explore regexes stay coherent
+    ├── test_media_utils.py
+    ├── test_tree_model_builder.py
+    ├── test_menu_controller_manifest_actions.py  # Language picker exclusivity, action toggle lifecycle
+    ├── test_i18n.py             # Catalog parity (en ↔ zh_TW), fallback, format-placeholder safety
+    └── test_uia_label_coupling.py  # Lint: every _uia.py constant exists in app/*.py or translations/*.yml
 ```
 
 ---
@@ -442,13 +467,15 @@ automatically. List order determines dedup priority (index 0 = highest priority)
 ## Languages
 
 The UI ships in **English** (`en`) and **Traditional Chinese** (`zh_TW`).
-Switch via **View › Language**; the change requires an app restart.
-The chosen locale is persisted in `settings.json` under `ui.locale`.
+Switch via **View › Language**; after a Yes/No confirmation the main
+window rebuilds in place — no app restart needed. The chosen locale is
+persisted in `settings.json` under `ui.locale`.
 
 To add another language, copy `translations/en.yml` to
-`translations/<code>.yml`, translate the values, and restart — the new
-locale appears automatically in the picker. Full translator workflow
-in [`docs/i18n.md`](docs/i18n.md).
+`translations/<code>.yml`, translate the values, and restart once —
+the new locale then appears automatically in the picker for the rest
+of the session and on every later launch. Full translator workflow in
+[`docs/i18n.md`](docs/i18n.md).
 
 ---
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -89,7 +89,7 @@ calls out what would be uncaught even with a green CI.
 |---|---|---|---|---|
 | `infrastructure/manifest_repository.py` | 99% | — | every scenario | very low |
 | `infrastructure/settings.py` | 100% | — | every scenario | none |
-| `infrastructure/i18n.py` | 90% | — | s22 (language switch + restart prompt + locale persistence) | low — uncovered branches are defensive `except (OSError, yaml.YAMLError)` paths in `available_locales()` and a couple of guards. The `test_zh_tw_has_every_key_present_in_english` test pins parity between the en and zh_TW catalogs at PR time, so a missing translation never ships silently. |
+| `infrastructure/i18n.py` | 93% | — | s22 (live language switch — Yes-confirm, in-place MainWindow rebuild, locale persistence in settings.json) | low — uncovered branches are defensive `except (OSError, yaml.YAMLError)` paths in `available_locales()` and a couple of guards. The `test_zh_tw_has_every_key_present_in_english` test pins parity between the en and zh_TW catalogs at PR time, so a missing translation never ships silently. |
 | `infrastructure/delete_service.py` | 93% | spot-add only | s13 (planned per #80) covers happy-path real send2trash | recycle-bin behavior on networked drives untested; error paths exercised via mocks. Spot-add a layer-2 test for specific bug cases (locked file, network drive, permission denied). |
 | `infrastructure/utils.py` | 89% | spot-add only | s08 (real EXIF on real fixtures) | DNG fallback only mocked. If a real DNG ever returns metadata in a shape we don't anticipate, that's the moment to add a layer-2 spot-test pinning the parse. |
 | `infrastructure/image_service.py` | **omit** | depends on running `QApplication` for image decode | s01, s05 | full responsibility on layer 3 |
@@ -112,7 +112,9 @@ calls out what would be uncaught even with a green CI.
 | `app/views/workers/scan_worker.py` | 91% | every scan scenario | minor — cancellation timing branch hard to test deterministically |
 | `app/views/handlers/file_operations.py` | 81% | s01 + every scenario that loads a manifest, plus s12 for Save Manifest Decisions end-to-end | uncovered 19% is QFileDialog interaction (file picker for open manifest) — Save Manifest is now driven by s12, with the WAL-checkpoint branch (#91) covered by both layer-1 unit test and the s12 layer-3 driver |
 | `app/views/handlers/context_menu.py` | 88% | s01 (menu probes) | low — `_open_folder` Windows + non-Windows + fallback paths covered; remaining 12% is Protocol stub bodies |
-| `app/views/dialogs/scan_dialog.py` | 84% | every scenario opens it | uncovered 16% is QFileDialog browse interaction + a few worker-signal branches |
+| `app/views/dialogs/scan_dialog.py` | 90% | every scenario opens it; s17 (full source-list operations) | uncovered 10% is QFileDialog browse interaction + a few worker-signal branches |
+| `app/views/components/menu_controller.py` | 89% | s01, s18, s21, s22, s28 | uncovered 11% is fallback branches in the language picker (no available locales) and a defensive guard for missing manifest-actions; the View → Language exclusivity + Yes/No confirm + dirty-flag exit prompt all unit-tested in `test_menu_controller_manifest_actions.py` |
+| `app/views/components/status_messages.py` | 95% | indirectly via every scenario that asserts on status-bar copy (s01, s12, s13, s14, s20, s21, s27, s29) | low — pure formatter; `test_status_messages.py` pins the output shape so qa-explore regexes stay coherent |
 | `app/views/dialogs/execute_action_dialog.py` | 83% | s13 (planned, will exercise real send2trash through the GUI) | uncovered 17% is `_on_tree_context_menu` + the actual destructive `_on_execute` flow — qa-explore s13 will cover the happy path; spot-add a layer-2 test only if a destructive-flow bug surfaces that's hard to reproduce via the GUI |
 | `app/views/dialogs/select_dialog.py` | 94% | s01 (action menu) | low |
 


### PR DESCRIPTION
## Summary

Resync of project docs after the recent cluster of merged PRs:
[#157 i18n](https://github.com/jackal998/photo-manager/pull/157),
[#158 bulk-regex remove + dirty-flag exit](https://github.com/jackal998/photo-manager/pull/158),
[#159 qa scenarios s28+s29](https://github.com/jackal998/photo-manager/pull/159),
[#160 scan-dialog two-column layout](https://github.com/jackal998/photo-manager/pull/160).

### `README.md`

- **Setting decisions** block: now lists `remove from list` alongside `delete` / `keep`, and documents the bulk-regex variant added in #158.
- New one-liner on the unsaved-decisions exit prompt — uses the actual button labels (Save & leave / Leave / Back).
- Project structure tree picks up the three additions: `app/views/components/status_messages.py` (#158), `infrastructure/i18n.py` (#157), top-level `translations/` (#157).
- Test count `391 tests` → `650+ tests`; seven new test files listed.
- **Languages** section: previously claimed the language switch "requires an app restart" — incorrect after #157. Now describes the Yes-confirm + in-place MainWindow rebuild, and clarifies that adding a *new locale file* still needs one relaunch before it appears in the picker.

### `docs/testing.md`

- `infrastructure/i18n.py` row: 90% → 93%; layer-3 cell rewritten to describe the live switch instead of the obsolete restart prompt.
- `app/views/dialogs/scan_dialog.py` row: 84% → 90% (past the 5pp maintenance threshold; lifted by the tests that landed with #160).
- Two new rows added for surfaces that had grown enough to warrant entries: `app/views/components/menu_controller.py` (89%) and `app/views/components/status_messages.py` (95%).

### What did NOT change

- `pyproject.toml` — Python version unchanged (py311); the `[tool.coverage.run] omit` list is still current and each entry already carries its layer pointer.
- `CLAUDE.md` — testing policy hasn't moved.

## Test plan

- [x] `pytest`: 652 passed, 2 skipped, 89.82% coverage (unchanged from before the doc edits — these are docs-only changes)
- [x] Verified file references (`infrastructure/i18n.py`, `status_messages.py`, `translations/`) all exist in the repo
- [x] Verified the dirty-flag exit prompt button labels match what s28 reports (`Save & leave / Leave / Back`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)