### PR TITLE
feat(regex-dialog): Phase A — live preview, validation, right-click parity

### DIFF
--- a/app/views/dialogs/execute_action_dialog.py
+++ b/app/views/dialogs/execute_action_dialog.py
@@ -198,6 +198,12 @@ class ExecuteActionDialog(QDialog):
             act.triggered.connect(
                 lambda _checked=False, _v=value, _p=path: self._set_decision(_p, _v)
             )
+        # Right-click parity with the main file list — the regex dialog
+        # was previously only reachable via the dedicated toolbar button.
+        # Discoverability matters more than menu purity; add it here too.
+        menu.addSeparator()
+        regex_act = menu.addAction(t("execute_dialog.set_action_by_regex_menu"))
+        regex_act.triggered.connect(self._show_select_dialog)
         menu.exec(self._tree.viewport().mapToGlobal(pos))
 
     def _set_decision(self, path: str, decision: str) -> None:
@@ -262,11 +268,16 @@ class ExecuteActionDialog(QDialog):
 
     def _show_select_dialog(self) -> None:
         from app.views.dialogs.select_dialog import ActionDialog
+        from app.views.handlers.file_operations import build_match_fn
 
         # Internal English keys; ActionDialog displays localized labels but
         # emits the English name back via setActionRequested.
         fields = ["Action", "File Name", "Folder", "Size (Bytes)", "Creation Date", "Shot Date"]
-        dlg = ActionDialog(fields=fields, parent=self)
+        # Build the live-preview match_fn from this dialog's groups —
+        # which alias the main window's vm.groups (see _remove_from_list_paths
+        # docstring), so both surfaces preview against the same data.
+        match_fn = build_match_fn(self._groups) if self._groups else None
+        dlg = ActionDialog(fields=fields, parent=self, match_fn=match_fn)
         dlg.setActionRequested.connect(self._set_decision_by_regex)
         dlg.exec()
 

--- a/app/views/dialogs/select_dialog.py
+++ b/app/views/dialogs/select_dialog.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
-from PySide6.QtCore import Qt, Signal
+import re
+from typing import Callable
+
+from PySide6.QtCore import Qt, QTimer, Signal
 from PySide6.QtWidgets import (
     QComboBox,
     QDialog,
     QHBoxLayout,
     QLabel,
     QLineEdit,
+    QListWidget,
     QPushButton,
+    QSplitter,
     QVBoxLayout,
+    QWidget,
 )
 
 from app.views.constants import settable_decisions
@@ -31,6 +37,13 @@ _FIELD_LABEL_KEYS: dict[str, str] = {
     "Shot Date":     "column.shot_date",
 }
 
+# Type alias for the live-preview match function. Callers (DialogHandler
+# from MainWindow, ExecuteActionDialog inline) build this via
+# `app.views.handlers.file_operations.build_match_fn` and pass it in.
+# Returns (matched_count, total_count, sample_basenames). Sample list is
+# bounded by build_match_fn's sample_cap; matched count is the full total.
+MatchFn = Callable[[str, str], tuple[int, int, list[str]]]
+
 
 def _field_display(name: str) -> str:
     """Return the localized label for an internal field name."""
@@ -44,6 +57,13 @@ class ActionDialog(QDialog):
     Signals:
         setActionRequested(str, str, str): Emitted when user clicks Apply
             (field, regex, action_value).
+
+    When a `match_fn` is supplied the dialog grows a right-hand preview
+    pane that updates live (debounced 150 ms) so the user can see how
+    many rows will be affected before clicking Apply, plus an inline ✓/✗
+    validator that surfaces `re.error` immediately. With `match_fn=None`
+    the dialog falls back to the original flat layout — keeps existing
+    callers, tests, and QA paths working unchanged.
     """
 
     setActionRequested = Signal(str, str, str)  # field, regex, action_value
@@ -54,6 +74,7 @@ class ActionDialog(QDialog):
         parent=None,
         row_values: dict[str, str] | None = None,
         initial_field: str | None = None,
+        match_fn: MatchFn | None = None,
     ) -> None:
         super().__init__(parent)
         self.setWindowTitle(t("action_dialog.title"))
@@ -64,34 +85,71 @@ class ActionDialog(QDialog):
         self.setWindowModality(Qt.ApplicationModal)
         self._fields = list(fields)
         self._row_values = dict(row_values or {})
+        self._match_fn = match_fn
+        self._sample_cap = 50  # mirrors build_match_fn default
 
-        root = QVBoxLayout(self)
+        # Build the per-field combo box, regex line edit, action combo, and
+        # buttons. They live in this `left_layout` regardless of whether
+        # the preview pane is constructed — the preview pane just sits
+        # next to them when present.
+        left_widget = QWidget()
+        left_layout = QVBoxLayout(left_widget)
+        left_layout.setContentsMargins(0, 0, 0, 0)
 
+        # ── Field row ──────────────────────────────────────────────────────
         row = QHBoxLayout()
         row.addWidget(QLabel(t("action_dialog.field_label")))
         self.combo = QComboBox()
+        self.combo.setObjectName("regexFieldCombo")
         # Display localized label; carry the English internal name as
         # itemData so currentField() always returns the lookup key.
         for fname in self._fields:
             self.combo.addItem(_field_display(fname), userData=fname)
         row.addWidget(self.combo)
-        root.addLayout(row)
+        left_layout.addLayout(row)
 
+        # ── Regex row + ✓/✗ icon + match counter ───────────────────────────
         row2 = QHBoxLayout()
         row2.addWidget(QLabel(t("action_dialog.regex_label")))
         self.regex = QLineEdit()
+        self.regex.setObjectName("regexLineEdit")
         self.regex.setPlaceholderText(t("action_dialog.regex_placeholder"))
         row2.addWidget(self.regex)
-        root.addLayout(row2)
 
+        self._validation_icon = QLabel("")
+        self._validation_icon.setObjectName("regexValidationIcon")
+        self._validation_icon.setFixedWidth(16)
+        row2.addWidget(self._validation_icon)
+
+        self._match_counter = QLabel("")
+        self._match_counter.setObjectName("regexMatchCounter")
+        # Hidden when match_fn is None — no records to count against.
+        if self._match_fn is None:
+            self._match_counter.hide()
+        row2.addWidget(self._match_counter)
+        left_layout.addLayout(row2)
+
+        # Friendly error string sits directly under the regex row, hidden
+        # when the regex compiles. Coloring the label red is enough; we
+        # don't restyle the QLineEdit border (focus-ring fights with the
+        # native Windows style on PySide6).
+        self._validation_error = QLabel("")
+        self._validation_error.setObjectName("regexValidationError")
+        self._validation_error.setStyleSheet("color: #d62728;")
+        self._validation_error.setWordWrap(True)
+        self._validation_error.hide()
+        left_layout.addWidget(self._validation_error)
+
+        # ── Tips ───────────────────────────────────────────────────────────
         tips = QLabel(t("action_dialog.regex_tips"))
         tips.setWordWrap(True)
-        root.addWidget(tips)
+        left_layout.addWidget(tips)
 
         # ── Set Action ─────────────────────────────────────────────────────
         action_row = QHBoxLayout()
         action_row.addWidget(QLabel(t("action_dialog.set_action_label")))
         self._action_combo = QComboBox()
+        self._action_combo.setObjectName("regexActionCombo")
         # include_remove=True surfaces "remove from list" alongside the
         # decision options. The receiving handler routes the sentinel
         # value to the remove-from-review backend instead of the
@@ -101,16 +159,37 @@ class ActionDialog(QDialog):
             self._action_combo.addItem(label)
         action_row.addWidget(self._action_combo)
         self._btn_set_action = QPushButton(t("action_dialog.apply_button"))
+        self._btn_set_action.setObjectName("regexApplyButton")
         action_row.addWidget(self._btn_set_action)
         action_row.addStretch(1)
-        root.addLayout(action_row)
+        left_layout.addLayout(action_row)
 
         # ── Close ──────────────────────────────────────────────────────────
         close_row = QHBoxLayout()
         self.btn_close = QPushButton(t("action_dialog.close_button"))
         close_row.addStretch(1)
         close_row.addWidget(self.btn_close)
-        root.addLayout(close_row)
+        left_layout.addLayout(close_row)
+
+        # ── Compose root layout ────────────────────────────────────────────
+        # Two shapes: with preview (QSplitter holding left + right panes)
+        # and without (flat layout — left widget is the whole dialog body).
+        # Tests and QA scenarios that don't pass match_fn see the original
+        # shape, so their UIA paths and findChild lookups stay valid.
+        root = QVBoxLayout(self)
+        if self._match_fn is not None:
+            splitter = QSplitter(Qt.Orientation.Horizontal)
+            splitter.addWidget(left_widget)
+            splitter.addWidget(self._build_preview_pane())
+            splitter.setSizes([380, 380])
+            root.addWidget(splitter)
+            self.setMinimumSize(750, 450)
+            self.resize(820, 480)
+        else:
+            root.addWidget(left_widget)
+            # Strip nested-widget margin so the unwrapped form looks the
+            # same as the original flat dialog.
+            left_layout.setContentsMargins(11, 11, 11, 11)
 
         self.btn_close.clicked.connect(self.accept)
         self._btn_set_action.clicked.connect(self._emit_set_action)
@@ -120,7 +199,132 @@ class ActionDialog(QDialog):
         else:
             self._set_default_field("File Name")
         self.combo.currentIndexChanged.connect(self._on_field_changed)
+
+        # Live validation runs synchronously — `re.compile` is microseconds.
+        # Preview runs through a debounce timer so we don't iterate the
+        # full record set on every keystroke.
+        self.regex.textChanged.connect(self._validate_regex)
+        if self._match_fn is not None:
+            self._preview_timer = QTimer(self)
+            self._preview_timer.setSingleShot(True)
+            self._preview_timer.setInterval(150)
+            self._preview_timer.timeout.connect(self._refresh_preview)
+            self.regex.textChanged.connect(self._preview_timer.start)
+            self.combo.currentIndexChanged.connect(self._preview_timer.start)
+
         self._apply_exact_regex_for_current_field()
+        # Apply may have set/cleared the regex synthetically; run an
+        # initial validation pass so the icon/counter are coherent before
+        # the user types anything.
+        self._validate_regex()
+        if self._match_fn is not None:
+            self._refresh_preview()
+
+    # ── Preview pane (only built when match_fn is supplied) ────────────────
+
+    def _build_preview_pane(self) -> QWidget:
+        right_widget = QWidget()
+        right_layout = QVBoxLayout(right_widget)
+        right_layout.setContentsMargins(0, 0, 0, 0)
+
+        right_layout.addWidget(QLabel(t("action_dialog.preview_label")))
+
+        self._preview_list = QListWidget()
+        self._preview_list.setObjectName("regexPreviewList")
+        right_layout.addWidget(self._preview_list, stretch=1)
+
+        self._preview_truncated = QLabel("")
+        self._preview_truncated.setObjectName("regexPreviewTruncated")
+        self._preview_truncated.setStyleSheet("color: #555; font-style: italic;")
+        self._preview_truncated.hide()
+        right_layout.addWidget(self._preview_truncated)
+
+        return right_widget
+
+    # ── Validation (synchronous) ───────────────────────────────────────────
+
+    def _validate_regex(self) -> None:
+        """Update ✓/✗ icon and the friendly error label.
+
+        Empty regex → no icon, no error (neutral state). Valid regex →
+        green ✓, error hidden. Invalid regex → red ✗, error shown with
+        the `re.error` message. The match counter falls back to an em
+        dash while the regex is invalid.
+        """
+        pattern = self.regex.text()
+        if not pattern:
+            self._validation_icon.setText("")
+            self._validation_icon.setStyleSheet("")
+            self._validation_icon.setAccessibleName("")
+            self._validation_error.hide()
+            return
+
+        try:
+            re.compile(pattern)
+        except re.error as exc:
+            self._validation_icon.setText("✗")
+            self._validation_icon.setStyleSheet("color: #d62728; font-weight: bold;")
+            self._validation_icon.setAccessibleName(
+                f"Regex invalid: {exc}"
+            )
+            self._validation_error.setText(
+                t("action_dialog.invalid_regex").format(error=str(exc))
+            )
+            self._validation_error.show()
+            if self._match_fn is not None:
+                self._match_counter.setText(
+                    t("action_dialog.match_counter_invalid")
+                )
+            return
+
+        self._validation_icon.setText("✓")
+        self._validation_icon.setStyleSheet("color: #2ca02c; font-weight: bold;")
+        self._validation_icon.setAccessibleName("Regex valid")
+        self._validation_error.hide()
+
+    # ── Preview (debounced) ────────────────────────────────────────────────
+
+    def _refresh_preview(self) -> None:
+        """Pull live counts + sample names from the injected match_fn."""
+        if self._match_fn is None:
+            return
+
+        pattern = self.regex.text()
+        # Only run the closure for syntactically-valid patterns; the
+        # validator already updated the counter to "—" for invalid ones.
+        if pattern:
+            try:
+                re.compile(pattern)
+            except re.error:
+                self._preview_list.clear()
+                self._preview_truncated.hide()
+                return
+
+        field = self._current_field()
+        matched, total, samples = self._match_fn(field, pattern)
+
+        self._match_counter.setText(
+            t("action_dialog.match_counter").format(matched=matched, total=total)
+        )
+
+        self._preview_list.clear()
+        if matched == 0:
+            self._preview_list.addItem(t("action_dialog.preview_empty"))
+        else:
+            for name in samples:
+                self._preview_list.addItem(name)
+
+        if matched > len(samples):
+            self._preview_truncated.setText(
+                t("action_dialog.preview_truncated").format(
+                    n=matched - len(samples)
+                )
+            )
+            self._preview_truncated.show()
+        else:
+            self._preview_truncated.hide()
+
+    # ── Existing API ───────────────────────────────────────────────────────
 
     def _current_field(self) -> str:
         """Return the active English field name (lookup key, not the displayed label)."""
@@ -149,8 +353,7 @@ class ActionDialog(QDialog):
         field = self._current_field()
         value = self._row_values.get(field, "")
         if value:
-            import re as _re
-            self.regex.setText(f"^{_re.escape(value)}$")
+            self.regex.setText(f"^{re.escape(value)}$")
         else:
             self.regex.clear()
 

--- a/app/views/handlers/context_menu.py
+++ b/app/views/handlers/context_menu.py
@@ -143,7 +143,16 @@ class ContextMenuHandler:
                     self.handlers.set_decision(_items, _v)
             )
 
+        # Right-click parity with the single-selection branch — the regex
+        # dialog is the bulk power tool, so it has to be reachable from
+        # multi-select right-click too. clicked_col=None falls back to
+        # the dialog's "File Name" default.
         menu.addSeparator()
+        action_dialog_action = menu.addAction(t("context_menu.set_action_by_regex"))
+        action_dialog_action.triggered.connect(
+            lambda: self.handlers.show_action_dialog(clicked_col=None)
+        )
+
         remove_action = menu.addAction(t("context_menu.remove_from_list"))
         remove_action.triggered.connect(
             lambda: self.handlers.remove_items_from_list(selected_items)

--- a/app/views/handlers/dialog_handler.py
+++ b/app/views/handlers/dialog_handler.py
@@ -61,10 +61,16 @@ class DialogHandler:
         parent_widget: QObject,
         tree_data_provider: TreeDataProvider,
         action_handler: Callable[[str, str, str], None] | None = None,
+        records_provider: Callable[[], list] | None = None,
     ) -> None:
         self.parent = parent_widget
         self.tree_provider = tree_data_provider
         self.action_handler = action_handler
+        # Optional callable returning the loaded PhotoGroups so the
+        # ActionDialog can build its live preview. We resolve it lazily
+        # at dialog-open time so the latest manifest state is reflected
+        # without re-wiring on every load.
+        self.records_provider = records_provider
 
     def show_action_dialog(self, clicked_col: int | None = None) -> None:
         """Show the Set Action by Field/Regex dialog."""
@@ -91,9 +97,20 @@ class DialogHandler:
 
         initial_field = _COL_TO_FIELD.get(clicked_col) if clicked_col is not None else None
         row_values = self._get_highlighted_row_values()
+        match_fn = None
+        if self.records_provider is not None:
+            from app.views.handlers.file_operations import build_match_fn
+
+            try:
+                groups = self.records_provider() or []
+            except Exception:
+                groups = []
+            if groups:
+                match_fn = build_match_fn(groups)
         dlg = ActionDialog(
             fields=fields, parent=self.parent,
             row_values=row_values, initial_field=initial_field,
+            match_fn=match_fn,
         )
 
         if self.action_handler is not None:

--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import Any, Protocol
+import re
+from typing import Any, Callable, Protocol
 
 from PySide6.QtCore import QObject
 from PySide6.QtWidgets import QDialog, QFileDialog, QMessageBox
@@ -42,6 +43,59 @@ def _get_record_field(rec: Any, field: str) -> str | None:
     if field == "File Name":
         return Path(str(val)).name
     return str(val)
+
+
+def build_match_fn(
+    groups: list, sample_cap: int = 50
+) -> Callable[[str, str], tuple[int, int, list[str]]]:
+    """Return a closure that counts regex matches across the records.
+
+    The closure returned by this function powers the ActionDialog's live
+    preview pane. Calling it with a (field, pattern) pair returns a tuple
+    (matched, total, sample_basenames) where:
+      - matched: total number of records whose `field` value matches `pattern`
+        (case-insensitive) under the same `_FIELD_TO_ATTR` map that
+        `set_decision_by_regex` will use, so the preview is byte-for-byte
+        consistent with what Apply will affect.
+      - total: total number of records iterated. Records whose field is
+        unavailable (no `_FIELD_TO_ATTR` entry, or the attr is None) count
+        toward `total` but cannot match.
+      - sample_basenames: at most `sample_cap` basenames of matching files,
+        for display in the preview list. Iteration continues past the cap
+        so the matched count is always accurate.
+
+    On `re.error` returns (0, total, []) — the dialog handles invalid-regex
+    feedback through its own validation row, so the closure stays silent.
+    """
+
+    def _match(field: str, pattern: str) -> tuple[int, int, list[str]]:
+        from pathlib import Path
+
+        try:
+            rx = re.compile(pattern, re.IGNORECASE)
+        except re.error:
+            total = sum(len(g.items) for g in groups)
+            return (0, total, [])
+
+        matched = 0
+        total = 0
+        samples: list[str] = []
+        for grp in groups:
+            for rec in grp.items:
+                total += 1
+                value = _get_record_field(rec, field)
+                if value is None:
+                    continue
+                if rx.search(value):
+                    matched += 1
+                    if len(samples) < sample_cap:
+                        path_val = getattr(rec, "file_path", None)
+                        samples.append(
+                            Path(str(path_val)).name if path_val else value
+                        )
+        return (matched, total, samples)
+
+    return _match
 
 
 class UIUpdateCallback(Protocol):

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -111,11 +111,15 @@ class MainWindow(QMainWindow):
         # Tree data provider for dialog handler
         self.tree_data_provider = TreeDataProviderImpl(self.tree, self.tree_controller)
 
-        # Initialize dialog handler
+        # Initialize dialog handler. records_provider lets the regex
+        # dialog build its live-preview match function from the current
+        # manifest state at open time (no caching — picks up any
+        # in-memory changes since the last open).
         self.dialog_handler = DialogHandler(
             parent_widget=self,
             tree_data_provider=self.tree_data_provider,
             action_handler=self._apply_action_by_regex,
+            records_provider=lambda: self._vm.groups,
         )
 
         # Action handlers for context menu

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -67,6 +67,10 @@ ALL_SCENARIOS = [
     # s29 — bulk regex remove-from-list as a deferred decision. Sister
     # to s14 (bulk regex delete) but with the deferred-remove action.
     "s29_remove_from_list_by_regex",
+    # s30 — Phase A regex-dialog UX upgrade: right-click parity in
+    # Execute Action dialog opens the same enhanced ActionDialog.
+    # Sister to s14 (menu route) and s13 (toolbar-button route).
+    "s30_execute_dialog_regex_right_click",
 ]
 
 

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -77,6 +77,10 @@ SCENARIO_SOURCES: dict[str, list[str] | None] = {
     # as s14 so the regex partition (q[89]\d) keeps producing 3 matches
     # / 2 unchanged.
     "s29_remove_from_list_by_regex": ["qa/sandbox/near-duplicates"],
+    # s30 — Phase A regex-dialog UX upgrade: right-click parity in
+    # Execute Action dialog. Same fixture and regex partition as s14
+    # so the verification flow can mirror it.
+    "s30_execute_dialog_regex_right_click": ["qa/sandbox/near-duplicates"],
 }
 
 

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -1313,15 +1313,22 @@ def open_execute_action_dialog(win: UIAWrapper) -> tuple[UIAWrapper, int]:
 
 def _drive_action_dialog_form(
     action_dlg: UIAWrapper, field: str, regex: str, action_label: str
-) -> None:
+) -> str | None:
     """Fill the Set Action by Field/Regex dialog and submit.
 
     Shared by both entry points (menu-bar standalone and Execute-dialog
     inner). Caller must have already focused `action_dlg`.
 
-    Steps: select Field combo → SetValue regex → select Action combo →
-    Apply → Close. Regex uses UIA ValuePattern to bypass IME interception
-    of Latin keystrokes under bopomofo input.
+    Steps: select Field combo → SetValue regex → wait for live-preview
+    debounce → capture match-counter text → select Action combo → Apply
+    → Close. Regex uses UIA ValuePattern to bypass IME interception of
+    Latin keystrokes under bopomofo input.
+
+    Returns the live-preview match-counter text (e.g. "3 of 5 match")
+    captured AFTER the 150 ms debounce window — or ``None`` if the
+    dialog has no preview pane (legacy callers that opened ActionDialog
+    without ``match_fn``). Scenarios can assert on this to verify the
+    preview is reachable and reflects the typed pattern.
     """
     # Two ComboBoxes in this dialog: Field combo (top) and Set Action combo
     # (bottom). Order is deterministic — find them by position (top-most first).
@@ -1355,7 +1362,27 @@ def _drive_action_dialog_form(
         raise RuntimeError("action dialog: no standalone Edit (regex line) found")
     regex_edit = standalone_edits[0]
     regex_edit.iface_value.SetValue(regex)
-    time.sleep(0.1)
+
+    # Live-preview debounce in ActionDialog is 150 ms; sleep past it
+    # before reading the counter so we never race against the timer.
+    time.sleep(0.3)
+
+    # Find the live-preview match counter. pywinauto's auto_id is the
+    # full QObject hierarchy path ending in objectName, so we suffix-match
+    # rather than exact-match — keeps the lookup stable if a wrapper
+    # widget gets inserted later.
+    counter_text: str | None = None
+    try:
+        for d in action_dlg.descendants(control_type="Text"):
+            try:
+                aid = d.element_info.automation_id or ""
+            except Exception:
+                aid = ""
+            if aid.endswith(".regexMatchCounter"):
+                counter_text = d.window_text() or None
+                break
+    except Exception:
+        counter_text = None
 
     action_combo.select(action_label)
     time.sleep(0.1)
@@ -1370,6 +1397,8 @@ def _drive_action_dialog_form(
     close_btn = _find_dialog_button(action_dlg, ACTION_DIALOG_BTN_CLOSE)
     close_btn.click_input()
     time.sleep(0.3)
+
+    return counter_text
 
 
 def _click_btn_and_wait_for_dialog(
@@ -1417,7 +1446,7 @@ def mark_all_via_regex(
     regex: str,
     action_label: str,
     dialog_timeout: float = 5,
-) -> None:
+) -> str | None:
     """Open the inner Set Action by Field/Regex dialog from inside the
     Execute Action dialog, set field+regex+action, click Apply, then Close.
 
@@ -1426,6 +1455,9 @@ def mark_all_via_regex(
     helper for the same rationale).
     `action_label` is the visible label in the Set Action combo
     (e.g. "delete" — see SETTABLE_DECISIONS in app/views/constants.py).
+
+    Returns the live-preview match-counter text or ``None`` (see
+    ``_drive_action_dialog_form``).
     """
     pid = execute_dlg.process_id()
     select_btn = execute_dlg.child_window(
@@ -1439,7 +1471,7 @@ def mark_all_via_regex(
     _focus(action_dlg)
     time.sleep(0.3)
 
-    _drive_action_dialog_form(action_dlg, field, regex, action_label)
+    return _drive_action_dialog_form(action_dlg, field, regex, action_label)
 
 
 def mark_all_via_regex_standalone(
@@ -1448,7 +1480,7 @@ def mark_all_via_regex_standalone(
     regex: str,
     action_label: str,
     dialog_timeout: float = 5,
-) -> None:
+) -> str | None:
     """Drive the standalone Set Action by Field/Regex flow from the menu bar.
 
     Distinct from `mark_all_via_regex` — this opens the dialog via
@@ -1458,6 +1490,9 @@ def mark_all_via_regex_standalone(
 
     Use for s14 (standalone Set Action) and any future scenario that
     exercises bulk-decision assignment without entering Execute review.
+
+    Returns the live-preview match-counter text or ``None`` (see
+    ``_drive_action_dialog_form``).
     """
     pid = main_win.process_id()
     menu_path(main_win, MENU_ACTION, ACTION_BY_REGEX)
@@ -1467,7 +1502,7 @@ def mark_all_via_regex_standalone(
     _focus(action_dlg)
     time.sleep(0.3)
 
-    _drive_action_dialog_form(action_dlg, field, regex, action_label)
+    return _drive_action_dialog_form(action_dlg, field, regex, action_label)
 
 
 def execute_and_confirm(

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -1363,14 +1363,33 @@ def _drive_action_dialog_form(
     regex_edit = standalone_edits[0]
     regex_edit.iface_value.SetValue(regex)
 
-    # Live-preview debounce in ActionDialog is 150 ms; sleep past it
-    # before reading the counter so we never race against the timer.
+    # Wait past the 150 ms live-preview debounce so the counter has
+    # populated before we read it (post-Apply, below).
     time.sleep(0.3)
 
-    # Find the live-preview match counter. pywinauto's auto_id is the
-    # full QObject hierarchy path ending in objectName, so we suffix-match
-    # rather than exact-match — keeps the lookup stable if a wrapper
-    # widget gets inserted later.
+    action_combo.select(action_label)
+    # 0.1 s was enough locally but flaked on the hosted CI runner under
+    # the new wider layout — the action-combo dropdown takes longer to
+    # commit when the dialog is taller. 0.4 s costs nothing and keeps the
+    # apply path deterministic.
+    time.sleep(0.4)
+
+    # Use _find_dialog_button (bottom-most match) — on en-US Windows the
+    # title-bar Close button shares the form Close's accessible name and a
+    # plain child_window lookup goes ambiguous.
+    apply_btn = _find_dialog_button(action_dlg, ACTION_DIALOG_BTN_APPLY)
+    apply_btn.click_input()
+    time.sleep(0.3)
+
+    # Counter readback happens AFTER Apply — Apply doesn't dismiss the
+    # dialog, so the live-preview pane is still on screen with the same
+    # numbers. Reading it before Apply meant the descendants() walk
+    # interleaved with combo selection, which raced against the
+    # dropdown-commit timing on hosted CI runners and caused intermittent
+    # action_label='remove from list' applies to silently miss.
+    # pywinauto's auto_id is the full QObject hierarchy path ending in
+    # objectName, so we suffix-match rather than exact-match — keeps the
+    # lookup stable if a wrapper widget gets inserted later.
     counter_text: str | None = None
     try:
         for d in action_dlg.descendants(control_type="Text"):
@@ -1383,16 +1402,6 @@ def _drive_action_dialog_form(
                 break
     except Exception:
         counter_text = None
-
-    action_combo.select(action_label)
-    time.sleep(0.1)
-
-    # Use _find_dialog_button (bottom-most match) — on en-US Windows the
-    # title-bar Close button shares the form Close's accessible name and a
-    # plain child_window lookup goes ambiguous.
-    apply_btn = _find_dialog_button(action_dlg, ACTION_DIALOG_BTN_APPLY)
-    apply_btn.click_input()
-    time.sleep(0.3)
 
     close_btn = _find_dialog_button(action_dlg, ACTION_DIALOG_BTN_CLOSE)
     close_btn.click_input()

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -1367,12 +1367,41 @@ def _drive_action_dialog_form(
     # populated before we read it (post-Apply, below).
     time.sleep(0.3)
 
-    action_combo.select(action_label)
-    # 0.1 s was enough locally but flaked on the hosted CI runner under
-    # the new wider layout — the action-combo dropdown takes longer to
-    # commit when the dialog is taller. 0.4 s costs nothing and keeps the
-    # apply path deterministic.
-    time.sleep(0.4)
+    # combo.select(text) works reliably locally but flaked on the
+    # hosted CI runner specifically for non-default items: s29
+    # (action='remove from list', third item) failed twice in a row
+    # while s14/s30 (action='delete', first item) always passed in
+    # the same runs. Mechanism unclear (possibly a focus or dropdown-
+    # visibility race that's invisible under local Windows), so we
+    # defend by retrying with a focus refresh between attempts and
+    # verifying the combo's displayed text actually changed.
+    for attempt in range(3):
+        try:
+            action_combo.set_focus()
+        except Exception:
+            pass
+        time.sleep(0.1)
+        try:
+            action_combo.select(action_label)
+        except Exception:
+            pass
+        time.sleep(0.4)
+        try:
+            current = (action_combo.window_text() or "").strip()
+        except Exception:
+            current = ""
+        if current == action_label:
+            break
+    else:
+        # Final fallback: ValuePattern.SetValue. This sets the visible
+        # text but does NOT fire QComboBox::currentIndexChanged on Qt's
+        # side — kept as a last-ditch so the helper at least surfaces
+        # a clearer failure if the click+verify path can't agree.
+        try:
+            action_combo.iface_value.SetValue(action_label)
+        except Exception:
+            pass
+        time.sleep(0.2)
 
     # Use _find_dialog_button (bottom-most match) — on en-US Windows the
     # title-bar Close button shares the form Close's accessible name and a
@@ -1622,6 +1651,8 @@ CTX_KEEP = "keep (remove action)"
 CTX_OPEN_FOLDER = "Open Folder"
 
 _VK_CONTROL = 0x11
+_VK_DOWN = 0x28
+_VK_UP = 0x26
 _KEYEVENTF_KEYUP = 0x0002
 
 

--- a/qa/scenarios/s14_action_by_regex.py
+++ b/qa/scenarios/s14_action_by_regex.py
@@ -89,9 +89,22 @@ def main() -> int:
     print(f"  field={FIELD!r} regex={REGEX!r} action={ACTION!r}")
     print(f"  expected_match={expected_match}")
     print(f"  expected_unchanged={expected_unchanged}")
-    _uia.mark_all_via_regex_standalone(
+    counter_text = _uia.mark_all_via_regex_standalone(
         win, field=FIELD, regex=REGEX, action_label=ACTION
     )
+
+    print("step: assert_live_preview_counter")
+    # The dialog now ships a live-preview pane; the counter must reflect
+    # the typed pattern by the time we click Apply. We only verify the
+    # text is non-empty and contains digits — exact format is locale-
+    # dependent (en: "3 of 5 match", zh_TW: "3 / 5 相符").
+    print(f"  counter_text={counter_text!r}")
+    if counter_text is None:
+        print("FAIL: live-preview counter not found — preview pane missing?")
+        return 1
+    if not any(ch.isdigit() for ch in counter_text):
+        print(f"FAIL: counter text {counter_text!r} has no digits — preview not populated")
+        return 1
 
     print("step: invariant_status_bar")
     _, win = _uia.connect_main()

--- a/qa/scenarios/s30_execute_dialog_regex_right_click.py
+++ b/qa/scenarios/s30_execute_dialog_regex_right_click.py
@@ -1,0 +1,221 @@
+"""Scenario 30 — Execute Action dialog: right-click → Set Action by Field/Regex…
+
+Required source: qa/sandbox/near-duplicates (5 files, basenames neardup_NN_qXX.jpg).
+
+Phase A of the regex-dialog UX upgrade unifies the right-click on file
+rows across the main window and the Execute Action dialog. Previously
+the Execute Action dialog only exposed regex via a dedicated toolbar
+button; non-destructive right-clicks gave you delete / keep / remove
+from list but no regex entry. This scenario pins the new behavior:
+
+  scan → close & load → open Execute Action dialog →
+  right-click first file row → click "Set Action by Field/Regex…" →
+  ActionDialog opens with a populated live-preview pane →
+  field=File Name, regex=q[89]\\d, action=delete → assert counter shows
+  "3 of 5 match" → Apply → Close inner → Close outer (no execute) →
+  verify (a) the 3 matching rows now have user_decision='delete' in
+  the manifest, (b) the 2 non-matching rows are unchanged.
+
+Sister to s14 (main-window menu-bar route) and s13 (Execute Action's
+toolbar-button route) — same regex partition (q[89]\\d → 3/2), same
+verification path, different entry point.
+
+Catches drift in: Execute Action context-menu wiring; new
+``execute_dialog.set_action_by_regex_menu`` translation key;
+ActionDialog match_fn pass-through from ExecuteActionDialog into the
+shared dialog; live-preview counter rendering.
+"""
+from __future__ import annotations
+
+import re
+import sqlite3
+import sys
+from pathlib import Path
+
+from qa.scenarios import _invariants, _uia
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO / "qa" / "run-manifest.sqlite"
+FIXTURE_NAME_GLOB = "neardup_"
+
+FIELD = "File Name"
+REGEX = r"q[89]\d"
+ACTION = "delete"
+# Localized menu label for the new right-click entry. Mirrors the
+# en.yml value of execute_dialog.set_action_by_regex_menu — drift
+# here surfaces as a popup-menu-item-not-found error from
+# select_popup_menu_path.
+REGEX_MENU_LABEL = "Set Action by Field/Regex…"
+
+
+def _read_decisions() -> dict[str, str]:
+    """Return {basename: user_decision} for every fixture row in the manifest."""
+    if not MANIFEST_PATH.exists():
+        raise RuntimeError(f"manifest not found at {MANIFEST_PATH}")
+    conn = sqlite3.connect(str(MANIFEST_PATH))
+    try:
+        rows = conn.execute(
+            "SELECT source_path, user_decision FROM migration_manifest "
+            "WHERE source_path LIKE ?",
+            (f"%{FIXTURE_NAME_GLOB}%",),
+        ).fetchall()
+    finally:
+        conn.close()
+    return {Path(p).name: (d or "") for p, d in rows}
+
+
+def main() -> int:
+    print("scenario: s30_execute_dialog_regex_right_click")
+    app, win = _uia.connect_main()
+    pid = win.process_id()
+    print(f"connected: pid={pid} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, _ = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    for line in _uia.extract_summary(log):
+        if line:
+            print(f"  log: {line}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+    _, win = _uia.connect_main()
+
+    print("step: snapshot_pre_decisions")
+    pre = _read_decisions()
+    if not pre:
+        print("FAIL: no fixture rows found in manifest after scan")
+        return 1
+    print(f"  pre_total={len(pre)}")
+
+    rx = re.compile(REGEX, re.IGNORECASE)
+    expected_match = sorted(name for name in pre if rx.search(name))
+    expected_unchanged = sorted(name for name in pre if not rx.search(name))
+    print(f"  expected_match={expected_match}")
+    print(f"  expected_unchanged={expected_unchanged}")
+    expected_match_count = len(expected_match)
+
+    # ExecuteActionDialog filters to "groups with at least one decision
+    # set" (see _groups_with_decisions). With a freshly-scanned manifest
+    # nothing has user_decision set yet → the tree is empty → there's
+    # no file row to right-click. Seed one decision via the main window
+    # right-click flow first; the tree then has at least one visible
+    # group that contains all 5 files (the same group_number).
+    print("step: seed_one_decision_via_main_tree")
+    seed_target = expected_match[0]
+    print(f"  seed_target={seed_target!r}")
+    _uia.left_click_tree_row(win, seed_target)
+    _uia.right_click_tree_row(win, seed_target)
+    _uia.select_popup_menu_path(pid, [_uia.CTX_SET_ACTION, _uia.CTX_DELETE])
+
+    print("step: open_execute_action_dialog")
+    exec_dlg, _ = _uia.open_execute_action_dialog(win)
+
+    print("step: right_click_first_file_row")
+    # ExecuteActionDialog's QTreeView doesn't materialize file rows as
+    # UIA TreeItems (a PySide6/Qt-accessibility quirk specific to that
+    # tree — the main window's tree exposes them fine). So we right-
+    # click by coordinate. _on_tree_context_menu only shows the popup
+    # for FILE rows (children of a group); a click on the group header
+    # row makes the handler bail. Layout when expanded:
+    #   header (~30 px) → group row (~25 px) → file rows (~22 px each).
+    # Aim for the middle of the SECOND file row to leave generous slack
+    # for header/row-height variation across DPI scaling.
+    import pywinauto.mouse
+    tree_rect = exec_dlg.descendants(control_type="Tree")[0].rectangle()
+    cx = tree_rect.left + (tree_rect.right - tree_rect.left) // 2
+    cy = tree_rect.top + 105  # header + group row + 1.5 file rows
+    print(f"  click_coords=({cx},{cy}) tree_rect={tree_rect}")
+    pywinauto.mouse.click(button="left", coords=(cx, cy))
+    import time
+    time.sleep(0.3)
+    pywinauto.mouse.right_click(coords=(cx, cy))
+    time.sleep(0.4)
+
+    print("step: open_regex_dialog_via_popup")
+    # Single-level path: just the regex menu item directly. No "Set
+    # Action" submenu in front — the regex entry sits at the bottom of
+    # the context menu, below the Set Action submenu and the separator.
+    _uia.select_popup_menu_path(pid, [REGEX_MENU_LABEL])
+
+    print("step: drive_action_dialog_form")
+    # _drive_action_dialog_form needs the freshly-opened ActionDialog,
+    # not the parent. Wait for it by title and connect by handle so the
+    # subsequent UIA queries scope to the right window.
+    action_hwnd = _uia.wait_for_dialog(
+        pid, _uia.ACTION_DIALOG_TITLE, timeout=5
+    )
+    action_dlg = _uia.connect_by_handle(action_hwnd)
+    counter_text = _uia._drive_action_dialog_form(
+        action_dlg, field=FIELD, regex=REGEX, action_label=ACTION
+    )
+
+    print("step: assert_live_preview_counter")
+    print(f"  counter_text={counter_text!r}")
+    if counter_text is None:
+        print("FAIL: live-preview counter not found — preview pane missing?")
+        return 1
+    # Format is locale-dependent — verify digits + the expected match
+    # count specifically. The counter is "3 of 5 match" (en) or
+    # "3 / 5 相符" (zh_TW); both contain "3" since 3 fixtures match.
+    if str(expected_match_count) not in counter_text:
+        print(
+            f"FAIL: counter text {counter_text!r} did not contain expected "
+            f"match count {expected_match_count}"
+        )
+        return 1
+
+    print("step: close_execute_action_dialog")
+    # Close (not Execute) — keeps the scenario non-destructive. The
+    # decisions were already persisted to the manifest by the regex
+    # apply path inside ExecuteActionDialog._set_decision_by_regex.
+    # _find_dialog_button picks the bottom-most "Close" so we
+    # disambiguate against the title-bar Close on en-US Windows.
+    close_btn = _uia._find_dialog_button(exec_dlg, "Close")
+    close_btn.click_input()
+
+    print("step: invariant_status_bar")
+    _, win = _uia.connect_main()
+    if not _invariants.assert_status_bar_matches(win, r"Decision set", within_s=2.0):
+        print("WARN: status bar did not echo 'Decision set' (may have cleared on timeout)")
+
+    print("step: verify_decisions_after_apply")
+    post = _read_decisions()
+    if set(post) != set(pre):
+        print(f"FAIL: row set changed; pre={sorted(pre)} post={sorted(post)}")
+        return 1
+
+    failures: list[str] = []
+    for name in expected_match:
+        if post[name] != "delete":
+            failures.append(f"{name}: expected 'delete', got {post[name]!r}")
+    for name in expected_unchanged:
+        if post[name] != pre[name]:
+            failures.append(
+                f"{name}: expected unchanged ({pre[name]!r}), got {post[name]!r}"
+            )
+
+    matched_rows = sum(1 for name in expected_match if post[name] == "delete")
+    unchanged_rows = sum(
+        1 for name in expected_unchanged if post[name] == pre[name]
+    )
+    print(f"  matched_rows={matched_rows} expected={len(expected_match)}")
+    print(f"  unchanged_rows={unchanged_rows} expected={len(expected_unchanged)}")
+    for name in sorted(post):
+        print(f"  row: name={name} pre={pre[name]!r} post={post[name]!r}")
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    print("scenario: s30_execute_dialog_regex_right_click DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -1186,3 +1186,137 @@ class TestDirtyTracking:
         ):
             handler.save_manifest_decisions()
         assert handler.is_dirty() is False
+
+
+# ── build_match_fn (powers ActionDialog live preview) ──────────────────────
+
+class TestBuildMatchFn:
+    """The closure must agree byte-for-byte with set_decision_by_regex.
+
+    These tests pin its contract: same field map, same case-insensitive
+    flag, same skip-on-None-field semantics. If they drift, the dialog's
+    preview will lie to the user about what Apply will do.
+    """
+
+    def _rec_with_folder(self, path: str, folder: str = "/photos") -> PhotoRecord:
+        rec = _rec(path)
+        rec.folder_path = folder
+        return rec
+
+    def test_returns_matched_total_samples(self):
+        from app.views.handlers.file_operations import build_match_fn
+
+        recs = [
+            _rec("/photos/IMG_001.jpg"),
+            _rec("/photos/IMG_002.jpg"),
+            _rec("/photos/note.txt"),
+        ]
+        groups = [PhotoGroup(group_number=1, items=recs)]
+
+        match_fn = build_match_fn(groups)
+        matched, total, samples = match_fn("File Name", r"^IMG_\d+\.jpg$")
+
+        assert matched == 2
+        assert total == 3
+        assert samples == ["IMG_001.jpg", "IMG_002.jpg"]
+
+    def test_invalid_regex_returns_zero_with_total(self):
+        """A live-preview must not crash on a partial regex; it returns
+        zero matches and lets the dialog's validation row show why."""
+        from app.views.handlers.file_operations import build_match_fn
+
+        recs = [_rec("/a.jpg"), _rec("/b.jpg")]
+        groups = [PhotoGroup(group_number=1, items=recs)]
+
+        match_fn = build_match_fn(groups)
+        matched, total, samples = match_fn("File Name", "(unclosed")
+
+        assert matched == 0
+        assert total == 2
+        assert samples == []
+
+    def test_sample_cap_truncates_but_count_is_full(self):
+        """Sample collection stops at sample_cap so the preview list
+        stays bounded; matched count must still be the true total."""
+        from app.views.handlers.file_operations import build_match_fn
+
+        recs = [_rec(f"/dir/file_{i:03d}.jpg") for i in range(100)]
+        groups = [PhotoGroup(group_number=1, items=recs)]
+
+        match_fn = build_match_fn(groups, sample_cap=50)
+        matched, total, samples = match_fn("File Name", r"\.jpg$")
+
+        assert matched == 100
+        assert total == 100
+        assert len(samples) == 50
+
+    def test_uses_get_record_field_for_basename(self):
+        """File Name field must extract basename, not the full path —
+        otherwise users can't write `^IMG` to anchor at the filename
+        (the path starts with `/photos/`)."""
+        from app.views.handlers.file_operations import build_match_fn
+
+        recs = [_rec("/photos/IMG_x.jpg"), _rec("/photos/note.txt")]
+        groups = [PhotoGroup(group_number=1, items=recs)]
+
+        match_fn = build_match_fn(groups)
+        matched, _total, _samples = match_fn("File Name", r"^IMG")
+
+        assert matched == 1
+
+    def test_folder_field_returns_folder(self):
+        """And Folder must NOT use the basename — pinning the field-map
+        routing matches what set_decision_by_regex does."""
+        from app.views.handlers.file_operations import build_match_fn
+
+        recs = [
+            self._rec_with_folder("/a.jpg", folder="/photos/2023"),
+            self._rec_with_folder("/b.jpg", folder="/photos/2024"),
+        ]
+        groups = [PhotoGroup(group_number=1, items=recs)]
+
+        match_fn = build_match_fn(groups)
+        matched, _, samples = match_fn("Folder", r"2023$")
+
+        assert matched == 1
+        # Sample is the basename of the matching record's file_path,
+        # not the folder string — so users see WHICH file matched.
+        assert samples == ["a.jpg"]
+
+    def test_unmapped_field_skips_without_match(self):
+        """Group Count / Similarity have no _FIELD_TO_ATTR entry — they
+        cannot match any regex, but records still count toward total."""
+        from app.views.handlers.file_operations import build_match_fn
+
+        recs = [_rec("/a.jpg"), _rec("/b.jpg")]
+        groups = [PhotoGroup(group_number=1, items=recs)]
+
+        match_fn = build_match_fn(groups)
+        matched, total, samples = match_fn("Group Count", r".*")
+
+        assert matched == 0
+        assert total == 2
+        assert samples == []
+
+    def test_empty_groups(self):
+        from app.views.handlers.file_operations import build_match_fn
+
+        match_fn = build_match_fn([])
+        matched, total, samples = match_fn("File Name", r".*")
+
+        assert matched == 0
+        assert total == 0
+        assert samples == []
+
+    def test_case_insensitive(self):
+        """Must match set_decision_by_regex's re.IGNORECASE flag —
+        otherwise the preview undercounts vs. what Apply will do."""
+        from app.views.handlers.file_operations import build_match_fn
+
+        recs = [_rec("/photos/IMG_001.JPG"), _rec("/photos/img_002.jpg")]
+        groups = [PhotoGroup(group_number=1, items=recs)]
+
+        match_fn = build_match_fn(groups)
+        matched, _total, _samples = match_fn("File Name", r"\.jpg$")
+
+        assert matched == 2

--- a/tests/test_select_dialog.py
+++ b/tests/test_select_dialog.py
@@ -138,3 +138,212 @@ class TestBackwardCompatAlias:
     def test_select_dialog_alias_works(self, qapp):
         from app.views.dialogs.select_dialog import SelectDialog, ActionDialog
         assert SelectDialog is ActionDialog
+
+
+# ── Live preview / validation / debounce (Phase A) ─────────────────────────
+
+
+class TestPreviewPane:
+    def test_no_match_fn_hides_preview_pane(self, qapp):
+        """match_fn=None falls back to the original flat layout — no
+        preview list, no counter visible. Existing UIA paths and tests
+        keep working unchanged."""
+        from app.views.dialogs.select_dialog import ActionDialog
+
+        dlg = ActionDialog(fields=["File Name"])
+        # No preview_list attribute when match_fn isn't supplied.
+        assert not hasattr(dlg, "_preview_list")
+        # Counter is constructed but hidden.
+        assert dlg._match_counter.isHidden()
+
+    def test_match_fn_called_on_typing(self, qapp):
+        """Typing into the regex must invoke match_fn after the debounce
+        timer fires (we shortcut the timer here)."""
+        from app.views.dialogs.select_dialog import ActionDialog
+        from unittest.mock import MagicMock
+
+        match_fn = MagicMock(return_value=(2, 3, ["a.jpg", "b.jpg"]))
+        dlg = ActionDialog(fields=["File Name"], match_fn=match_fn)
+
+        match_fn.reset_mock()
+        dlg.regex.setText("IMG")
+        dlg._refresh_preview()
+
+        match_fn.assert_called_with("File Name", "IMG")
+
+    def test_preview_lists_samples(self, qapp):
+        """Preview list shows the sample names returned by match_fn."""
+        from app.views.dialogs.select_dialog import ActionDialog
+
+        match_fn = lambda f, p: (3, 100, ["one.jpg", "two.jpg", "three.jpg"])
+        dlg = ActionDialog(fields=["File Name"], match_fn=match_fn)
+        dlg.regex.setText(".*")
+        dlg._refresh_preview()
+
+        items = [
+            dlg._preview_list.item(i).text()
+            for i in range(dlg._preview_list.count())
+        ]
+        assert items == ["one.jpg", "two.jpg", "three.jpg"]
+
+    def test_preview_truncation_footer(self, qapp):
+        """When matched count exceeds samples returned, the truncation
+        footer must show "…and N more"."""
+        from app.views.dialogs.select_dialog import ActionDialog
+
+        # 50 samples, 200 total matches — 150 are hidden.
+        match_fn = lambda f, p: (200, 4500, [f"x{i}.jpg" for i in range(50)])
+        dlg = ActionDialog(fields=["File Name"], match_fn=match_fn)
+        dlg.regex.setText(".*")
+        dlg._refresh_preview()
+
+        assert dlg._preview_list.count() == 50
+        assert not dlg._preview_truncated.isHidden()
+        assert "150" in dlg._preview_truncated.text()
+
+    def test_no_truncation_when_all_samples_fit(self, qapp):
+        """If matched <= len(samples), the truncation footer stays
+        hidden — otherwise users see "…and 0 more" which is confusing."""
+        from app.views.dialogs.select_dialog import ActionDialog
+
+        match_fn = lambda f, p: (5, 100, ["a", "b", "c", "d", "e"])
+        dlg = ActionDialog(fields=["File Name"], match_fn=match_fn)
+        dlg.regex.setText(".*")
+        dlg._refresh_preview()
+
+        assert dlg._preview_truncated.isHidden()
+
+    def test_field_change_retriggers_match_fn(self, qapp):
+        """Changing the field combo restarts the debounce timer so the
+        preview re-runs with the new field."""
+        from app.views.dialogs.select_dialog import ActionDialog
+        from unittest.mock import MagicMock
+
+        match_fn = MagicMock(return_value=(0, 0, []))
+        dlg = ActionDialog(
+            fields=["File Name", "Folder"], match_fn=match_fn
+        )
+        dlg.regex.setText("foo")
+        match_fn.reset_mock()
+
+        dlg.combo.setCurrentText("Folder")
+        dlg._refresh_preview()
+
+        # The first call after combo change is for the new field.
+        called_fields = [c.args[0] for c in match_fn.call_args_list]
+        assert "Folder" in called_fields
+
+    def test_no_match_shows_empty_placeholder(self, qapp):
+        """matched == 0 → list shows the localized "No matches"
+        placeholder, not an empty list (which feels broken)."""
+        from app.views.dialogs.select_dialog import ActionDialog
+        from infrastructure.i18n import t
+
+        match_fn = lambda f, p: (0, 100, [])
+        dlg = ActionDialog(fields=["File Name"], match_fn=match_fn)
+        dlg.regex.setText("zz_no_such_pattern")
+        dlg._refresh_preview()
+
+        assert dlg._preview_list.count() == 1
+        assert dlg._preview_list.item(0).text() == t("action_dialog.preview_empty")
+
+
+class TestRegexValidation:
+    def test_valid_regex_shows_check_icon(self, qapp):
+        from app.views.dialogs.select_dialog import ActionDialog
+
+        dlg = ActionDialog(fields=["File Name"])
+        dlg.regex.setText("^IMG_\\d+$")
+        dlg._validate_regex()
+
+        assert dlg._validation_icon.text() == "✓"
+        assert dlg._validation_error.isHidden()
+
+    def test_invalid_regex_shows_x_and_error(self, qapp):
+        from app.views.dialogs.select_dialog import ActionDialog
+
+        dlg = ActionDialog(fields=["File Name"])
+        dlg.regex.setText("(unclosed")
+        dlg._validate_regex()
+
+        assert dlg._validation_icon.text() == "✗"
+        assert not dlg._validation_error.isHidden()
+        # Localized prefix from action_dialog.invalid_regex.
+        assert "Invalid regex" in dlg._validation_error.text() \
+            or "正規式錯誤" in dlg._validation_error.text()
+
+    def test_empty_regex_clears_validation_state(self, qapp):
+        """Empty input is neutral — no icon, no error. Otherwise the
+        dialog feels broken before the user has typed anything."""
+        from app.views.dialogs.select_dialog import ActionDialog
+
+        dlg = ActionDialog(fields=["File Name"])
+        dlg.regex.setText("(")
+        dlg._validate_regex()
+        assert dlg._validation_icon.text() == "✗"
+
+        dlg.regex.setText("")
+        dlg._validate_regex()
+        assert dlg._validation_icon.text() == ""
+        assert dlg._validation_error.isHidden()
+
+    def test_invalid_regex_does_not_call_match_fn(self, qapp):
+        """match_fn iterates the records — must not run for unparseable
+        patterns. Counter shows em dash instead."""
+        from app.views.dialogs.select_dialog import ActionDialog
+        from unittest.mock import MagicMock
+
+        match_fn = MagicMock(return_value=(0, 0, []))
+        dlg = ActionDialog(fields=["File Name"], match_fn=match_fn)
+        match_fn.reset_mock()
+
+        dlg.regex.setText("(")
+        # Validation runs synchronously; should mark counter as "—".
+        # Then we manually fire the preview timer's slot to confirm the
+        # closure short-circuits on invalid regex.
+        dlg._refresh_preview()
+
+        assert match_fn.call_count == 0
+        assert dlg._match_counter.text() == "—"
+
+
+class TestMatchCounter:
+    def test_counter_format_uses_translation(self, qapp):
+        """Counter text is built from the action_dialog.match_counter
+        i18n template — verifies localization rather than hardcoded
+        English."""
+        from app.views.dialogs.select_dialog import ActionDialog
+        from infrastructure.i18n import t
+
+        match_fn = lambda f, p: (7, 200, [])
+        dlg = ActionDialog(fields=["File Name"], match_fn=match_fn)
+        dlg.regex.setText(".*")
+        dlg._refresh_preview()
+
+        expected = t("action_dialog.match_counter").format(matched=7, total=200)
+        assert dlg._match_counter.text() == expected
+
+
+class TestObjectNames:
+    """Pinning objectName values that QA scenarios will use to find
+    widgets without relying on geometry / type-path."""
+
+    def test_widget_object_names_are_set(self, qapp):
+        from app.views.dialogs.select_dialog import ActionDialog
+
+        dlg = ActionDialog(fields=["File Name"])
+        assert dlg.regex.objectName() == "regexLineEdit"
+        assert dlg.combo.objectName() == "regexFieldCombo"
+        assert dlg._action_combo.objectName() == "regexActionCombo"
+        assert dlg._btn_set_action.objectName() == "regexApplyButton"
+        assert dlg._validation_icon.objectName() == "regexValidationIcon"
+        assert dlg._validation_error.objectName() == "regexValidationError"
+        assert dlg._match_counter.objectName() == "regexMatchCounter"
+
+    def test_preview_widgets_object_names_set_when_present(self, qapp):
+        from app.views.dialogs.select_dialog import ActionDialog
+
+        match_fn = lambda f, p: (0, 0, [])
+        dlg = ActionDialog(fields=["File Name"], match_fn=match_fn)
+        assert dlg._preview_list.objectName() == "regexPreviewList"
+        assert dlg._preview_truncated.objectName() == "regexPreviewTruncated"

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -140,6 +140,7 @@ execute_dialog:
   no_match_title: "Set Action — No Match"
   no_match_body: "No files matched the pattern."
   invalid_regex_title: "Invalid Regex"
+  set_action_by_regex_menu: "Set Action by Field/Regex…"
   files_not_found_title: "Files Not Found"
   files_not_found_body: "The following files could not be found and were skipped:\n\n{missing}{suffix}"
   files_not_found_more: "\n…and {n} more"
@@ -158,6 +159,12 @@ action_dialog:
   set_action_label: "Set Action:"
   apply_button: "Apply"
   close_button: "Close"
+  preview_label: "Preview"
+  match_counter: "{matched} of {total} match"
+  match_counter_invalid: "—"
+  invalid_regex: "Invalid regex: {error}"
+  preview_truncated: "…and {n} more"
+  preview_empty: "No matches"
 
 # Right-click context menu on the main tree.
 context_menu:

--- a/translations/zh_TW.yml
+++ b/translations/zh_TW.yml
@@ -121,6 +121,7 @@ execute_dialog:
   no_match_title: "設定動作 — 無相符項目"
   no_match_body: "沒有檔案符合此正規式。"
   invalid_regex_title: "正規式錯誤"
+  set_action_by_regex_menu: "依欄位/正規式設定動作…"
   files_not_found_title: "找不到檔案"
   files_not_found_body: "下列檔案找不到,已略過:\n\n{missing}{suffix}"
   files_not_found_more: "\n…以及其餘 {n} 個"
@@ -138,6 +139,12 @@ action_dialog:
   set_action_label: "設定動作:"
   apply_button: "套用"
   close_button: "關閉"
+  preview_label: "預覽"
+  match_counter: "{matched} / {total} 相符"
+  match_counter_invalid: "—"
+  invalid_regex: "正規式錯誤:{error}"
+  preview_truncated: "…還有 {n} 筆"
+  preview_empty: "無相符項目"
 
 context_menu:
   set_action: "設定動作"


### PR DESCRIPTION
## Summary

Phase A of the regex-dialog UX upgrade. Turns "Set Action by Field/Regex…" from a silent commit-or-fail dialog into a live tool a non-regex user can drive confidently.

### Live preview pane

- Right-side `QListWidget` (debounced 150 ms after the last keystroke) shows up to 50 matched filenames with a "…and N more" footer.
- Match counter ("12 of 4500 match") next to the regex input.
- Dialog grows to 750×450 min when a `match_fn` is supplied; falls back to today's flat layout when `match_fn=None` (so any caller that hasn't been updated yet keeps working).

### Live validation

- Green ✓ / red ✗ icon next to the regex input.
- Friendly error label ("Invalid regex: unmatched ')' at position 7") the moment `re.compile` fails — no more silent failure on Apply.
- The closure short-circuits on invalid regex so we never iterate the record set with a broken pattern.

### Right-click parity

- Execute Action dialog's tree context menu now offers **"Set Action by Field/Regex…"** alongside delete / keep / remove from list.
- Main window's **multi-selection** right-click also offers the regex entry (single-selection already had it).

## Architecture

| What | Where | Notes |
|---|---|---|
| `build_match_fn(groups, sample_cap=50)` | `app/views/handlers/file_operations.py` | Closure shared by both call sites; routes through `_get_record_field` so the preview is byte-for-byte consistent with what `set_decision_by_regex` will match on Apply. |
| `ActionDialog(..., match_fn=None)` | `app/views/dialogs/select_dialog.py` | New optional arg. When None: original flat layout. When supplied: horizontal `QSplitter` with controls on the left and preview pane on the right. |
| `DialogHandler(..., records_provider=None)` | `app/views/handlers/dialog_handler.py` | Lazy callable so the dialog always builds against current state at open time (no caching). |
| Main window wiring | `app/views/main_window.py` | Passes `records_provider=lambda: self._vm.groups`. |
| Execute dialog wiring | `app/views/dialogs/execute_action_dialog.py` | `_show_select_dialog` builds `match_fn` from `self._groups`; `_on_tree_context_menu` adds the new menu entry. |
| Multi-select main-window menu | `app/views/handlers/context_menu.py` | Mirrors the single-selection branch — separator + regex entry + remove. |

All new widgets carry stable `objectName` values so QA scenarios find them without relying on geometry: `regexLineEdit`, `regexFieldCombo`, `regexActionCombo`, `regexApplyButton`, `regexValidationIcon`, `regexValidationError`, `regexMatchCounter`, `regexPreviewList`, `regexPreviewTruncated`.

## What Phase B will add

Deferred to a follow-up PR (per plan): plain-language toggle (`Field [contains | starts with | ends with] [text]`), recent-patterns dropdown, cheatsheet sidebar, and highlight-matched-span in the preview list. Phase A first, learn from usage, then layer more on.

## Test plan

- [x] **pytest**: 674 passed, 2 skipped, 90.19% coverage
- [x] 14 new unit tests across `test_select_dialog.py` (preview, validation, debounce short-circuit, counter format, objectName pinning) and `test_file_operations.py` (`build_match_fn` shape, sample cap, IGNORECASE, field-not-in-map fallback)
- [x] **qa s14_action_by_regex** — main-window menu route — green; now asserts the live counter is populated after typing
- [x] **qa s30_execute_dialog_regex_right_click** (new) — exercises the right-click parity end-to-end: scan → seed one decision → open Execute Action dialog → right-click file row → "Set Action by Field/Regex…" → verify counter → Apply → verify decisions persisted
- [x] **qa s15_context_menu, s27_rescan_confirm** — green (no regression)
- [ ] **CI qa-batch** will run the full 30-scenario sweep including s13 (destructive) which I skip locally

## Translation keys added

Under `action_dialog:` — `preview_label`, `match_counter`, `match_counter_invalid`, `invalid_regex`, `preview_truncated`, `preview_empty`.
Under `execute_dialog:` — `set_action_by_regex_menu`.
Both `en.yml` and `zh_TW.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)