### PR TITLE
chore(hooks): enforce qa/scenarios coverage on feature PRs

### DIFF
--- a/.claude/settings.json.example
+++ b/.claude/settings.json.example
@@ -1,5 +1,18 @@
 {
   "$schema": "https://json.schemastore.org/claude-code-settings.json",
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".venv/Scripts/python.exe scripts/hooks/qa_scenario_guard.py"
+          }
+        ]
+      }
+    ]
+  },
   "permissions": {
     "allow": [
       "Bash(.venv/Scripts/python.exe -m qa.scenarios.*:*)"

--- a/scripts/hooks/qa_scenario_guard.py
+++ b/scripts/hooks/qa_scenario_guard.py
@@ -1,0 +1,116 @@
+"""PreToolUse hook: enforce QA-scenario coverage for user-facing PRs.
+
+When ``gh pr create`` is about to run, scan the branch's diff vs.
+``origin/master`` for user-facing file changes (handlers / dialogs /
+components / workers under ``app/views/``). If any are present and no
+``qa/scenarios/sNN_*.py`` change accompanies them, block the PR creation
+with a clear stderr message naming the offenders.
+
+Per CLAUDE.md, layer-3 ``qa/scenarios/sNN_*.py`` drivers are a hard
+requirement for user-facing flows. Words alone in the docs were not
+enough — see photo-manager#175 (Locked-state PR initially shipped
+without a QA scenario; required a follow-up commit to comply).
+
+Bypass
+------
+Include the literal token ``[qa-not-needed: <reason>]`` anywhere in the
+``gh pr create`` command (typically in ``--title`` or ``--body``) when
+a change genuinely doesn't need a QA scenario — e.g. an internal
+refactor with zero user-visible effect, a translation-string update, a
+docstring fix. The reason becomes part of the PR title/body so the
+choice is visible in code review.
+
+Hook protocol
+-------------
+* stdin  — JSON with shape ``{"tool_name": ..., "tool_input": {"command": ...}}``
+* exit 0 — allow the tool call (default; not a ``gh pr create``, no
+  user-facing changes, QA changes present, or bypass token found).
+* exit 2 — BLOCK the tool call. Stderr is shown to Claude; tool input
+  is rejected. Per Claude Code hook docs.
+* any other non-zero exit — surfaced to the user but does NOT block.
+  We deliberately use exit 2 for the enforcement path.
+"""
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+
+USER_FACING_PATTERNS = (
+    re.compile(r"^app/views/handlers/.*\.py$"),
+    re.compile(r"^app/views/dialogs/.*\.py$"),
+    re.compile(r"^app/views/components/.*\.py$"),
+    re.compile(r"^app/views/workers/.*\.py$"),
+)
+QA_SCENARIO_PATTERN = re.compile(r"^qa/scenarios/s\d+.*\.py$")
+BYPASS_PATTERN = re.compile(r"\[qa-not-needed:[^\]]*\]")
+
+
+def _changed_files() -> list[str]:
+    """Return files changed on the current branch vs origin/master."""
+    try:
+        out = subprocess.check_output(
+            ["git", "diff", "--name-only", "origin/master...HEAD"],
+            text=True, stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return []
+    return [line.strip() for line in out.splitlines() if line.strip()]
+
+
+def main() -> int:
+    try:
+        payload = json.load(sys.stdin)
+    except (ValueError, json.JSONDecodeError):
+        return 0  # don't block on malformed input — fail open
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+    cmd = (payload.get("tool_input") or {}).get("command") or ""
+    if "gh pr create" not in cmd:
+        return 0
+
+    if BYPASS_PATTERN.search(cmd):
+        return 0
+
+    changed = _changed_files()
+    if not changed:
+        # No diff against origin/master — nothing to check (or no remote).
+        # Don't block; CI / review will surface other issues if relevant.
+        return 0
+
+    user_facing = [
+        f for f in changed if any(p.match(f) for p in USER_FACING_PATTERNS)
+    ]
+    qa_changes = [f for f in changed if QA_SCENARIO_PATTERN.match(f)]
+
+    if user_facing and not qa_changes:
+        msg_lines = [
+            "QA-scenario guard fired — blocking `gh pr create`.",
+            "",
+            "  user-facing files changed:",
+        ]
+        for f in user_facing:
+            msg_lines.append(f"    {f}")
+        msg_lines += [
+            "",
+            "  no qa/scenarios/sNN_*.py changes in this PR.",
+            "",
+            "  Per CLAUDE.md, user-facing flows (button / dialog / menu /",
+            "  status bar) require a layer-3 qa/scenarios/sNN_*.py driver.",
+            "",
+            "  To unblock:",
+            "    a) Add or extend a qa/scenarios/sNN_*.py driver, OR",
+            "    b) Include `[qa-not-needed: <reason>]` in the gh pr create",
+            "       command (title or body) — the reason will be visible in",
+            "       review so the choice is auditable.",
+        ]
+        sys.stderr.write("\n".join(msg_lines) + "\n")
+        return 2
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_qa_scenario_guard.py
+++ b/tests/test_qa_scenario_guard.py
@@ -1,0 +1,240 @@
+"""Tests for ``scripts/hooks/qa_scenario_guard.py`` — the PreToolUse hook
+that blocks ``gh pr create`` when user-facing files changed without a
+qa/scenarios/sNN_*.py driver.
+
+Failure mode the hook is preventing: shipping a feature PR (e.g.
+photo-manager#175 in its first iteration) that touches dialogs /
+handlers / components but lacks layer-3 coverage. CLAUDE.md is the
+spec; this hook + these tests are the enforcement.
+"""
+from __future__ import annotations
+
+import io
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+HOOK_PATH = REPO / "scripts" / "hooks" / "qa_scenario_guard.py"
+
+
+def _load_hook(monkeypatch):
+    """Import the hook module without executing main(). Patches
+    sys.argv so ``if __name__ == '__main__'`` is suppressed via the
+    ``runpy``-free direct-import path."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "qa_scenario_guard", str(HOOK_PATH)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _run(monkeypatch, command: str, changed: list[str]) -> int:
+    """Invoke ``main()`` with a synthetic stdin payload + mocked diff."""
+    mod = _load_hook(monkeypatch)
+    monkeypatch.setattr(mod, "_changed_files", lambda: list(changed))
+    payload = json.dumps(
+        {"tool_name": "Bash", "tool_input": {"command": command}}
+    )
+    monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+    return mod.main()
+
+
+# ── exit 0 paths (allowed) ────────────────────────────────────────────────
+
+
+class TestAllow:
+    def test_non_pr_command_passes(self, monkeypatch):
+        rc = _run(monkeypatch, "git status", changed=[])
+        assert rc == 0
+
+    def test_pr_create_with_no_diff_passes(self, monkeypatch):
+        """No files changed vs origin/master — nothing to enforce."""
+        rc = _run(monkeypatch, "gh pr create --title 'fix: typo'", changed=[])
+        assert rc == 0
+
+    def test_pr_create_with_only_qa_changes_passes(self, monkeypatch):
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'qa: extend s14'",
+            changed=["qa/scenarios/s14_action_by_regex.py"],
+        )
+        assert rc == 0
+
+    def test_pr_create_with_only_test_changes_passes(self, monkeypatch):
+        """Pure test refactors / docs / scanner-only / infra-only PRs do
+        not touch user-facing UI surfaces — no QA scenario required."""
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'tests: refactor manifest fixtures'",
+            changed=[
+                "tests/test_manifest_repository.py",
+                "infrastructure/manifest_repository.py",
+            ],
+        )
+        assert rc == 0
+
+    def test_pr_create_with_user_facing_AND_qa_passes(self, monkeypatch):
+        """Happy path for a feature PR — user-facing change accompanied
+        by a qa/scenarios/sNN_*.py driver."""
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'feat: lock state'",
+            changed=[
+                "app/views/handlers/file_operations.py",
+                "app/views/dialogs/execute_action_dialog.py",
+                "qa/scenarios/s32_lock_protects_from_bulk_regex.py",
+            ],
+        )
+        assert rc == 0
+
+    def test_bypass_token_in_title_skips_check(self, monkeypatch):
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'refactor: rename internal fn [qa-not-needed: pure rename, no behaviour change]'",
+            changed=["app/views/handlers/file_operations.py"],
+        )
+        assert rc == 0
+
+    def test_bypass_token_in_body_skips_check(self, monkeypatch):
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'fix' --body 'whatever [qa-not-needed: sweep] more'",
+            changed=["app/views/dialogs/select_dialog.py"],
+        )
+        assert rc == 0
+
+    def test_malformed_stdin_fails_open(self, monkeypatch):
+        """Hook must not block on parse errors — fail open is safer than
+        blocking every PR if stdin shape ever changes."""
+        mod = _load_hook(monkeypatch)
+        monkeypatch.setattr(sys, "stdin", io.StringIO("not json"))
+        assert mod.main() == 0
+
+    def test_non_bash_tool_passes(self, monkeypatch):
+        mod = _load_hook(monkeypatch)
+        payload = json.dumps(
+            {"tool_name": "Read", "tool_input": {"file_path": "x"}}
+        )
+        monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
+        monkeypatch.setattr(mod, "_changed_files", lambda: [])
+        assert mod.main() == 0
+
+
+# ── exit 2 paths (block) ──────────────────────────────────────────────────
+
+
+class TestBlock:
+    @pytest.mark.parametrize("user_facing_file", [
+        "app/views/handlers/file_operations.py",
+        "app/views/handlers/context_menu.py",
+        "app/views/dialogs/execute_action_dialog.py",
+        "app/views/dialogs/select_dialog.py",
+        "app/views/dialogs/scan_dialog.py",
+        "app/views/components/menu_controller.py",
+        "app/views/components/status_messages.py",
+        "app/views/workers/scan_worker.py",
+    ])
+    def test_user_facing_change_without_qa_blocks(
+        self, monkeypatch, user_facing_file, capsys
+    ):
+        """Every directory under our user-facing list must trip the guard."""
+        rc = _run(
+            monkeypatch,
+            f"gh pr create --title 'feat: thing'",
+            changed=[user_facing_file, "tests/test_thing.py"],
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "QA-scenario guard" in err
+        assert user_facing_file in err
+        assert "qa-not-needed" in err  # bypass instructions surfaced
+
+    def test_block_message_lists_all_offenders(self, monkeypatch, capsys):
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'feat: lock state'",
+            changed=[
+                "app/views/handlers/file_operations.py",
+                "app/views/dialogs/execute_action_dialog.py",
+                "app/views/handlers/context_menu.py",
+                "tests/test_file_operations.py",  # not user-facing but unrelated
+            ],
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "app/views/handlers/file_operations.py" in err
+        assert "app/views/dialogs/execute_action_dialog.py" in err
+        assert "app/views/handlers/context_menu.py" in err
+
+    def test_test_only_qa_change_does_not_satisfy(self, monkeypatch):
+        """A test file that happens to live under tests/ named test_qa_*.py
+        is NOT a layer-3 driver — only files matching
+        ``qa/scenarios/sNN_*.py`` count."""
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'feat: thing'",
+            changed=[
+                "app/views/dialogs/select_dialog.py",
+                "tests/test_qa_helpers.py",  # NOT a qa/scenarios/ file
+            ],
+        )
+        assert rc == 2
+
+    def test_qa_uia_helper_does_not_satisfy(self, monkeypatch):
+        """``qa/scenarios/_uia.py`` and other ``_*.py`` helpers don't
+        satisfy the rule — must be a numbered ``sNN_*.py`` driver."""
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'feat: thing'",
+            changed=[
+                "app/views/handlers/context_menu.py",
+                "qa/scenarios/_uia.py",
+            ],
+        )
+        assert rc == 2
+
+
+# ── bypass token edge cases ───────────────────────────────────────────────
+
+
+class TestBypassTokenShape:
+    def test_bypass_with_complex_reason_works(self, monkeypatch):
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'x [qa-not-needed: covered by existing s14, no new flow]'",
+            changed=["app/views/handlers/file_operations.py"],
+        )
+        assert rc == 0
+
+    def test_bypass_with_unicode_reason_works(self, monkeypatch):
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'x [qa-not-needed: 翻譯字串更新]'",
+            changed=["app/views/handlers/file_operations.py"],
+        )
+        assert rc == 0
+
+    def test_unclosed_bracket_does_not_count(self, monkeypatch):
+        """Defensive: a malformed token like ``[qa-not-needed: forgot``
+        without closing ``]`` must NOT count as bypass — otherwise an
+        accidental edit could disable enforcement."""
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'x [qa-not-needed: forgot to close'",
+            changed=["app/views/handlers/file_operations.py"],
+        )
+        assert rc == 2
+
+    def test_similar_but_wrong_token_does_not_count(self, monkeypatch):
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'x [qa: not needed]'",
+            changed=["app/views/handlers/file_operations.py"],
+        )
+        assert rc == 2


### PR DESCRIPTION
## Summary

Installs a ``PreToolUse`` hook that blocks ``gh pr create`` when user-facing files changed without a ``qa/scenarios/sNN_*.py`` driver. CLAUDE.md already specifies this rule; this is the enforcement so it isn't a manual-review-checklist item.

Motivation: PR #175 (Locked-state) initially shipped without the s32 layer-3 driver and required a follow-up commit to comply. Hard requirement → hard enforcement.

## How it works

**Detection**:
- ``git diff --name-only origin/master...HEAD``
- User-facing if path matches ``app/views/{handlers,dialogs,components,workers}/.*\.py``
- QA scenario if path matches ``qa/scenarios/s\d+.*\.py``
- Block (exit 2) when user-facing changes exist with no QA scenario change.

**Bypass**: include ``[qa-not-needed: <reason>]`` anywhere in the ``gh pr create`` command (typically in ``--title`` or ``--body``). Reason is part of the PR — the choice is visible in review.

**Fail-open posture**: malformed stdin, missing git remote, or non-Bash tool → exit 0. The hook does not introduce new failure modes.

## What it would have caught

PR #175's first iteration would have surfaced:

```
QA-scenario guard fired — blocking ``gh pr create``.

  user-facing files changed:
    app/views/handlers/file_operations.py
    app/views/handlers/context_menu.py
    app/views/dialogs/execute_action_dialog.py
    app/views/dialogs/select_dialog.py
    app/views/tree_model_builder.py

  no qa/scenarios/sNN_*.py changes in this PR.
  ...
```

## Files

| File | Tracked? | Purpose |
|---|---|---|
| ``scripts/hooks/qa_scenario_guard.py`` | committed | the check, ~95 LOC, no third-party deps |
| ``.claude/settings.json.example`` | committed | hook config; fresh checkouts inherit on the existing copy-from-example step |
| ``tests/test_qa_scenario_guard.py`` | committed | 24 tests pinning allow / block / bypass behaviour |

(Local ``.claude/settings.json`` was also updated on this machine so the hook is live during this session — that file is gitignored per the existing convention.)

## Tests (24 new)

- ``TestAllow`` (8) — non-PR commands, no diff, only-QA-changes, only-test-changes, happy path (user-facing + QA), bypass in title/body, malformed stdin, non-Bash tools.
- ``TestBlock`` (parametrised over 8 user-facing dirs + 3 explicit cases) — block fires for every user-facing directory; message lists all offenders; ``tests/test_qa_*.py`` and ``qa/scenarios/_uia.py`` helpers do NOT satisfy the rule.
- ``TestBypassTokenShape`` (4) — bypass tolerates complex / unicode reasons but rejects unclosed bracket and "similar-but-wrong" tokens (defensive).

## Test plan

- [x] ``pytest tests/`` — 750 passed, 2 skipped (+24 new vs master).
- [x] ``scripts/check_coverage_per_file.py`` — all 37 tracked files clear the 70% per-file floor.
- [x] Hook does not fire on this PR's own diff (only ``scripts/hooks/``, ``.claude/``, ``tests/`` — none user-facing).
- [ ] After merge: next user-facing PR should either include a qa/scenarios driver or carry the bypass token. Catch the next time I forget.

## Out of scope

- Updating CLAUDE.md to mention the hook — the rule is already there in the testing-strategy section; the hook's stderr message points at the same source of truth so the doc and the hook can't drift.
- Per-author / per-branch bypass — the bypass token is the only escape hatch by design.