### PR TITLE
ci: run qa-batch on every PR (drop paths filter)

### DIFF
--- a/.github/workflows/qa-batch.yml
+++ b/.github/workflows/qa-batch.yml
@@ -1,9 +1,15 @@
 name: qa-batch
 
-# Run the layer-3 qa-explore batch on PRs that touch UI / scanner / qa surface.
-# Goal: catch driver-vs-app label drift and state-transition regressions
-# before merge, instead of relying on a manual `python -m qa.scenarios._batch`
-# discipline (#74).
+# Run the layer-3 qa-explore batch on every PR. Goal: catch driver-vs-app
+# label drift and state-transition regressions before merge, instead of
+# relying on a manual `python -m qa.scenarios._batch` discipline (#74).
+#
+# No `paths:` filter — the principle is "every PR, every check." Tooling /
+# docs / hook PRs pay the runner cost (~15–20 min on windows-latest) for
+# the consistency of a single uniform CI posture. Same shape as
+# .github/workflows/tests.yml. If runner cost ever bites, the right fix
+# is to make the batch faster (parallelise scenarios, prune slow ones),
+# not to silently skip it on a class of PRs.
 #
 # Status: NON-REQUIRED, informational. Per #74's acceptance criteria, this
 # workflow needs ≥10 consecutive flake-free runs on real PRs before being
@@ -12,17 +18,7 @@ name: qa-batch
 
 on:
   pull_request:
-    paths:
-      - '.github/workflows/qa-batch.yml'
-      - 'app/views/**'
-      - 'qa/**'
-      - 'scanner/**'
-      - 'infrastructure/**'
-      - 'requirements.txt'
-      - 'dev-requirements.txt'
-      - 'qa/requirements.txt'
-      - 'scripts/make_qa_sandbox.py'
-      - 'scripts/make_qa_images.py'
+    branches: [master]
   workflow_dispatch: {}   # allow manual trigger from the Actions UI for debugging
 
 concurrency:


### PR DESCRIPTION
## Summary

The qa-batch workflow had a ``paths:`` allowlist that silently skipped PRs touching only tooling / hooks / docs / ``.claude/`` / ``.github/``. That created two-tier CI — feature PRs got layer-3 vetting; tooling PRs didn't — even though tooling PRs occasionally break things in ways the path filter cannot see.

Drop the filter so qa-batch runs on every PR, matching the posture of [tests.yml](.github/workflows/tests.yml) (which has no path filter and runs everywhere).

Surfaced during PR #176 review: a hook / tooling PR shipped without qa-batch running, prompting the question "shouldn't all CI apply to all PRs?". Yes — this lands that.

## Diff

One file: ``.github/workflows/qa-batch.yml``.

```diff
 on:
   pull_request:
-    paths:
-      - '.github/workflows/qa-batch.yml'
-      - 'app/views/**'
-      - 'qa/**'
-      - 'scanner/**'
-      - 'infrastructure/**'
-      - 'requirements.txt'
-      - 'dev-requirements.txt'
-      - 'qa/requirements.txt'
-      - 'scripts/make_qa_sandbox.py'
-      - 'scripts/make_qa_images.py'
+    branches: [master]
```

Plus an updated leading comment explaining the "every PR, every check" principle and the trade-offs.

## Trade-offs

| Concern | Mitigation |
|---|---|
| ~15–20 min runner cost on every PR including tooling / docs | Acknowledged. The right answer to "qa-batch is too slow" is to make it faster (parallelise scenarios, prune slow ones), not to silently skip it on a class of PRs. |
| More runs of a still-stabilising suite → more flake exposure | Per the existing comment, qa-batch is still NON-REQUIRED until #74's "≥10 flake-free runs" criterion is met. A red qa-batch is a signal to investigate, not a merge blocker. |
| Required-check readiness | Removing the filter is a step toward "qa-batch as a required check" — the filter would have made required-status awkward (skipped runs ≠ passed). Now it's clean: every PR has a qa-batch result. |

## Test plan

- [x] Workflow YAML still parses (no syntax change beyond the path-block removal).
- [x] qa-scenario-guard hook (#176) does not fire on this PR — diff is ``.github/workflows/qa-batch.yml`` only, none of the user-facing patterns match. Hook passes silently.
- [ ] After merge: this PR's own qa-batch run will be the first under the new posture. If it greens on a workflow-only diff, posture is correct.

## Out of scope

- Promoting qa-batch to required-check status — separate decision, separate PR; needs the flake-free-runs metric.
- Speeding up qa-batch (parallelisation, pruning) — orthogonal optimisation.
- Adding a ``[skip qa-batch]`` opt-out token for emergency hotfixes — explicitly NOT added; the principle here is no opt-outs.