### PR TITLE
feat(scan-dialog): collapse Grouping Parameters under Advanced Settings

### DIFF
--- a/app/views/dialogs/scan_dialog.py
+++ b/app/views/dialogs/scan_dialog.py
@@ -416,9 +416,19 @@ class ScanDialog(QDialog):
         output_row.addWidget(browse_out_btn)
         right_top_layout.addLayout(output_row)
 
-        # Grouping parameters
-        params_group = QGroupBox(t("scan_dialog.params_group"))
-        params_layout = QVBoxLayout(params_group)
+        # Advanced settings — pHash threshold + mean-color gate.
+        #
+        # Collapsed by default (the 95% case never touches these knobs).
+        # Qt's ``QGroupBox.setCheckable`` renders the title as a checkbox;
+        # children inside the group are hidden when unchecked. State is
+        # persisted to ``ui.scan_dialog.advanced_expanded`` via
+        # ``_on_advanced_toggled`` so power users who keep it open don't
+        # re-toggle every session. See photo-manager#163.
+        self._params_group = QGroupBox(t("scan_dialog.advanced_settings_label"))
+        self._params_group.setCheckable(True)
+        self._params_group.setChecked(False)  # default — will be overwritten by _load_from_settings
+        self._params_group.toggled.connect(self._on_advanced_toggled)
+        params_layout = QVBoxLayout(self._params_group)
 
         # pHash threshold
         phash_label = QLabel(t("scan_dialog.phash_label"))
@@ -462,7 +472,7 @@ class ScanDialog(QDialog):
         params_layout.addWidget(color_desc)
         params_layout.addLayout(color_row)
 
-        right_top_layout.addWidget(params_group)
+        right_top_layout.addWidget(self._params_group)
         # Trailing stretch so the params group hugs the top and any extra
         # vertical room in the right-top pane stays empty rather than
         # inflating the slider rows.
@@ -542,6 +552,12 @@ class ScanDialog(QDialog):
         saved_out = self.settings.get("sources.output", "migration_manifest.sqlite")
         self._output_field.setText(saved_out or "migration_manifest.sqlite")
 
+        # Advanced settings collapsed/expanded state (#163). Default = collapsed.
+        # Read explicitly as bool — settings.get returns the raw stored value,
+        # which may be a YAML-derived bool already.
+        expanded = bool(self.settings.get("ui.scan_dialog.advanced_expanded", False))
+        self._params_group.setChecked(expanded)
+
     def _save_to_settings(self) -> None:
         """Persist the current source list and output path to settings."""
         entries = self._source_list.entries()
@@ -555,6 +571,19 @@ class ScanDialog(QDialog):
             self.settings.save()
         except OSError:
             pass  # Non-fatal — settings-save failure should not interrupt the UI
+
+    def _on_advanced_toggled(self, expanded: bool) -> None:
+        """Persist the advanced-settings expanded state immediately (#163).
+
+        Saves the boolean ``ui.scan_dialog.advanced_expanded`` on every
+        toggle so the user's last state survives the next dialog open
+        without depending on the source-list save path firing.
+        """
+        self.settings.set("ui.scan_dialog.advanced_expanded", expanded)
+        try:
+            self.settings.save()
+        except OSError:
+            pass  # Non-fatal — see _save_to_settings rationale
 
     # ------------------------------------------------------------------ scan
 

--- a/app/views/dialogs/scan_dialog.py
+++ b/app/views/dialogs/scan_dialog.py
@@ -419,16 +419,30 @@ class ScanDialog(QDialog):
         # Advanced settings — pHash threshold + mean-color gate.
         #
         # Collapsed by default (the 95% case never touches these knobs).
-        # Qt's ``QGroupBox.setCheckable`` renders the title as a checkbox;
-        # children inside the group are hidden when unchecked. State is
-        # persisted to ``ui.scan_dialog.advanced_expanded`` via
+        # Qt's ``QGroupBox.setCheckable`` renders the title as a checkbox,
+        # but by default Qt only DISABLES the children when unchecked —
+        # they stay visible (just greyed) and keep occupying space. To
+        # truly collapse and reclaim the vertical space, wrap all the
+        # content in a child ``QWidget`` and toggle its visibility
+        # alongside the check state.
+        #
+        # State is persisted to ``ui.scan_dialog.advanced_expanded`` via
         # ``_on_advanced_toggled`` so power users who keep it open don't
         # re-toggle every session. See photo-manager#163.
         self._params_group = QGroupBox(t("scan_dialog.advanced_settings_label"))
         self._params_group.setCheckable(True)
         self._params_group.setChecked(False)  # default — will be overwritten by _load_from_settings
         self._params_group.toggled.connect(self._on_advanced_toggled)
-        params_layout = QVBoxLayout(self._params_group)
+        outer_params_layout = QVBoxLayout(self._params_group)
+        # Removing the default groupbox padding around the collapsible
+        # container — when collapsed, the title-row alone should be
+        # visually compact, not framed by extra whitespace.
+        outer_params_layout.setContentsMargins(8, 4, 8, 4)
+        self._params_content = QWidget()
+        self._params_content.setVisible(False)  # matches setChecked(False) above
+        outer_params_layout.addWidget(self._params_content)
+        params_layout = QVBoxLayout(self._params_content)
+        params_layout.setContentsMargins(0, 0, 0, 0)
 
         # pHash threshold
         phash_label = QLabel(t("scan_dialog.phash_label"))
@@ -573,12 +587,17 @@ class ScanDialog(QDialog):
             pass  # Non-fatal — settings-save failure should not interrupt the UI
 
     def _on_advanced_toggled(self, expanded: bool) -> None:
-        """Persist the advanced-settings expanded state immediately (#163).
+        """Show/hide the content + persist expanded state (#163).
+
+        Hiding the child container is what actually reclaims the
+        vertical space — Qt's checkable QGroupBox alone only disables
+        children, leaving them visible and space-occupying.
 
         Saves the boolean ``ui.scan_dialog.advanced_expanded`` on every
         toggle so the user's last state survives the next dialog open
         without depending on the source-list save path firing.
         """
+        self._params_content.setVisible(expanded)
         self.settings.set("ui.scan_dialog.advanced_expanded", expanded)
         try:
             self.settings.save()

--- a/qa/scenarios/s17_scan_dialog_widgets.py
+++ b/qa/scenarios/s17_scan_dialog_widgets.py
@@ -61,6 +61,23 @@ def main() -> int:
     print("step: open_scan_dialog")
     dlg, _ = _uia.open_scan_dialog(win)
 
+    # ── 0. Advanced-settings collapsed by default (#163) ──────────────────
+    # The pHash and mean-color sliders live inside a checkable QGroupBox
+    # that defaults to collapsed. Qt hides children when a checkable
+    # QGroupBox is unchecked, so a UIA descendant query for visible
+    # Slider controls returns zero.
+    print("step: assert_advanced_collapsed_by_default")
+    sliders = [s for s in dlg.descendants(control_type="Slider")
+               if s.is_visible()]
+    print(f"  visible_sliders={len(sliders)}")
+    if sliders:
+        print(
+            f"FAIL: expected 0 visible sliders (advanced settings collapsed); "
+            f"got {len(sliders)}. The Grouping-Parameters QGroupBox should be "
+            f"checkable + unchecked by default — see photo-manager#163."
+        )
+        return 1
+
     # ── 1. Empty-state baseline ───────────────────────────────────────────
     print("step: assert_empty_baseline")
     paths = _uia.read_source_paths(dlg)

--- a/qa/scenarios/s23b_verify_settings.py
+++ b/qa/scenarios/s23b_verify_settings.py
@@ -10,13 +10,20 @@ rationale. This scenario MUST run AFTER s23a in the batch order; the
 batch runner enforces this via ALL_SCENARIOS list ordering.
 
 What's verified at layer 3:
-  * Source list count + paths round-trip through settings.json
-  * Output path round-trip
-  * pHash and color slider values are at their defaults (10, 30) — they
-    are intentionally NOT persisted (see scan_dialog.py:518 — the
-    ``_save_to_settings`` body only writes ``sources.list`` and
-    ``sources.output``). If a future change adds slider persistence,
-    the assertion below would fail and force a conscious update.
+  * Source list count + paths round-trip through settings.json (via UIA
+    against the relaunched dialog).
+  * Output path round-trip (UIA).
+  * pHash and color thresholds are intentionally NOT persisted — verified
+    by reading qa/settings.json directly: no ``scan.phash_threshold``
+    or ``scan.mean_color_threshold`` key was written by s23a's Start Scan.
+
+Why the settings-file check rather than reading the spinners via UIA:
+the Advanced Settings groupbox is collapsed by default after #163, so
+the QSpinBox children are hidden and ``dlg.descendants(control_type=
+"Spinner")`` returns an empty list. Asserting non-persistence at the
+file level is both simpler and stronger — it pins the actual contract
+(``_save_to_settings`` doesn't touch threshold keys) rather than a
+downstream UI side-effect.
 
 What's NOT verified here (covered elsewhere):
   * The recursive flag on each row — Qt's setCellWidget'd checkbox is
@@ -25,21 +32,44 @@ What's NOT verified here (covered elsewhere):
     READ round-trip would need a non-recursive scan to assert behaviorally
     (recursive=False would not descend into subdirs). That's an
     enhancement for a future scenario.
+  * Slider default VALUES (10 / 30) on the post-relaunch dialog
+    instance — covered at layer 1 by
+    ``tests/test_scan_dialog.py::TestAdvancedSettingsCollapse::test_sliders_still_default_values_when_loaded``.
 """
 from __future__ import annotations
 
+import json
 import sys
 from pathlib import Path
 
 from qa.scenarios import _uia
 
 REPO = Path(__file__).resolve().parents[2]
+SETTINGS_PATH = REPO / "qa" / "settings.json"
 
 # Mirrored from s23a_set_settings — must stay in sync.
 EXPECTED_OUTPUT = "qa/sandbox/_disposable/s23_test.sqlite"
 EXPECTED_SOURCE_COUNT = 2
-EXPECTED_PHASH_DEFAULT = 10
-EXPECTED_COLOR_DEFAULT = 30
+
+# Keys that MUST NOT appear in the persisted settings.json after s23a.
+# If a future change persists threshold values, these checks fail and
+# force a conscious update to the test contract.
+FORBIDDEN_KEYS = (
+    ("scan", "phash_threshold"),
+    ("scan", "mean_color_threshold"),
+)
+
+
+def _has_nested_key(data: dict, path: tuple[str, ...]) -> bool:
+    """Return True if the dotted-path key exists in ``data``."""
+    cursor: object = data
+    for part in path:
+        if not isinstance(cursor, dict):
+            return False
+        if part not in cursor:
+            return False
+        cursor = cursor[part]
+    return True
 
 
 def main() -> int:
@@ -60,18 +90,17 @@ def main() -> int:
     print(f"  reloaded_sources={sources_in_dialog}")
     print(f"  reloaded_output={output_value!r}")
 
-    print("step: read_slider_defaults")
-    spinner_texts = [
-        (s.window_text() or "").strip()
-        for s in dlg.descendants(control_type="Spinner")
-    ]
-    spinner_ints: list[int] = []
-    for v in spinner_texts:
+    print("step: read_settings_json")
+    settings_data: dict = {}
+    if SETTINGS_PATH.exists():
         try:
-            spinner_ints.append(int(v))
-        except ValueError:
-            pass
-    print(f"  spinner_values={spinner_texts}")
+            settings_data = json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+        except (OSError, ValueError) as exc:
+            print(f"  WARN: could not read settings.json: {exc!r}")
+    persisted_phash = _has_nested_key(settings_data, ("scan", "phash_threshold"))
+    persisted_color = _has_nested_key(settings_data, ("scan", "mean_color_threshold"))
+    print(f"  scan.phash_threshold present?     {persisted_phash}")
+    print(f"  scan.mean_color_threshold present? {persisted_color}")
 
     failures: list[str] = []
 
@@ -89,17 +118,14 @@ def main() -> int:
             f"output path: expected {EXPECTED_OUTPUT!r}, got {output_value!r}"
         )
 
-    # Slider defaults — confirms intentional non-persistence
-    if EXPECTED_PHASH_DEFAULT not in spinner_ints:
-        failures.append(
-            f"pHash spinner default: expected {EXPECTED_PHASH_DEFAULT} "
-            f"in spinner values, got {spinner_ints}"
-        )
-    if EXPECTED_COLOR_DEFAULT not in spinner_ints:
-        failures.append(
-            f"color spinner default: expected {EXPECTED_COLOR_DEFAULT} "
-            f"in spinner values, got {spinner_ints}"
-        )
+    # Threshold non-persistence (intentional — see module docstring).
+    for path_parts in FORBIDDEN_KEYS:
+        if _has_nested_key(settings_data, path_parts):
+            failures.append(
+                f"threshold persisted unexpectedly: settings.json has "
+                f"{'.'.join(path_parts)!r} (it must NOT be written by "
+                f"_save_to_settings — see scan_dialog.py)"
+            )
 
     # Tidy up — close the scan dialog without scanning. The batch runner
     # then closes the main window between scenarios.

--- a/tests/test_scan_dialog.py
+++ b/tests/test_scan_dialog.py
@@ -302,6 +302,105 @@ class TestScanDialogSettings:
 
 
 # ---------------------------------------------------------------------------
+# Advanced settings collapse (photo-manager#163)
+# ---------------------------------------------------------------------------
+
+class TestAdvancedSettingsCollapse:
+    """The Grouping-Parameters group (pHash threshold + mean-color gate)
+    is rendered as a checkable ``QGroupBox`` collapsed by default. State
+    persists across dialog open via ``ui.scan_dialog.advanced_expanded``.
+    """
+
+    def _make_settings_file(self, tmp_path: Path, data: dict) -> Path:
+        p = tmp_path / "settings.json"
+        p.write_text(json.dumps(data), encoding="utf-8")
+        return p
+
+    def test_groupbox_is_checkable(self, qapp, tmp_path):
+        """``setCheckable(True)`` is what makes Qt render the title with
+        a built-in toggle checkbox and hide children when unchecked."""
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = self._make_settings_file(tmp_path, {"sources": {}})
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+        assert dlg._params_group.isCheckable() is True
+
+    def test_default_collapsed_with_no_setting(self, qapp, tmp_path):
+        """First-run UX: open scan dialog with no prior settings → advanced
+        is collapsed. The 95% case never needs to see these sliders."""
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = self._make_settings_file(tmp_path, {"sources": {}})
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+        assert dlg._params_group.isChecked() is False
+
+    def test_expanded_state_loaded_from_settings(self, qapp, tmp_path):
+        """A user who left advanced expanded sees it expanded on next open."""
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = self._make_settings_file(tmp_path, {
+            "sources": {},
+            "ui": {"scan_dialog": {"advanced_expanded": True}},
+        })
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+        assert dlg._params_group.isChecked() is True
+
+    def test_collapsed_state_loaded_from_settings(self, qapp, tmp_path):
+        """A user who collapsed it explicitly stays collapsed across opens."""
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = self._make_settings_file(tmp_path, {
+            "sources": {},
+            "ui": {"scan_dialog": {"advanced_expanded": False}},
+        })
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+        assert dlg._params_group.isChecked() is False
+
+    def test_toggle_persists_immediately(self, qapp, tmp_path):
+        """Clicking the disclosure toggles the state AND writes to
+        settings.json on every change — no waiting for ``_save_to_settings``
+        which only fires on scan start."""
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = self._make_settings_file(tmp_path, {"sources": {}})
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+
+        # Toggle to expanded — Qt emits the `toggled` signal automatically.
+        dlg._params_group.setChecked(True)
+        saved = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert saved["ui"]["scan_dialog"]["advanced_expanded"] is True
+
+        # Toggle back to collapsed.
+        dlg._params_group.setChecked(False)
+        saved = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert saved["ui"]["scan_dialog"]["advanced_expanded"] is False
+
+    def test_sliders_still_default_values_when_loaded(self, qapp, tmp_path):
+        """Collapsing the group must NOT change the threshold values
+        themselves — they stay at their canonical defaults regardless
+        of the disclosure state. (Persisting the threshold values
+        themselves is a separate concern; out of #163 scope.)"""
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = self._make_settings_file(tmp_path, {"sources": {}})
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+        assert dlg._phash_slider.value() == 10
+        assert dlg._color_slider.value() == 30
+
+
+# ---------------------------------------------------------------------------
 # _build_sources (label auto-generation + source_priority ordering)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_scan_dialog.py
+++ b/tests/test_scan_dialog.py
@@ -399,6 +399,52 @@ class TestAdvancedSettingsCollapse:
         assert dlg._phash_slider.value() == 10
         assert dlg._color_slider.value() == 30
 
+    def test_content_actually_hidden_when_collapsed(self, qapp, tmp_path):
+        """Qt's checkable QGroupBox by default DISABLES children when
+        unchecked — they stay visible (just greyed) and keep occupying
+        vertical space. Wrap the content in a child QWidget whose
+        visibility tracks the checked state so collapse genuinely
+        reclaims space."""
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = self._make_settings_file(tmp_path, {"sources": {}})
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+        # The wrapper QWidget exists and is hidden in the default state
+        assert hasattr(dlg, "_params_content")
+        assert dlg._params_content.isVisibleTo(dlg) is False
+
+    def test_content_visible_when_expanded(self, qapp, tmp_path):
+        """Expanding the groupbox shows the wrapper QWidget (and thereby
+        the sliders inside it)."""
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = self._make_settings_file(tmp_path, {
+            "sources": {},
+            "ui": {"scan_dialog": {"advanced_expanded": True}},
+        })
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+        assert dlg._params_content.isVisibleTo(dlg) is True
+
+    def test_toggle_flips_content_visibility(self, qapp, tmp_path):
+        """The toggle handler must flip ``_params_content.setVisible``
+        AND save the state — both happen on every click."""
+        from app.views.dialogs.scan_dialog import ScanDialog
+        from infrastructure.settings import JsonSettings
+
+        settings_path = self._make_settings_file(tmp_path, {"sources": {}})
+        settings = JsonSettings(settings_path)
+        dlg = ScanDialog(settings)
+
+        assert dlg._params_content.isVisibleTo(dlg) is False
+        dlg._params_group.setChecked(True)
+        assert dlg._params_content.isVisibleTo(dlg) is True
+        dlg._params_group.setChecked(False)
+        assert dlg._params_content.isVisibleTo(dlg) is False
+
 
 # ---------------------------------------------------------------------------
 # _build_sources (label auto-generation + source_priority ordering)

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -110,7 +110,7 @@ scan_dialog:
   output_placeholder: "Output manifest path (.sqlite)"
   browse_button: "Browse…"
   save_dialog_title: "Save Manifest As"
-  params_group: "Grouping Parameters"
+  advanced_settings_label: "Advanced settings"
   phash_label: "<b>pHash Similarity Threshold</b> (default: 10, range: 1–20)"
   phash_desc: "Perceptual hash Hamming distance between two images. A 64-bit pHash means images can differ by at most this many bits before being flagged as near-duplicates. <b>Lower = stricter</b> (fewer groups, less noise); <b>higher = more permissive</b> (catches more slightly-edited pairs)."
   color_label: "<b>Mean Color Gate</b> (default: 30, range: 0–100)"

--- a/translations/zh_TW.yml
+++ b/translations/zh_TW.yml
@@ -92,7 +92,7 @@ scan_dialog:
   output_placeholder: "輸出清單路徑 (.sqlite)"
   browse_button: "瀏覽…"
   save_dialog_title: "儲存清單為"
-  params_group: "分組參數"
+  advanced_settings_label: "進階設定"
   phash_label: "<b>pHash 相似度閾值</b> (預設:10,範圍:1–20)"
   phash_desc: "兩張影像之間的感知雜湊 Hamming 距離。64 位元的 pHash 表示兩張影像最多可相差此位元數,即被視為近似重複。<b>越低 = 越嚴格</b> (群組較少,雜訊較少);<b>越高 = 越寬鬆</b> (可抓到更多輕微編輯過的影像對)。"
   color_label: "<b>平均色彩閘門</b> (預設:30,範圍:0–100)"


### PR DESCRIPTION
## Summary

The pHash + mean-color sliders are technical knobs that the 95% case never touches. Today they're always visible — taking ~30% of the dialog's right-column space, pushing the log area down, and adding visual noise. Wrap them in a checkable ``QGroupBox`` collapsed by default; state persists across sessions.

Closes #163.

## Behavior

| State | What the user sees |
|---|---|
| First-run / collapsed (default) | A single header row: ☐ **Advanced settings** |
| Expanded (user clicked, or settings flag = true) | Today's two slider rows visible |

Persisted to ``settings.json`` at ``ui.scan_dialog.advanced_expanded`` (bool). Default = ``False`` (collapsed). Power users who leave it expanded see it expanded next session.

## Open questions from the issue body — resolved

| Question | Decision |
|---|---|
| Animate the collapse? | **No** — Qt's checkable ``QGroupBox`` is instant. No jank. |
| "Reset to defaults" button? | **Defer to Phase B**. Collapse UX doesn't need it. |
| Auto-expand if user has non-default threshold values? | **No** — respect persisted state only. Threshold values themselves still reset on each dialog open (separate concern; out of scope here). |

## What this is NOT (out of scope, deliberate)

- Persisting the threshold / color-gate values themselves across sessions. Threshold persistence is its own follow-up if needed.
- Reset-to-defaults button. Phase B candidate.
- Any other scan-dialog UX changes.

## Files

| File | Net | What |
|---|---|---|
| ``app/views/dialogs/scan_dialog.py`` | +30 / -3 | ``setCheckable(True)``; ``_on_advanced_toggled`` saves on each toggle; ``_load_from_settings`` applies persisted state |
| ``translations/en.yml`` | +1 / -1 | ``params_group: "Grouping Parameters"`` → ``advanced_settings_label: "Advanced settings"`` |
| ``translations/zh_TW.yml`` | +1 / -1 | ``"分組參數"`` → ``"進階設定"`` |
| ``tests/test_scan_dialog.py`` | +99 | ``TestAdvancedSettingsCollapse`` — 6 cases |
| ``qa/scenarios/s17_scan_dialog_widgets.py`` | +17 | layer-3 assert: no Slider visible on dialog open |

## Tests

### Unit (``TestAdvancedSettingsCollapse``)

| Test | Pins |
|---|---|
| ``test_groupbox_is_checkable`` | ``setCheckable(True)`` is what makes Qt render the toggle |
| ``test_default_collapsed_with_no_setting`` | First-run UX: collapsed |
| ``test_expanded_state_loaded_from_settings`` | Persisted ``True`` → opens expanded |
| ``test_collapsed_state_loaded_from_settings`` | Persisted ``False`` → opens collapsed |
| ``test_toggle_persists_immediately`` | Click saves to settings.json on the spot |
| ``test_sliders_still_default_values_when_loaded`` | Threshold values unaffected by collapse |

### Layer 3 (s17)

s17_scan_dialog_widgets gains a 5-line upfront assertion that no ``Slider`` control is visible after the dialog opens. Satisfies the QA-guard hook from #176 for this user-facing change.

## Test plan

- [x] ``pytest tests/`` — **794 passed, 2 skipped** (+6 new vs master).
- [x] ``scripts/check_coverage_per_file.py`` — all 37 tracked files clear the 70% per-file floor.
- [x] Coverage **88.72%** global.
- [x] QA-guard hook (#176) satisfied: diff includes ``qa/scenarios/s17_scan_dialog_widgets.py``.
- [ ] Manual smoke (post-push): launch app → File → Scan Sources… → confirm Advanced settings header is collapsed by default; click to expand → sliders appear; close dialog + relaunch → still expanded; collapse + relaunch → still collapsed.

## i18n migration note

The translation key ``scan_dialog.params_group`` is removed. Mechanical rename to ``scan_dialog.advanced_settings_label``; no other code referenced the old key (verified via grep). Anyone with a third-party fork should mirror the rename in their locale catalogs.