### PR TITLE
chore(ci): add monthly pip-audit workflow (#69)

### DIFF
--- a/.github/workflows/pip-audit.yml
+++ b/.github/workflows/pip-audit.yml
@@ -1,0 +1,29 @@
+name: pip-audit
+
+on:
+  schedule:
+    # Monthly on the 1st at 06:00 UTC
+    - cron: '0 6 1 * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Run pip-audit (requirements.txt + dev-requirements.txt)
+        uses: pypa/gh-action-pip-audit@v1.1.0
+        with:
+          inputs: |
+            requirements.txt
+            dev-requirements.txt

--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ enforced by `scripts/check_coverage_per_file.py`, run as a CI step
 right after `pytest`). CI runs this on every push and pull request to
 `master` via `.github/workflows/tests.yml`.
 
+A separate monthly job (`.github/workflows/pip-audit.yml`) runs
+`pip-audit` against `requirements.txt` + `dev-requirements.txt` on the
+1st of each month plus on-demand via `workflow_dispatch`; failure = a
+known CVE was found against a pinned dependency.
+
 Two more test layers exist locally:
 
 ```powershell


### PR DESCRIPTION
## Summary
- New `.github/workflows/pip-audit.yml` — runs `pip-audit` against `requirements.txt` + `dev-requirements.txt` on a monthly schedule (1st of the month, 06:00 UTC) plus `workflow_dispatch` for on-demand.
- README testing section gets a one-liner pointing at the new workflow.
- Replaces the manual-reminder approach #69 was tracking; workflow failure surfaces any known CVE against a pinned dependency.

## Behavior
- Uses [`pypa/gh-action-pip-audit@v1.1.0`](https://github.com/pypa/gh-action-pip-audit) — official PyPA action.
- Permissions: `contents: read`, `issues: write` (reserved for a future "auto-file issue on finding" step; not used today).
- Clean runs: silent green check in the Actions tab.
- CVE found: workflow goes red, standard GitHub workflow-failure notification fires.

## Test plan
- [ ] Workflow file parses (GitHub validates on push to the branch — this happens automatically before merge).
- [ ] Trigger one manual run via Actions → pip-audit → Run workflow after merge to confirm the action resolves and runs end-to-end against the current pinned deps.
- [ ] If the manual run is green: leave it; next auto-fire is the 1st of next month.
- [ ] If the manual run is red: that's a real CVE — file as a follow-up.

Closes #69