### PR TITLE
chore(skill): rename parallel-fanout to parallel-brief-generator + refine

### DIFF
--- a/.claude/skills/parallel-brief-generator/SKILL.md
+++ b/.claude/skills/parallel-brief-generator/SKILL.md
@@ -1,55 +1,62 @@
 ---
-name: parallel-fanout
-description: Generate self-contained briefs for N cold Claude Code desktop sessions to work in parallel on N file-disjoint tasks. The orchestrator session (where this skill is invoked) does cross-bundle coordination — file-scope collision check, scenario slot pre-assignment, base SHA pinning — and outputs N copy-paste-ready prompts. Each prompt goes into a fresh "+ New session" → Select folder; the desktop app auto-creates a worktree per session, so the cold sessions are truly isolated. Use this when the user wants to ship multiple unrelated issues at once ("fan out X, Y, Z in parallel", "work on these N issues at the same time", "ship the status-bar bundle and the scan-dialog fix in parallel"), or when scope is file-disjoint and serializing would just waste wall-clock time. Do NOT use for: a single task (no coordination needed — just paste the task into a new session), or tasks where one depends on another merging first.
+name: parallel-brief-generator
+description: Generate self-contained briefs for one or more cold Claude Code desktop sessions that will work in isolated parallel worktrees. The orchestrator session (where this skill is invoked) takes the user's high-level intent, researches each task independently via `gh issue view` + codebase Read/Grep, runs pre-flight (clean tree, base SHA pin, `.worktreeinclude` check, scenario slot pre-assignment, file-disjoint collision matrix), and outputs N copy-paste-ready prompts. The user pastes each into a fresh "+ New session" with the "create worktree" option enabled so each session is truly isolated — never sees, never touches the others' work. Use whenever the user wants to scope out one or more issues for cold-session work; single-task input is valid (the cross-bundle steps are no-ops at N=1) and parallel multi-issue is the primary use case. Triggers include "fan out X, Y, Z in parallel", "brief out these issues", "generate work brief for #N", "prepare a cold session to do …", "ship the status-bar bundle and the scan-dialog fix in parallel".
 ---
 
-# parallel-fanout — brief generator for parallel desktop sessions
+# parallel-brief-generator — briefs for isolated parallel sessions
 
 ## What this skill actually does
 
-The Claude Code desktop app creates a git worktree for every new
-session automatically (under `.claude/worktrees/<session-name>/`).
-That means the parallelism mechanism is built in: open N "+ New
-session" windows on the same project, and you have N isolated
-worktrees with N independent contexts, no orchestration overhead.
+The Claude Code desktop app can create a git worktree per session
+(under `.claude/worktrees/<session-name>/`) when the user enables
+the "create worktree" option at session-open time. That gives true
+isolation: each session has its own checkout, own branch, own
+context — never sees the others' work.
 
-But N cold sessions can't coordinate with each other. They share no
-state at startup. So three things still need a single orchestrator:
+But cold sessions can't coordinate with each other. They share no
+state at startup. So a few things still need a single orchestrator:
 
-1. **File-scope collision check** — if Bundle A and Bundle B both
-   plan to edit `main_window.py`, you want to know before fanning,
-   so the second-merged branch's rebase cost is named up-front (not
-   discovered at PR-merge time).
-2. **Scenario slot pre-assignment** — if two cold sessions both grab
+1. **Per-task research** — the user gives high-level intent ("brief
+   #144" or "fan out the status bar bundle and scan dialog fix"),
+   not pre-digested specs. The orchestrator runs `gh issue view`,
+   reads issue bodies, Greps the codebase for the cited files, and
+   builds a concrete task spec for each.
+2. **File-scope collision check** — if Bundle A and Bundle B both
+   plan to edit `main_window.py`, name the overlap up-front so the
+   second-merged branch's rebase cost is visible at fan-out time,
+   not discovered at PR-merge time.
+3. **Scenario slot pre-assignment** — if two cold sessions both grab
    `qa/scenarios/s37_*.py`, you get a name collision at PR time.
-   Hand out s37, s38, s39 in advance.
-3. **Base SHA pinning** — all N sessions branch off the same commit,
+   Hand out s37, s38, s39 in advance from the first free slot.
+4. **Base SHA pinning** — all sessions branch off the same commit,
    so their work is comparable and merge-order-flexible.
 
-This skill, run in the orchestrator session, does those three things
-and **emits N briefs** — self-contained prompts you paste into cold
-sessions. Each brief tells its session everything it needs (the
-pre-flight checks, the task spec, the project conventions, the
-through-PR workflow) without any reference back to this conversation.
+This skill, run in the orchestrator session, does those things and
+**emits one brief per task** — self-contained prompts the user
+pastes into cold sessions. Each brief tells its session everything
+it needs (the pre-flight checks, the task spec, the project
+conventions, the through-PR workflow) without any reference back to
+the orchestrator. Single-task input is valid; the cross-bundle
+steps (collision check, slot pre-assignment) are no-ops at N=1, but
+the research and brief-template benefits still apply.
 
 ## When to use vs when to skip
 
-Fan out when:
-- **Scope is file-disjoint** — agents editing different files in
-  different modules won't conflict.
-- **Tasks share no API surface** — if two bundles both extend
-  `DeleteResult`, fan out one, do the other after.
-- **You have ≥2 independent items** and serial would mostly be idle
-  wait.
+Use this skill whenever:
+- **Multiple independent items** the user wants briefed for parallel
+  work, especially file-disjoint scope.
+- **One task the user wants written up as a hardened brief** with
+  pre-flight baked in (e.g., they'll paste it into a new session
+  later or share it with another developer).
 
-Skip the skill (just open one session) when:
-- **You only have one task.** Open a session, work, ship. No skill
-  needed.
-- **One task's design depends on another's outcome** — e.g. #68 (UI
-  bucket split) depends on #165 (execute-dialog redesign). Fan-out
-  wastes the loser's work.
-- **A shared module is about to change shape.** Pick the larger one
-  first, merge it, then fan out the rest off the new master.
+Skip the skill (prompt the new session directly) when:
+- The task is trivial (one-line config edit) and a full brief is
+  ceremony, OR
+- The user already has the task spec in their head and wants to
+  just open the session and start typing, OR
+- One task's design depends on another's outcome — e.g. #68 (UI
+  bucket split) depends on #165 (execute-dialog redesign). Brief out
+  one; defer the other until the design lands.
 
 ## Required one-time repo setup
 
@@ -71,22 +78,45 @@ broken worktree config.
 
 ## Orchestrator workflow
 
-### Step 1 — Gather inputs
+### Step 1 — Understand intent and research independently
 
-Before generating briefs, get from the user (or infer from
-conversation):
+The user gives high-level intent, not pre-digested task details.
+Typical inputs:
 
-1. **Task list** — N concrete tasks. For each: issue numbers,
-   one-line summary, files/modules expected to be in scope.
-2. **Base ref** — usually `master`. Confirm up to date.
-3. **Branch prefix** — `fix/`, `feat/`, `chore/`, `test/` per task type.
-4. **PR pipeline scope** — does each cold session push + open PR
-   end-to-end (default), or stop earlier? Default: full pipeline,
-   with normal per-PR gated confirms in each cold session.
+- `"fan out the status bar bundle and the scan dialog fix"`
+- `"brief out #138+#140, #144, #136+#141"`
+- `"just brief #144 — I want to do it next"`
+- `"prepare a session to tackle the locked-state preview pane idea (#165)"`
 
-If any of these is vague, ask the user. A fan-out where the second
-session has to come back to the user mid-flight to clarify scope is
-worse than the 30 seconds of clarification up-front.
+**Your job is to research the tasks yourself, not ask the user to
+summarize them.** Asking the user to paste in issue bodies is a code
+smell — the issues are right there on the remote.
+
+For each issue mentioned (or implied by bundle name):
+
+1. `gh issue view <N>` — read the body. Extract the user-visible
+   problem, the suggested fix (if any), the files/line numbers the
+   author cited.
+2. If the body cites file paths or line numbers, `Read`/`Grep` those
+   locations to verify currency (the body may be stale relative to
+   master).
+3. If the user names a bundle without numbers ("status bar bundle"),
+   skim `gh issue list --state open --limit 30` and pair the
+   bundle name to issue numbers by topic. The recent conversation
+   history of the project (if available) is the next-best source.
+4. If two open issues plausibly match the user's description, ask
+   ONE clarifying question. Otherwise don't outsource research.
+
+You also need (these are usually trivial to infer):
+
+- **Base ref** — usually `master`. Confirm up to date with
+  `git fetch origin`.
+- **Branch prefix** — `fix/`, `feat/`, `chore/`, `test/` based on
+  task type. Each cold session picks its own slug.
+- **PR pipeline scope** — default: each cold session pushes + opens
+  its own PR end-to-end with the normal per-PR gated confirms. Only
+  override if the user explicitly says "stop at branches, I'll
+  push myself".
 
 ### Step 2 — Cross-bundle pre-flight (orchestrator side)
 
@@ -113,10 +143,15 @@ brief. Template structure:
 
 ```
 You are working on photo-manager issue(s) #<N> in a fresh Claude Code
-desktop session. You have your own auto-worktree under
-`.claude/worktrees/<your-session-name>/`. The orchestrator session
-fanned out parallel work; you have no visibility into the other
-sessions and they have none into you.
+desktop session. If the user opened this session with the
+"create worktree" option enabled, you're in your own auto-worktree
+under `.claude/worktrees/<your-session-name>/` — isolated from any
+other sessions. If the option was off, you share the current
+checkout — fine for sequential work, risky for true parallel work.
+
+The orchestrator session that generated this brief is independent;
+you have no visibility into it or into any sibling sessions, and
+they have none into you.
 
 ## Pre-flight — verify before touching code
 
@@ -202,21 +237,26 @@ Output each brief in its own clearly-labeled code block. Tell the
 user the desktop flow:
 
 > Open Claude Code desktop → click **+ New session** in the sidebar →
-> click **Select folder** → pick the photo-manager repo. Paste
-> brief #1 into the first new session. Repeat for briefs #2 and #3.
-> Each new session lands in its own auto-worktree under
-> `.claude/worktrees/`.
+> **Select folder** (the photo-manager repo) → **enable the "create
+> worktree" option for parallel work** (leave off only if you intend
+> to run the briefs sequentially in one checkout). Paste one brief in
+> as the first message.
+>
+> Briefs are time-independent — paste them when and in whatever
+> order you want. You don't have to open all N sessions at once;
+> the briefs all branch off the same SHA so they're merge-order
+> flexible.
 
-### Step 5 — Stop
+### Step 5 — Done
 
-The orchestrator session's job is done. It does not monitor the
-cold sessions, does not aggregate their results, does not push their
-branches. Each cold session ships its own PR end-to-end with the
+Once briefs are handed off, the orchestrator's primary job is done.
+Each cold session does its own pre-flight, work, and PR with the
 normal gates intact.
 
-If a cold session gets stuck and asks you (via the user relaying)
-for help, treat that as a normal one-off question — answer it for
-that bundle, don't try to re-orchestrate.
+You can optionally stay open as a coordination point — if a sibling
+session asks (via the user) "how do I resolve a docs-guard block on
+my branch?", answer it. But don't try to drive the cold sessions
+from here; they own their work end-to-end.
 
 ## Anti-patterns — do not do these
 
@@ -289,8 +329,12 @@ Done. Open Claude Code desktop → + New session × N → Select folder
 
 ## Quick reference — minimal flow
 
-1. User: "fan out these N issues in parallel"
-2. Orchestrator runs steps 1–3 of this skill in current session.
+1. User: high-level intent — "fan out X, Y, Z" / "brief #N" / "prep
+   a session to do …".
+2. Orchestrator researches each task (`gh issue view`, Read/Grep),
+   runs pre-flight (steps 1–3 of this skill).
 3. Orchestrator outputs N briefs + collision report.
-4. User opens N "+ New session" windows, pastes one brief into each.
+4. User opens N "+ New session" windows (or fewer, or one — N is
+   the user's call) — enabling the worktree option for parallel
+   work — and pastes briefs in as first messages.
 5. Each cold session does its own pre-flight, work, and PR.


### PR DESCRIPTION
## Summary

Rename + content refinement for the recently-added skill at `.claude/skills/parallel-fanout/SKILL.md` (PR #189).

- **Rename**: `parallel-fanout` → `parallel-brief-generator`. The skill generates briefs for isolated cold sessions, not orchestrating an in-process fan-out (sub-agent fan-out doesn't work in this harness anyway — see the PR #189 commit message). The \"parallel\" prefix stays as the isolation contract.

- **Single-task input is now valid.** Dropped the \"do NOT use for a single task\" rule. Cross-bundle steps (file-scope collision, slot pre-assignment) are no-ops at N=1 but the research + brief-template still apply.

- **Step 1 reframed** from \"gather inputs from user\" → \"research independently\". The orchestrator runs `gh issue view`, Reads cited files, Greps for context. The user is not expected to paste issue bodies.

- **Step 4 worktree language corrected.** The desktop app does NOT auto-create worktrees — it offers a \"create worktree\" checkbox at session-open time. Briefs are time-independent; user opens sessions when ready.

- **Step 5 softened** from strict \"Stop\" to \"Done; can stay as coordination point\". Orchestrator may also work on one of the bundles if user chooses.

## Test plan
- [ ] Smoke test: open a fresh \"+ New session\" with the worktree checkbox enabled, invoke the skill with \"brief #144\", verify the session researches the issue independently and outputs a copy-paste-ready brief
- [ ] Then open a second cold session, paste the brief, verify it pre-flights cleanly and ships a PR

[docs-not-needed: skill body IS the documentation; README mention will follow once smoke-tested]