### PR TITLE
chore(ci): shard qa-batch into 5 parallel jobs (#188) + s19 title-poll (#196)

### DIFF
--- a/.github/workflows/qa-batch.yml
+++ b/.github/workflows/qa-batch.yml
@@ -15,6 +15,11 @@ name: qa-batch
 # workflow needs ≥10 consecutive flake-free runs on real PRs before being
 # promoted to a required status check via branch protection. Until then,
 # treat a red qa-batch as a signal to investigate, not a merge blocker.
+#
+# Sharding (#188). The batch is split across 3 parallel jobs via
+# strategy.matrix to bring wall-clock from ~15–20 min down toward ~6–7 min.
+# Selection is sorted-stride in qa/scenarios/_batch.py::select_shard, which
+# also keeps s23a/s23b in the same shard (s23b reads what s23a wrote).
 
 on:
   pull_request:
@@ -22,7 +27,10 @@ on:
   workflow_dispatch: {}   # allow manual trigger from the Actions UI for debugging
 
 concurrency:
-  group: qa-batch-${{ github.ref }}
+  # Shard number is part of the key: GitHub Actions cancels by group, and
+  # we want all 3 shards of the same PR to coexist. Without "-shard…",
+  # the second shard to start would cancel the first.
+  group: qa-batch-${{ github.head_ref || github.ref }}-shard${{ matrix.shard }}
   cancel-in-progress: true
 
 # Public-repo hardening: workflow is read-only, no write back to the repo,
@@ -35,6 +43,12 @@ jobs:
   qa:
     runs-on: windows-latest
     timeout-minutes: 20
+    strategy:
+      # Don't cancel sibling shards when one fails — we want a full picture
+      # of which scenarios failed across the whole batch from a single run.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
     steps:
       - uses: actions/checkout@v4
 
@@ -91,7 +105,7 @@ jobs:
           # defaults to the OEM codepage for child-process I/O.
           [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
           $OutputEncoding = [System.Text.Encoding]::UTF8
-          python -m qa.scenarios._batch 2>&1 | Tee-Object -FilePath qa-batch.log
+          python -m qa.scenarios._batch --shard ${{ matrix.shard }} --total-shards 3 2>&1 | Tee-Object -FilePath qa-batch.log
           # Forward the batch's exit code; PowerShell pipes default to the
           # tail-element rc which is Tee-Object's (always 0). The variable
           # `$LASTEXITCODE` from the python invocation is what matters.
@@ -104,8 +118,9 @@ jobs:
         if: always()
         shell: pwsh
         run: |
+          $heading = '## QA batch summary (shard ${{ matrix.shard }}/3)'
           if (Test-Path qa-batch.log) {
-            Add-Content $env:GITHUB_STEP_SUMMARY '## QA batch summary'
+            Add-Content $env:GITHUB_STEP_SUMMARY $heading
             Add-Content $env:GITHUB_STEP_SUMMARY ''
             Add-Content $env:GITHUB_STEP_SUMMARY '```'
             Select-String -Path qa-batch.log -Pattern '^=====|^total:|^\s+\[(OK|FAIL)\]' |
@@ -113,18 +128,20 @@ jobs:
               Add-Content $env:GITHUB_STEP_SUMMARY
             Add-Content $env:GITHUB_STEP_SUMMARY '```'
           } else {
-            Add-Content $env:GITHUB_STEP_SUMMARY '## QA batch summary'
+            Add-Content $env:GITHUB_STEP_SUMMARY $heading
             Add-Content $env:GITHUB_STEP_SUMMARY ''
             Add-Content $env:GITHUB_STEP_SUMMARY '_qa-batch.log was not produced — see the "Run qa batch" step for setup-time errors._'
           }
 
       # Upload the full log so debugging a failed scenario doesn't require
-      # re-running CI. 7-day retention is plenty for triage cycles.
+      # re-running CI. 7-day retention is plenty for triage cycles. The name
+      # is suffixed with the shard number because upload-artifact@v4 rejects
+      # duplicate names within a single workflow run.
       - name: Upload full batch log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: qa-batch-log
+          name: qa-batch-log-shard${{ matrix.shard }}
           path: qa-batch.log
           if-no-files-found: ignore
           retention-days: 7

--- a/.github/workflows/qa-batch.yml
+++ b/.github/workflows/qa-batch.yml
@@ -26,13 +26,6 @@ on:
     branches: [master]
   workflow_dispatch: {}   # allow manual trigger from the Actions UI for debugging
 
-concurrency:
-  # Shard number is part of the key: GitHub Actions cancels by group, and
-  # we want all 3 shards of the same PR to coexist. Without "-shard…",
-  # the second shard to start would cancel the first.
-  group: qa-batch-${{ github.head_ref || github.ref }}-shard${{ matrix.shard }}
-  cancel-in-progress: true
-
 # Public-repo hardening: workflow is read-only, no write back to the repo,
 # no token-scoped operations. Locking permissions explicitly here keeps it
 # audit-ready and resilient to future GitHub default changes.
@@ -43,6 +36,15 @@ jobs:
   qa:
     runs-on: windows-latest
     timeout-minutes: 20
+    # Concurrency must live at the job level (not workflow level): the
+    # ``matrix`` context is only in scope inside a job, so a workflow-level
+    # group key referencing ``matrix.shard`` is a workflow-file error and
+    # the run fails at parse time. Including the shard number in the key
+    # is what lets all 3 shards of the same PR coexist — without it,
+    # GitHub Actions would cancel earlier shards when the next one starts.
+    concurrency:
+      group: qa-batch-${{ github.head_ref || github.ref }}-shard${{ matrix.shard }}
+      cancel-in-progress: true
     strategy:
       # Don't cancel sibling shards when one fails — we want a full picture
       # of which scenarios failed across the whole batch from a single run.

--- a/.github/workflows/qa-batch.yml
+++ b/.github/workflows/qa-batch.yml
@@ -16,10 +16,19 @@ name: qa-batch
 # promoted to a required status check via branch protection. Until then,
 # treat a red qa-batch as a signal to investigate, not a merge blocker.
 #
-# Sharding (#188). The batch is split across 3 parallel jobs via
-# strategy.matrix to bring wall-clock from ~15–20 min down toward ~6–7 min.
+# Sharding (#188). The batch is split across 5 parallel jobs via
+# strategy.matrix to bring wall-clock from ~15–20 min down toward ~5 min.
 # Selection is sorted-stride in qa/scenarios/_batch.py::select_shard, which
 # also keeps s23a/s23b in the same shard (s23b reads what s23a wrote).
+#
+# Why 5 and not more? Per-shard fixed overhead (~1.5 min: checkout + pip +
+# exiftool + sandbox build) is paid per shard in parallel. Past ~5 shards
+# the fixed-overhead floor dominates the scenario-time savings, so further
+# shards mostly burn runner minutes for diminishing wall-clock wins. Plenty
+# of headroom remains under GitHub's free-tier 20-concurrent-job cap
+# (https://docs.github.com/en/actions/reference/actions-limits) and the
+# 256-jobs-per-matrix hard limit
+# (https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs).
 
 on:
   pull_request:
@@ -50,7 +59,7 @@ jobs:
       # of which scenarios failed across the whole batch from a single run.
       fail-fast: false
       matrix:
-        shard: [1, 2, 3]
+        shard: [1, 2, 3, 4, 5]
     steps:
       - uses: actions/checkout@v4
 
@@ -107,7 +116,7 @@ jobs:
           # defaults to the OEM codepage for child-process I/O.
           [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
           $OutputEncoding = [System.Text.Encoding]::UTF8
-          python -m qa.scenarios._batch --shard ${{ matrix.shard }} --total-shards 3 2>&1 | Tee-Object -FilePath qa-batch.log
+          python -m qa.scenarios._batch --shard ${{ matrix.shard }} --total-shards 5 2>&1 | Tee-Object -FilePath qa-batch.log
           # Forward the batch's exit code; PowerShell pipes default to the
           # tail-element rc which is Tee-Object's (always 0). The variable
           # `$LASTEXITCODE` from the python invocation is what matters.
@@ -120,7 +129,7 @@ jobs:
         if: always()
         shell: pwsh
         run: |
-          $heading = '## QA batch summary (shard ${{ matrix.shard }}/3)'
+          $heading = '## QA batch summary (shard ${{ matrix.shard }}/5)'
           if (Test-Path qa-batch.log) {
             Add-Content $env:GITHUB_STEP_SUMMARY $heading
             Add-Content $env:GITHUB_STEP_SUMMARY ''

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -265,6 +265,38 @@ buttonBox). See `_find_filename_edit` and
 
 ---
 
+## Layer 3 sharding in CI ([#188](https://github.com/jackal998/photo-manager/issues/188))
+
+The qa-batch workflow runs as 3 parallel jobs via `strategy.matrix.shard:
+[1, 2, 3]`. Each job invokes
+`python -m qa.scenarios._batch --shard N --total-shards 3`. Selection is
+sorted-stride in `qa.scenarios._batch.select_shard` over `ALL_SCENARIOS`.
+
+Invariants pinned by `tests/test_batch_shard.py`:
+
+- **Pairwise disjoint, union complete** — every scenario runs exactly once
+  across the three shards.
+- **s23a and s23b stay on the same shard** — s23b reads settings s23a
+  wrote. The selector pairs them into a single unit before striding.
+- **Balanced** — shard sizes differ by ≤1.
+
+The `concurrency` key includes the shard number so the three shards of
+the same PR don't auto-cancel each other; each shard's artifact name
+(`qa-batch-log-shard{N}`) is similarly suffixed because
+`actions/upload-artifact@v4` rejects duplicates within a run.
+
+Running a shard locally for debugging:
+
+```
+.venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 3 --dry-run
+.venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 3
+```
+
+An explicit positional list (`python -m qa.scenarios._batch sNN_xyz …`)
+still works and overrides sharding — handy for targeted iteration.
+
+---
+
 ## Open work
 
 - **Layer 2 is on-demand**, not on the roadmap. Add a spot-test under

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -267,20 +267,31 @@ buttonBox). See `_find_filename_edit` and
 
 ## Layer 3 sharding in CI ([#188](https://github.com/jackal998/photo-manager/issues/188))
 
-The qa-batch workflow runs as 3 parallel jobs via `strategy.matrix.shard:
-[1, 2, 3]`. Each job invokes
-`python -m qa.scenarios._batch --shard N --total-shards 3`. Selection is
+The qa-batch workflow runs as 5 parallel jobs via `strategy.matrix.shard:
+[1, 2, 3, 4, 5]`. Each job invokes
+`python -m qa.scenarios._batch --shard N --total-shards 5`. Selection is
 sorted-stride in `qa.scenarios._batch.select_shard` over `ALL_SCENARIOS`.
 
 Invariants pinned by `tests/test_batch_shard.py`:
 
 - **Pairwise disjoint, union complete** — every scenario runs exactly once
-  across the three shards.
+  across the five shards.
 - **s23a and s23b stay on the same shard** — s23b reads settings s23a
   wrote. The selector pairs them into a single unit before striding.
-- **Balanced** — shard sizes differ by ≤1.
+- **Balanced** — shard sizes differ by ≤2 (the s23 pair perturbs the
+  standard floor/ceil split by +1 in whichever shard owns it; today at
+  M=5 the sizes are 9/8/8/8/7).
 
-The `concurrency` key includes the shard number so the three shards of
+Why 5? Per-shard fixed overhead (~1.5 min for checkout + pip + exiftool +
+sandbox build) is paid per shard in parallel. With 40 scenarios at ~25s
+each, the per-shard wall-clock equation is
+`fixed + scenarios/shards × 25s` — past ~5 shards the fixed-overhead
+floor dominates and additional shards mostly burn runner minutes for
+diminishing wall-clock wins. Well under GitHub's
+[20-concurrent-job free-tier cap](https://docs.github.com/en/actions/reference/actions-limits)
+and the [256-jobs-per-matrix hard limit](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs).
+
+The `concurrency` key includes the shard number so the five shards of
 the same PR don't auto-cancel each other; each shard's artifact name
 (`qa-batch-log-shard{N}`) is similarly suffixed because
 `actions/upload-artifact@v4` rejects duplicates within a run.
@@ -288,8 +299,8 @@ the same PR don't auto-cancel each other; each shard's artifact name
 Running a shard locally for debugging:
 
 ```
-.venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 3 --dry-run
-.venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 3
+.venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 5 --dry-run
+.venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 5
 ```
 
 An explicit positional list (`python -m qa.scenarios._batch sNN_xyz …`)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,14 @@ omit = [
   "tests/*",
   "scripts/*",
   ".claude/*",
+  # qa/ is the layer-3 driver harness itself (subprocess spawning,
+  # UIA interaction, scenario configuration). It can't be exercised
+  # inside the layer-1 test process by design. The one pure-logic
+  # piece — qa/scenarios/_batch.select_shard — is unit-tested in
+  # tests/test_batch_shard.py; the rest is layer-3 plumbing that
+  # runs every time qa.scenarios._batch is invoked locally or in
+  # the qa-batch CI workflow (#188 sharded across 3 jobs).
+  "qa/*",
   # `omit` is reserved for files that genuinely cannot be exercised
   # inside the layer-1 test process. Each entry below carries (a) why
   # it isn't reachable from unit tests, and (b) where it IS covered

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -8,11 +8,15 @@ For each scenario:
   5. close the window via UIA
   6. wait for the subprocess to exit (or terminate if stuck)
 
-Usage:  .venv/Scripts/python.exe -m qa.scenarios._batch [scenarios...]
-        .venv/Scripts/python.exe -m qa.scenarios._batch s02_empty_folder s04_corrupted
+Usage:
+  .venv/Scripts/python.exe -m qa.scenarios._batch [scenarios...]
+  .venv/Scripts/python.exe -m qa.scenarios._batch s02_empty_folder s04_corrupted
+  .venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 3
+  .venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 3 --dry-run
 """
 from __future__ import annotations
 
+import argparse
 import ctypes
 import ctypes.wintypes
 import os
@@ -120,6 +124,45 @@ ALL_SCENARIOS = [
     # cleans it up at startup.
     "s39_window_geometry_persist",
 ]
+
+
+def select_shard(
+    scenarios: list[str], shard: int, total_shards: int
+) -> list[str]:
+    """Return the subset of ``scenarios`` belonging to ``shard`` of ``total_shards``.
+
+    Sorted-stride selection over *units*: scenarios are sorted alphabetically,
+    grouped into units, then units at positions (shard-1, shard-1+N, ...) are
+    picked. Most units are singletons; ``s23a_set_settings`` and
+    ``s23b_verify_settings`` form a single two-element unit so they always run
+    in the same shard (s23b reads what s23a wrote — splitting them would break
+    the scenario).
+
+    Shards are pairwise disjoint and their union equals ``set(scenarios)``.
+    Within a shard, original sorted order is preserved.
+
+    ``shard`` is 1-indexed (matches CI matrix conventions).
+    """
+    if total_shards < 1:
+        raise ValueError(f"total_shards must be >= 1, got {total_shards}")
+    if not 1 <= shard <= total_shards:
+        raise ValueError(
+            f"shard must be in 1..{total_shards}, got {shard}"
+        )
+    sorted_scenarios = sorted(scenarios)
+    units: list[tuple[str, ...]] = []
+    i = 0
+    while i < len(sorted_scenarios):
+        name = sorted_scenarios[i]
+        nxt = sorted_scenarios[i + 1] if i + 1 < len(sorted_scenarios) else None
+        if name == "s23a_set_settings" and nxt == "s23b_verify_settings":
+            units.append((name, nxt))
+            i += 2
+        else:
+            units.append((name,))
+            i += 1
+    selected_units = units[shard - 1 :: total_shards]
+    return [name for unit in selected_units for name in unit]
 
 
 def _close_window() -> None:
@@ -271,8 +314,75 @@ def run_one(name: str) -> tuple[int, str]:
     return driver_rc, driver_err
 
 
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        prog="python -m qa.scenarios._batch",
+        description=(
+            "Run qa.scenarios drivers sequentially. With no args, runs every "
+            "scenario in ALL_SCENARIOS. An explicit positional list always "
+            "wins over --shard / --total-shards."
+        ),
+    )
+    parser.add_argument(
+        "scenarios",
+        nargs="*",
+        help=(
+            "Explicit scenarios to run (e.g. s02_empty_folder s04_corrupted). "
+            "When supplied, --shard / --total-shards are ignored."
+        ),
+    )
+    parser.add_argument(
+        "--shard",
+        type=int,
+        default=None,
+        metavar="N",
+        help="1-indexed shard number to run (use with --total-shards).",
+    )
+    parser.add_argument(
+        "--total-shards",
+        type=int,
+        default=None,
+        metavar="M",
+        help=(
+            "Total number of shards. Selection is sorted-stride; the "
+            "s23a/s23b pair is kept on the same shard."
+        ),
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the selected scenarios and exit without launching any.",
+    )
+    args = parser.parse_args(argv)
+    if (args.shard is None) != (args.total_shards is None):
+        parser.error("--shard and --total-shards must be used together")
+    return args
+
+
 def main() -> int:
-    targets = sys.argv[1:] or ALL_SCENARIOS
+    args = _parse_args(sys.argv[1:])
+    if args.scenarios:
+        targets = args.scenarios
+    elif args.shard is not None:
+        targets = select_shard(ALL_SCENARIOS, args.shard, args.total_shards)
+    else:
+        targets = list(ALL_SCENARIOS)
+
+    if args.dry_run:
+        label = (
+            f"shard {args.shard}/{args.total_shards}"
+            if args.shard is not None and not args.scenarios
+            else "explicit"
+            if args.scenarios
+            else "all"
+        )
+        print(
+            f"dry-run ({label}): {len(targets)} scenario(s)", flush=True
+        )
+        for name in targets:
+            print(f"  {name}", flush=True)
+        return 0
+
     print(f"batch: running {len(targets)} scenarios: {targets}", flush=True)
     results: list[tuple[str, int, str]] = []
     for name in targets:

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -11,8 +11,8 @@ For each scenario:
 Usage:
   .venv/Scripts/python.exe -m qa.scenarios._batch [scenarios...]
   .venv/Scripts/python.exe -m qa.scenarios._batch s02_empty_folder s04_corrupted
-  .venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 3
-  .venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 3 --dry-run
+  .venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 5
+  .venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 5 --dry-run
 """
 from __future__ import annotations
 

--- a/qa/scenarios/s19_context_menu_open_folder.py
+++ b/qa/scenarios/s19_context_menu_open_folder.py
@@ -72,33 +72,49 @@ def main() -> int:
     _uia.right_click_tree_row(win, ROW_TARGET)
     _uia.select_popup_menu_path(pid, [_uia.CTX_OPEN_FOLDER])
 
-    # ── Wait for Explorer to spawn, find the new window ───────────────────
+    # ── Wait for Explorer to spawn AND its title to populate ──────────────
+    # Two races to clear, both serialized against a single deadline:
+    #   1. Explorer process starts + spawns its window. Typically <1 s on
+    #      local, 1–2 s on hosted runners.
+    #   2. Explorer populates the new window's title. The window first
+    #      appears with a generic placeholder (English: 'File Explorer';
+    #      localised variants on non-en-US runners) and only switches to
+    #      the folder-basename title once Explorer has enumerated the
+    #      folder contents. On a contended hosted runner this delay can
+    #      land *after* a single post-spawn snapshot, which silently
+    #      flakes the title-match assert (#196 — observed on shard 4 of
+    #      PR #195's qa-batch run; new_hwnds had the spawned window with
+    #      title='File Explorer' instead of 'near-duplicates …').
+    #
+    # Folding the title check into the same poll loop means a fast
+    # title-update finishes quickly (typical: <1.5 s) while a slow runner
+    # can still pass under the 10 s budget. The window title is the
+    # Explorer-displayed folder name and may be substring-matched (some
+    # locales prefix with parent path).
     print("step: wait_for_explorer_window")
     new_hwnds: list[tuple[int, str]] = []
-    deadline = time.time() + 5
+    matching: list[tuple[int, str]] = []
+    deadline = time.time() + 10
     while time.time() < deadline:
         current = _uia.list_explorer_windows()
         new_hwnds = [(h, t) for h, t in current if h not in baseline_hwnds]
-        if new_hwnds:
+        matching = [
+            (h, t) for h, t in new_hwnds
+            if EXPECTED_FOLDER_NAME.lower() in (t or "").lower()
+        ]
+        if matching:
             break
         time.sleep(0.2)
     print(f"  new_explorer_windows={[(h, t) for h, t in new_hwnds]!r}")
 
     if not new_hwnds:
         print(
-            "FAIL: no new Explorer window appeared within 5s after Open Folder "
-            "(regression of #102 — Open Folder action wiring or subprocess "
-            "invocation broken)"
+            "FAIL: no new Explorer window appeared within 10s after Open "
+            "Folder (regression of #102 — Open Folder action wiring or "
+            "subprocess invocation broken)"
         )
         return 1
 
-    # The window title is the Explorer-displayed folder name, which on
-    # Windows defaults to the folder's basename. Match case-insensitively
-    # and as a substring (some locales prefix with parent path).
-    matching = [
-        (h, t) for h, t in new_hwnds
-        if EXPECTED_FOLDER_NAME.lower() in (t or "").lower()
-    ]
     print(f"  matching_by_folder_name={[(h, t) for h, t in matching]!r}")
 
     if not matching:

--- a/tests/test_batch_shard.py
+++ b/tests/test_batch_shard.py
@@ -1,0 +1,99 @@
+"""Unit tests for ``qa.scenarios._batch.select_shard``.
+
+The CI workflow ``.github/workflows/qa-batch.yml`` slices ``ALL_SCENARIOS``
+across three parallel GitHub Actions jobs via ``--shard / --total-shards``.
+Three invariants must hold or the batch becomes meaningless:
+
+  1. Pairwise disjoint — no scenario runs twice (wasted runner minutes).
+  2. Union equals ALL_SCENARIOS — every scenario runs exactly once.
+  3. s23a and s23b stay on the same shard — s23b reads what s23a wrote;
+     splitting them across shards breaks the scenario silently.
+
+Tests run the real function over the real ``ALL_SCENARIOS`` list. We're
+not mocking the dispatch; we're checking the selection math against the
+production input.
+"""
+from __future__ import annotations
+
+import pytest
+
+from qa.scenarios._batch import ALL_SCENARIOS, select_shard
+
+
+# 1 is degenerate (one shard = everything) but it's a useful sanity check.
+# 2, 3, 4 are the candidates the CI matrix could realistically run.
+_SHARD_COUNTS = [1, 2, 3, 4]
+
+
+@pytest.mark.parametrize("total_shards", _SHARD_COUNTS)
+def test_shards_are_pairwise_disjoint(total_shards: int) -> None:
+    shards = [
+        select_shard(ALL_SCENARIOS, k, total_shards)
+        for k in range(1, total_shards + 1)
+    ]
+    for i in range(len(shards)):
+        for j in range(i + 1, len(shards)):
+            overlap = set(shards[i]) & set(shards[j])
+            assert overlap == set(), (
+                f"shard {i+1} and shard {j+1} overlap "
+                f"(N={total_shards}): {sorted(overlap)}"
+            )
+
+
+@pytest.mark.parametrize("total_shards", _SHARD_COUNTS)
+def test_shards_union_equals_all_scenarios(total_shards: int) -> None:
+    shards = [
+        select_shard(ALL_SCENARIOS, k, total_shards)
+        for k in range(1, total_shards + 1)
+    ]
+    union: set[str] = set().union(*shards)
+    assert union == set(ALL_SCENARIOS)
+
+
+@pytest.mark.parametrize("total_shards", _SHARD_COUNTS)
+def test_s23_pair_lives_on_same_shard(total_shards: int) -> None:
+    """s23b reads settings s23a wrote — never split them."""
+    for k in range(1, total_shards + 1):
+        shard = select_shard(ALL_SCENARIOS, k, total_shards)
+        has_a = "s23a_set_settings" in shard
+        has_b = "s23b_verify_settings" in shard
+        assert has_a == has_b, (
+            f"shard {k}/{total_shards} splits the s23 pair: "
+            f"s23a={has_a}, s23b={has_b}"
+        )
+
+
+@pytest.mark.parametrize("total_shards", _SHARD_COUNTS)
+def test_s23a_runs_before_s23b_within_shard(total_shards: int) -> None:
+    """Within whichever shard owns them, s23a must precede s23b."""
+    for k in range(1, total_shards + 1):
+        shard = select_shard(ALL_SCENARIOS, k, total_shards)
+        if "s23a_set_settings" in shard:
+            assert shard.index("s23a_set_settings") < shard.index(
+                "s23b_verify_settings"
+            )
+
+
+def test_shard_count_balance_is_reasonable() -> None:
+    """All three production shards should be within 1 scenario of each other.
+
+    Sorted-stride over N items into M shards is balanced by construction
+    (each shard has floor(N/M) or ceil(N/M)). Pairing s23 into one unit
+    can perturb this by at most 1. If a future addition tilts it by more,
+    the imbalance is worth catching here rather than as a slow CI shard.
+    """
+    sizes = [
+        len(select_shard(ALL_SCENARIOS, k, 3)) for k in range(1, 4)
+    ]
+    assert max(sizes) - min(sizes) <= 1, (
+        f"shard sizes unbalanced: {sizes}"
+    )
+
+
+def test_invalid_shard_number_raises() -> None:
+    with pytest.raises(ValueError):
+        select_shard(ALL_SCENARIOS, 0, 3)
+    with pytest.raises(ValueError):
+        select_shard(ALL_SCENARIOS, 4, 3)
+    with pytest.raises(ValueError):
+        select_shard(ALL_SCENARIOS, 1, 0)

--- a/tests/test_batch_shard.py
+++ b/tests/test_batch_shard.py
@@ -21,8 +21,9 @@ from qa.scenarios._batch import ALL_SCENARIOS, select_shard
 
 
 # 1 is degenerate (one shard = everything) but it's a useful sanity check.
-# 2, 3, 4 are the candidates the CI matrix could realistically run.
-_SHARD_COUNTS = [1, 2, 3, 4]
+# 5 is the production CI matrix size; 2/3/4 bracket it so the invariants
+# are pinned across the range of values someone might bump to.
+_SHARD_COUNTS = [1, 2, 3, 4, 5]
 
 
 @pytest.mark.parametrize("total_shards", _SHARD_COUNTS)
@@ -75,25 +76,31 @@ def test_s23a_runs_before_s23b_within_shard(total_shards: int) -> None:
 
 
 def test_shard_count_balance_is_reasonable() -> None:
-    """All three production shards should be within 1 scenario of each other.
+    """Production shards should differ in size by at most 2 scenarios.
 
-    Sorted-stride over N items into M shards is balanced by construction
-    (each shard has floor(N/M) or ceil(N/M)). Pairing s23 into one unit
-    can perturb this by at most 1. If a future addition tilts it by more,
+    Sorted-stride over U units into M shards is balanced by construction
+    (each shard has floor(U/M) or ceil(U/M) units → delta of at most 1).
+    Pairing s23 into one unit means whichever shard owns it gets one
+    extra scenario when units are flattened back, so the delta can rise
+    by 1 more — bounded at 2. Concretely at M=5 with 40 scenarios / 39
+    units, sizes are 9/8/8/8/7 (the 9 is the pair-holding shard).
+    If a future addition tilts it past 2 (e.g. a third s23-style pair),
     the imbalance is worth catching here rather than as a slow CI shard.
     """
+    total_shards = 5  # keep in sync with .github/workflows/qa-batch.yml matrix
     sizes = [
-        len(select_shard(ALL_SCENARIOS, k, 3)) for k in range(1, 4)
+        len(select_shard(ALL_SCENARIOS, k, total_shards))
+        for k in range(1, total_shards + 1)
     ]
-    assert max(sizes) - min(sizes) <= 1, (
+    assert max(sizes) - min(sizes) <= 2, (
         f"shard sizes unbalanced: {sizes}"
     )
 
 
 def test_invalid_shard_number_raises() -> None:
     with pytest.raises(ValueError):
-        select_shard(ALL_SCENARIOS, 0, 3)
+        select_shard(ALL_SCENARIOS, 0, 5)
     with pytest.raises(ValueError):
-        select_shard(ALL_SCENARIOS, 4, 3)
+        select_shard(ALL_SCENARIOS, 6, 5)
     with pytest.raises(ValueError):
         select_shard(ALL_SCENARIOS, 1, 0)


### PR DESCRIPTION
## Summary

Closes #188 and #196 — bundled because #196 was surfaced by the very
qa-batch run #188 stood up, and shipping them together lets "5-shard
qa-batch turns green" be a single landable unit.

### #188 — shard qa-batch across 5 parallel jobs

The layer-3 `qa-batch` workflow took ~15–20 min wall-clock unsharded on
`windows-latest`. Sharded across **5 parallel jobs** via
`strategy.matrix.shard: [1, 2, 3, 4, 5]`, target **~5 min** per shard
(observed on first run: 3:48–4:19, max 4:19).

- `qa/scenarios/_batch.py` — new `select_shard()` (sorted-stride **over
  units**, with `s23a_set_settings` + `s23b_verify_settings` paired into
  one unit so s23b can still read what s23a wrote). New CLI:
  `--shard N --total-shards M --dry-run`. Explicit positional list still
  wins over sharding.
- `.github/workflows/qa-batch.yml` — matrix with `fail-fast: false`;
  **job-level** `concurrency` group keyed on shard so the five shards of
  one PR don't auto-cancel each other (concurrency at the workflow level
  can't reference `matrix.*` — that bit us in
  [db0cb63](https://github.com/jackal998/photo-manager/pull/195/commits/db0cb63));
  artifact name suffixed with shard (`upload-artifact@v4` rejects
  duplicate names in a single run).
- `tests/test_batch_shard.py` — 22 tests over `[1, 2, 3, 4, 5]` shard
  counts: pairwise-disjoint, union-equals-ALL, s23 co-location,
  intra-shard s23a-before-s23b order, balance ≤2, invalid-arg
  `ValueError`.
- `pyproject.toml` — added `qa/*` to `[tool.coverage.run] omit`. The new
  test imports `qa.scenarios._batch`, which surfaced the harness in
  `coverage.json`; the only pure-logic piece (`select_shard`) is layer-1
  tested, the rest is subprocess orchestration that belongs to layer 3.
- `docs/testing.md` — new "Layer 3 sharding in CI (#188)" section
  documenting the shard layout, the pinned invariants, and local debug
  commands.

#### Why pair s23a/s23b?

A naive sorted-stride splits adjacent items across shards. With s23a at
sorted index 22 and s23b at 23, `index % N` differs for N ∈ {2, 3, 4, 5},
so they would land on different shards. `select_shard` builds a unit list
where (s23a, s23b) is a single 2-element unit, then strides over units.

#### Why 5 shards (and not more)?

Per-shard fixed overhead is paid per shard in parallel:

```
wall-clock ≈ per-shard-setup + (scenario_time / shard_count)
           ≈ ~1.5 min        + (~17 min      / 5)
           ≈ ~5 min
```

Past ~5 shards the fixed-overhead floor dominates and additional shards
mostly burn runner minutes for diminishing wall-clock wins. Plenty of
headroom remains under GitHub's documented limits:

- **20 concurrent jobs** on the free tier (5 qa shards + 1 pytest = 6/20)
  — [Actions limits](https://docs.github.com/en/actions/reference/actions-limits).
- **256 jobs per matrix** per workflow run, hard ceiling —
  [Using a matrix for your jobs](https://docs.github.com/en/actions/using-jobs/using-a-matrix-for-your-jobs).
- macOS has a separate cap (5 on free tier); not relevant here since the
  job runs on `windows-latest` —
  [Actions billing & administration](https://docs.github.com/en/actions/administering-github-actions/usage-limits-billing-and-administration).

Shard sizes today: **9 / 8 / 8 / 8 / 7** (40 scenarios → 39 units after
pairing s23). The 9 is whichever shard owns the s23 pair.

### #196 — s19 Explorer-title race

Surfaced by shard 4's run on
[25751789973](https://github.com/jackal998/photo-manager/actions/runs/25751789973):

```
new_explorer_windows=[(327806, 'File Explorer')]
matching_by_folder_name=[]
FAIL: spawned Explorer window did not show 'near-duplicates'
```

The Open Folder action fires correctly — Explorer spawns a new window
(non-empty `new_explorer_windows`) — but the window first appears with a
generic `'File Explorer'` placeholder and only flips to the folder
basename once Explorer has enumerated the folder. The previous driver
polled for the spawn, then snapshotted the title once, catching the
placeholder on contended runners.

Fold the title check into the same poll loop so a fast title-update
finishes quickly (~1 s typical) while a slow runner can still pass under
the new 10 s budget (was 5 s for the spawn-only wait).

### Local debug

```
.venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 5 --dry-run
.venv/Scripts/python.exe -m qa.scenarios._batch --shard 1 --total-shards 5
```

Per #74 this workflow remains **non-required** until it accumulates ≥10
consecutive flake-free runs on real PRs.

## Test plan

- [x] `pytest` — 916 passed, 2 skipped, total coverage 88.5%.
- [x] `scripts/check_coverage_per_file.py` — all 42 tracked files clear 70%.
- [x] `--dry-run` for shards 1..5 — disjoint, union complete, sizes 9/8/8/8/7.
- [x] s23a + s23b on the same shard; s23a precedes s23b within the shard.
- [x] Explicit positional list still works and overrides `--shard`.
- [x] YAML parses cleanly; `concurrency` block scoped to the job so
      `matrix.shard` is in scope.
- [x] First qa-batch run on this PR — 4 of 5 shards passed at 3:48–4:19;
      shard 4 hit #196 (now fixed).
- [ ] Re-run with #196 fix lands all 5 shards green at ~5 min wall-clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)