### PR TITLE
feat(schema): scoring columns for keep-worthiness scorer (#187)

### DIFF
--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -87,6 +87,13 @@ _MIGRATIONS = [
     ("pixel_width",     "INTEGER"),
     ("pixel_height",    "INTEGER"),
     ("is_locked",       "INTEGER NOT NULL DEFAULT 0"),
+    # Scoring system (#187) — raw signals + composite score. Populated by
+    # the extended exiftool pass (PR 2) and scorer (PR 3/4). NULL on old
+    # manifests; scorer treats NULL as 0.0 so old manifests degrade gracefully.
+    ("exif_tag_count",  "INTEGER"),
+    ("gps_present",     "INTEGER NOT NULL DEFAULT 0"),
+    ("xmp_derived",     "INTEGER NOT NULL DEFAULT 0"),
+    ("score",           "REAL"),
 ]
 
 _UPDATE_DECISION_SQL = """

--- a/scanner/dedup.py
+++ b/scanner/dedup.py
@@ -78,6 +78,13 @@ class ManifestRow:
     group_id: Optional[str] = None       # canonical root path of connected component; written to DB
     pixel_width: Optional[int] = None    # image width in pixels; written to DB
     pixel_height: Optional[int] = None   # image height in pixels; written to DB
+    # Scoring system (#187) — raw signals + composite score. Populated by
+    # the extended exiftool pass (PR 2) and scorer (PR 3/4). All default to
+    # None/False so existing constructors continue to work unchanged.
+    exif_tag_count: Optional[int] = None # count of census EXIF/XMP/QuickTime tags present
+    gps_present: bool = False            # True if GPSLatitude tag present
+    xmp_derived: bool = False            # True if xmpMM:DerivedFrom tag present (file is a derivative)
+    score: Optional[float] = None        # composite quality score in [0.0, 1.0]; NULL for isolated or unscored rows
 
 
 # ---------------------------------------------------------------------------

--- a/scanner/manifest.py
+++ b/scanner/manifest.py
@@ -26,7 +26,11 @@ CREATE TABLE IF NOT EXISTS migration_manifest (
     creation_date    TEXT,
     mtime            TEXT,
     pixel_width      INTEGER,
-    pixel_height     INTEGER
+    pixel_height     INTEGER,
+    exif_tag_count   INTEGER,
+    gps_present      INTEGER NOT NULL DEFAULT 0,
+    xmp_derived      INTEGER NOT NULL DEFAULT 0,
+    score            REAL
 );
 CREATE INDEX IF NOT EXISTS idx_source_hash ON migration_manifest(source_hash);
 CREATE INDEX IF NOT EXISTS idx_phash       ON migration_manifest(phash);
@@ -39,8 +43,9 @@ INSERT INTO migration_manifest
     (source_path, source_label, dest_path, action, source_hash,
      phash, hamming_distance, group_id, reason,
      file_size_bytes, shot_date, creation_date, mtime,
-     pixel_width, pixel_height)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?, ?, ?)
+     pixel_width, pixel_height,
+     exif_tag_count, gps_present, xmp_derived, score)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?)
 """
 
 
@@ -73,6 +78,10 @@ def write_manifest(rows: list[ManifestRow], output: Path) -> None:
                     r.mtime,
                     r.pixel_width,
                     r.pixel_height,
+                    r.exif_tag_count,
+                    int(r.gps_present),
+                    int(r.xmp_derived),
+                    r.score,
                 )
                 for r in rows
             ],

--- a/tests/test_manifest_repository.py
+++ b/tests/test_manifest_repository.py
@@ -1184,3 +1184,97 @@ class TestIsLockedPersistence:
         # File doesn't even exist; empty dict should be a guard-clause early return
         ManifestRepository().batch_update_lock_state(str(db), {})
         assert not db.exists()
+
+
+# ---------------------------------------------------------------------------
+# Scoring system schema migration (photo-manager#187 — PR 1)
+# ---------------------------------------------------------------------------
+
+
+class TestScoringSchemaMigration:
+    """Old DBs lacking exif_tag_count / gps_present / xmp_derived / score must
+    auto-migrate on load. New manifests get the columns from the base DDL;
+    older manifests get them via the additive ALTER TABLE list.
+
+    These four columns are added together in PR 1 (#187) so the scoring
+    system has somewhere to write its raw signals and composite score.
+    Old manifests load with gps_present=0, xmp_derived=0, exif_tag_count=NULL,
+    score=NULL — all of which the scorer interprets as 'no signal' (0.0).
+    """
+
+    def test_old_db_without_scoring_columns_auto_migrates(self, tmp_path):
+        """An old DB without any of the four scoring columns gains them on
+        first load. The load itself must not raise; subsequent inspection
+        confirms all four columns are present with the expected types."""
+        cand = tmp_path / "a.jpg"
+        ref = tmp_path / "b.jpg"
+        cand.write_bytes(b""); ref.write_bytes(b"")
+        gid = "/group/a"
+        # _DDL_WITH_IS_LOCKED predates the scoring columns — same shape as a
+        # manifest written before #187.
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": str(cand), "action": "REVIEW_DUPLICATE",
+                  "group_id": gid}),
+            _row({"source_path": str(ref), "action": "MOVE", "group_id": gid,
+                  "hamming_distance": None}),
+        ], ddl=_DDL_WITH_IS_LOCKED)
+
+        # First load triggers the migration (ALTER TABLE ADD COLUMN x4).
+        list(ManifestRepository().load(str(db)))
+
+        # All four columns now exist.
+        conn = sqlite3.connect(db)
+        try:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(migration_manifest)")}
+        finally:
+            conn.close()
+        for expected in ("exif_tag_count", "gps_present", "xmp_derived", "score"):
+            assert expected in cols, f"Migration did not add column: {expected}"
+
+    def test_old_db_scoring_columns_have_safe_defaults(self, tmp_path):
+        """After migration, pre-existing rows get the documented defaults:
+        gps_present=0, xmp_derived=0, exif_tag_count=NULL, score=NULL.
+        These are the 'no signal' values for an unscored manifest."""
+        cand = tmp_path / "a.jpg"
+        ref = tmp_path / "b.jpg"
+        cand.write_bytes(b""); ref.write_bytes(b"")
+        gid = "/group/a"
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": str(cand), "action": "REVIEW_DUPLICATE",
+                  "group_id": gid}),
+            _row({"source_path": str(ref), "action": "MOVE", "group_id": gid,
+                  "hamming_distance": None}),
+        ], ddl=_DDL_WITH_IS_LOCKED)
+
+        list(ManifestRepository().load(str(db)))  # trigger migration
+
+        conn = sqlite3.connect(db)
+        try:
+            r = conn.execute(
+                "SELECT exif_tag_count, gps_present, xmp_derived, score "
+                "FROM migration_manifest"
+            ).fetchone()
+        finally:
+            conn.close()
+        # exif_tag_count and score nullable; gps_present and xmp_derived
+        # NOT NULL DEFAULT 0 per migration spec.
+        assert r == (None, 0, 0, None)
+
+    def test_migration_is_idempotent(self, tmp_path):
+        """Loading an already-migrated DB must not error — ALTER TABLE ADD
+        COLUMN raises on duplicate columns, which the repository swallows.
+        Re-running load() twice exercises that swallow path."""
+        cand = tmp_path / "a.jpg"
+        ref = tmp_path / "b.jpg"
+        cand.write_bytes(b""); ref.write_bytes(b"")
+        gid = "/group/a"
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": str(cand), "action": "REVIEW_DUPLICATE",
+                  "group_id": gid}),
+            _row({"source_path": str(ref), "action": "MOVE", "group_id": gid,
+                  "hamming_distance": None}),
+        ], ddl=_DDL_WITH_IS_LOCKED)
+
+        # First load adds the columns; second load must not raise.
+        list(ManifestRepository().load(str(db)))
+        list(ManifestRepository().load(str(db)))  # should not raise

--- a/tests/test_scanner_manifest.py
+++ b/tests/test_scanner_manifest.py
@@ -296,3 +296,108 @@ class TestManifestSchemaColumns:
         )
         result = _make_row(hr, "MOVE")
         assert result.shot_date is None
+
+
+# ── Scoring system schema (#187 — PR 1) ────────────────────────────────────
+
+class TestScoringSchemaColumns:
+    """Scoring system adds 4 columns: exif_tag_count, gps_present, xmp_derived, score.
+
+    Raw signals (exif_tag_count, gps_present, xmp_derived) are populated by the
+    extended exiftool pass in PR 2. The composite score is written by the scorer
+    in PR 3/4. PR 1 establishes the schema and ManifestRow plumbing only — all
+    four columns default to NULL or 0 until later PRs populate them.
+    """
+
+    def _cols(self, out: Path) -> set[str]:
+        with sqlite3.connect(out) as conn:
+            return {row[1] for row in conn.execute("PRAGMA table_info(migration_manifest)").fetchall()}
+
+    def test_manifest_has_exif_tag_count_column(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        write_manifest([], out)
+        assert "exif_tag_count" in self._cols(out)
+
+    def test_manifest_has_gps_present_column(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        write_manifest([], out)
+        assert "gps_present" in self._cols(out)
+
+    def test_manifest_has_xmp_derived_column(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        write_manifest([], out)
+        assert "xmp_derived" in self._cols(out)
+
+    def test_manifest_has_score_column(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        write_manifest([], out)
+        assert "score" in self._cols(out)
+
+    def test_write_manifest_stores_exif_tag_count(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        row = ManifestRow(
+            source_path="/a.jpg", source_label="iphone",
+            dest_path=None, action="MOVE", source_hash="abc",
+            phash=None, hamming_distance=None, duplicate_of=None, reason="",
+            exif_tag_count=12,
+        )
+        write_manifest([row], out)
+        with sqlite3.connect(out) as conn:
+            val = conn.execute("SELECT exif_tag_count FROM migration_manifest").fetchone()[0]
+        assert val == 12
+
+    def test_write_manifest_stores_gps_present_true(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        row = ManifestRow(
+            source_path="/a.jpg", source_label="iphone",
+            dest_path=None, action="MOVE", source_hash="abc",
+            phash=None, hamming_distance=None, duplicate_of=None, reason="",
+            gps_present=True,
+        )
+        write_manifest([row], out)
+        with sqlite3.connect(out) as conn:
+            val = conn.execute("SELECT gps_present FROM migration_manifest").fetchone()[0]
+        assert val == 1
+
+    def test_write_manifest_stores_xmp_derived_true(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        row = ManifestRow(
+            source_path="/a.jpg", source_label="iphone",
+            dest_path=None, action="MOVE", source_hash="abc",
+            phash=None, hamming_distance=None, duplicate_of=None, reason="",
+            xmp_derived=True,
+        )
+        write_manifest([row], out)
+        with sqlite3.connect(out) as conn:
+            val = conn.execute("SELECT xmp_derived FROM migration_manifest").fetchone()[0]
+        assert val == 1
+
+    def test_write_manifest_stores_score(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        row = ManifestRow(
+            source_path="/a.jpg", source_label="iphone",
+            dest_path=None, action="REVIEW_DUPLICATE", source_hash="abc",
+            phash=None, hamming_distance=None, duplicate_of=None, reason="",
+            score=0.875,
+        )
+        write_manifest([row], out)
+        with sqlite3.connect(out) as conn:
+            val = conn.execute("SELECT score FROM migration_manifest").fetchone()[0]
+        assert val == pytest.approx(0.875)
+
+    def test_write_manifest_defaults_gps_and_xmp_to_zero(self, tmp_path):
+        """Existing callers that don't set the new fields get safe defaults
+        (gps_present=0, xmp_derived=0, exif_tag_count=NULL, score=NULL)."""
+        out = tmp_path / "manifest.sqlite"
+        row = ManifestRow(
+            source_path="/a.jpg", source_label="iphone",
+            dest_path=None, action="MOVE", source_hash="abc",
+            phash=None, hamming_distance=None, duplicate_of=None, reason="",
+        )
+        write_manifest([row], out)
+        with sqlite3.connect(out) as conn:
+            r = conn.execute(
+                "SELECT exif_tag_count, gps_present, xmp_derived, score "
+                "FROM migration_manifest"
+            ).fetchone()
+        assert r == (None, 0, 0, None)


### PR DESCRIPTION
## Summary

PR 1 of 7 for the keep-worthiness scoring system designed in #187.
Establishes the DB schema and `ManifestRow` plumbing so subsequent PRs
(exiftool extension, scorer logic, scan-pipeline wiring) have somewhere
to write — no behavior change for existing users.

- Adds four columns to `migration_manifest`: `exif_tag_count` (INTEGER),
  `gps_present` (INTEGER NOT NULL DEFAULT 0), `xmp_derived` (INTEGER NOT
  NULL DEFAULT 0), `score` (REAL). All follow the existing additive
  ALTER TABLE migration pattern.
- Extends `ManifestRow` with matching fields (all default-safe — existing
  call sites are kwargs-only and untouched).
- Old manifests auto-migrate on first load and degrade gracefully: the
  scorer in later PRs reads NULL/0 as "no signal" → score 0.0 for those
  rows.

## Test plan

- [x] 12 new tests pass (9 round-trip in `test_scanner_manifest.py`,
  3 migration / idempotency in `test_manifest_repository.py`)
- [x] Full suite: 974 passed, 2 skipped, coverage 88.37% (per-file floor
  >70% on every touched file — manifest_repository 99%, manifest 96%,
  dedup 94%)
- [x] Idempotent re-load on already-migrated DB does not error
- [x] No public API breakage — all `ManifestRow(...)` call sites use kwargs

## What this PR does NOT do

- No extractor changes (PR 2: extended exiftool + `MediaExtract` schema)
- No scorer logic (PR 3: `scanner/scoring.py`)
- No UI changes (PR 5: `COL_SCORE` + within-group sort)
- No new column appears in the loaded `PhotoRecord` yet (PR 5 surfaces it)

The full 7-PR design and prior-art attribution (Apple Photos +
py-image-dedup) live in the issue body.

[docs-not-needed: schema-only PR — new columns are unpopulated and have
no user-visible effect until PR 2/4 (raw signal extraction + score
computation) and PR 5 (COL_SCORE column). README's `Cached metadata`
section will be updated in PR 5 when these columns reach the UI.]

🤖 Generated with [Claude Code](https://claude.com/claude-code)