### PR TITLE
feat(scoring): two-tier compute_score + 8 weighted dimensions (#187)

### DIFF
--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -87,6 +87,13 @@ _MIGRATIONS = [
     ("pixel_width",     "INTEGER"),
     ("pixel_height",    "INTEGER"),
     ("is_locked",       "INTEGER NOT NULL DEFAULT 0"),
+    # Scoring system (#187) — raw signals + composite score. Populated by
+    # the extended exiftool pass (PR 2) and scorer (PR 3/4). NULL on old
+    # manifests; scorer treats NULL as 0.0 so old manifests degrade gracefully.
+    ("exif_tag_count",  "INTEGER"),
+    ("gps_present",     "INTEGER NOT NULL DEFAULT 0"),
+    ("xmp_derived",     "INTEGER NOT NULL DEFAULT 0"),
+    ("score",           "REAL"),
 ]
 
 _UPDATE_DECISION_SQL = """

--- a/scanner/dedup.py
+++ b/scanner/dedup.py
@@ -56,6 +56,46 @@ class HashResult:
     pixel_width: Optional[int] = None  # image width in pixels; None for video/failure
     pixel_height: Optional[int] = None # image height in pixels; None for video/failure
 
+    def to_media_extract(self) -> "MediaExtract":  # noqa: F821 — runtime import
+        """Convert this HashResult into a partial MediaExtract (#187 — PR 2).
+
+        Used by the scan pipeline to feed the merge step alongside the
+        exiftool partial. The ``extracted_by`` set is populated per the
+        tool(s) that actually contributed data:
+
+        * ``"hasher"`` — always (sha256 always present).
+        * ``"pil"`` — when phash was computed (i.e. PIL opened the bytes).
+          For RAW files this means PIL opened the rawpy-extracted
+          thumbnail.
+        * ``"rawpy"`` — added for RAW files when sensor dimensions were
+          read; ``merge_extracts`` uses this to prefer rawpy's sensor
+          dims over PIL's thumbnail dims.
+        """
+        from scanner.media_extract import MediaExtract
+
+        extracted: set[str] = {"hasher"}
+        if self.phash is not None:
+            extracted.add("pil")
+        if (
+            self.record.file_type == "raw"
+            and self.pixel_width is not None
+        ):
+            extracted.add("rawpy")
+
+        return MediaExtract(
+            path=self.record.path,
+            file_type=self.record.file_type,
+            sha256=self.sha256,
+            phash=self.phash,
+            mean_color=self.mean_color,
+            pixel_width=self.pixel_width,
+            pixel_height=self.pixel_height,
+            exif_date=self.exif_date,
+            # exif_date_tag intentionally None — PIL doesn't surface which
+            # tag produced the date. The exiftool partial will fill it.
+            extracted_by=extracted,
+        )
+
 
 @dataclass
 class ManifestRow:

--- a/scanner/dedup.py
+++ b/scanner/dedup.py
@@ -78,6 +78,13 @@ class ManifestRow:
     group_id: Optional[str] = None       # canonical root path of connected component; written to DB
     pixel_width: Optional[int] = None    # image width in pixels; written to DB
     pixel_height: Optional[int] = None   # image height in pixels; written to DB
+    # Scoring system (#187) — raw signals + composite score. Populated by
+    # the extended exiftool pass (PR 2) and scorer (PR 3/4). All default to
+    # None/False so existing constructors continue to work unchanged.
+    exif_tag_count: Optional[int] = None # count of census EXIF/XMP/QuickTime tags present
+    gps_present: bool = False            # True if GPSLatitude tag present
+    xmp_derived: bool = False            # True if xmpMM:DerivedFrom tag present (file is a derivative)
+    score: Optional[float] = None        # composite quality score in [0.0, 1.0]; NULL for isolated or unscored rows
 
 
 # ---------------------------------------------------------------------------

--- a/scanner/exif.py
+++ b/scanner/exif.py
@@ -194,6 +194,206 @@ _JSON_DATE_KEYS = (
 )
 
 
+# ── Extended batch for scoring system (#187) ───────────────────────────────
+#
+# The functions below extract a richer set of tags than ``batch_read_dates``:
+# GPS, XMP provenance, user rating, and a census tag count needed by the
+# scorer. ``-fast`` is *not* used because GPS and XMP segments live past the
+# first IFD block that ``-fast`` would stop at. Latency cost on JPEG is ~3-5×
+# higher per file; for a one-time scan this is acceptable for the precision
+# gain.
+#
+# ``batch_read_dates`` is kept for backward compatibility with callers that
+# only need dates. The scan pipeline (PR 4) switches to ``batch_read_extracts``.
+
+
+# Census tags counted toward ``exif_tag_count``. Counting from the union
+# of image + video censuses keeps the extraction file-type-agnostic; the
+# scorer (PR 3) normalises the count against the appropriate baseline
+# (image=16, video=9) when computing the EXIF-completeness sub-score.
+_CENSUS_TAGS: frozenset = frozenset({
+    # Image (EXIF/XMP namespace)
+    "EXIF:DateTimeOriginal", "EXIF:Make", "EXIF:Model", "EXIF:ISO",
+    "EXIF:FocalLength", "EXIF:ExposureTime", "EXIF:FNumber", "EXIF:Flash",
+    "EXIF:Orientation", "EXIF:Software", "EXIF:LensModel",
+    "EXIF:GPSLatitude", "EXIF:ColorSpace", "EXIF:WhiteBalance",
+    "XMP:Rating", "XMP:Subject",
+    # Video (QuickTime namespace)
+    "QuickTime:CreateDate", "QuickTime:Duration", "QuickTime:VideoFrameRate",
+    "QuickTime:ImageWidth", "QuickTime:ImageHeight",
+    "QuickTime:AudioChannels", "QuickTime:AudioSampleRate",
+    "QuickTime:CompressorName", "QuickTime:GPSCoordinates",
+})
+
+# Tags that, if present in the record, mark GPS as available.
+_GPS_TAGS: tuple[str, ...] = (
+    "EXIF:GPSLatitude",
+    "EXIF:GPSLongitude",
+    "QuickTime:GPSCoordinates",
+)
+
+# Tags that, if present, indicate the file is a derivative (Photoshop /
+# Lightroom export, etc.). Under ``-G`` (group-0) the xmpMM:DerivedFrom
+# tag surfaces under the ``XMP:`` group-0 prefix.
+_XMP_DERIVED_TAGS: tuple[str, ...] = (
+    "XMP:DerivedFrom",
+    "XMP-xmpMM:DerivedFrom",   # in case caller uses -G1 / -G:1 in the future
+)
+
+
+def batch_read_extracts(
+    paths: list[Path],
+    et: "ExiftoolProcess",
+    chunk_size: int = _EXIF_CHUNK,
+) -> dict[Path, "MediaExtract"]:
+    """Return {path: MediaExtract} populated with EXIF-side scoring signals.
+
+    For each path the returned ``MediaExtract`` carries:
+    * ``exif_date`` and ``exif_date_tag`` — parsed date + which exiftool
+      tag produced it (e.g. ``"EXIF:DateTimeOriginal"``).
+    * ``exif_tag_count`` — count of census tags present.
+    * ``gps_present`` — True if any GPS tag is present, else False
+      (*never None* after this function runs; that is the silent-dropout
+      regression contract).
+    * ``xmp_derived`` — True if ``xmpMM:DerivedFrom`` is present, else False.
+    * ``xmp_rating`` — integer 0–5 if ``XMP:Rating`` is present, else None.
+    * ``extracted_by = {"exiftool"}``.
+
+    Paths that exiftool fails to return a record for still receive a
+    ``MediaExtract`` with ``extracted_by={"exiftool"}`` and
+    ``extraction_errors`` describing the missing record — they are *not*
+    silently absent from the result dict. Downstream scoring treats the
+    missing values as 'no signal'.
+    """
+    if not paths:
+        return {}
+
+    from scanner.media_extract import MediaExtract  # local import — avoid cycle
+
+    result: dict[Path, MediaExtract] = {}
+    for offset in range(0, len(paths), chunk_size):
+        chunk = paths[offset: offset + chunk_size]
+        result.update(_read_extract_chunk(chunk, et))
+    return result
+
+
+def _read_extract_chunk(
+    paths: list[Path], et: "ExiftoolProcess"
+) -> dict[Path, "MediaExtract"]:
+    """Single ``-stay_open`` exiftool call for one chunk of paths.
+
+    Tag selectors cover the scoring-system signals plus the existing date
+    fallback chain. ``-fast`` is intentionally absent — GPS and XMP tags
+    live in segments past the first IFD that ``-fast`` would skip
+    (verified live against ``qa/sandbox/`` GPS-tagged JPEGs during #187
+    research).
+    """
+    from scanner.media_extract import MediaExtract
+
+    args = [
+        "-j", "-G",
+        # Date fallback chain (same as batch_read_dates).
+        "-DateTimeOriginal", "-CreateDate", "-QuickTime:CreateDate",
+        # GPS presence.
+        "-GPSLatitude", "-GPSLongitude", "-QuickTime:GPSCoordinates",
+        # XMP provenance and user metadata.
+        "-XMP-xmpMM:DerivedFrom",
+        "-XMP:Rating", "-XMP:Subject",
+        # Image census (the rest of the 16-tag image baseline).
+        "-EXIF:Make", "-EXIF:Model", "-EXIF:ISO", "-EXIF:FocalLength",
+        "-EXIF:ExposureTime", "-EXIF:FNumber", "-EXIF:Flash",
+        "-EXIF:Orientation", "-EXIF:Software", "-EXIF:LensModel",
+        "-EXIF:ColorSpace", "-EXIF:WhiteBalance",
+        # Video census (QuickTime:CreateDate already in date chain above).
+        "-QuickTime:Duration", "-QuickTime:VideoFrameRate",
+        "-QuickTime:ImageWidth", "-QuickTime:ImageHeight",
+        "-QuickTime:AudioChannels", "-QuickTime:AudioSampleRate",
+        "-QuickTime:CompressorName",
+        # NB: NO -fast here.
+    ]
+    args += [str(p) for p in paths]
+    output = et.execute(args)
+    records = _parse_exiftool_json(output)
+
+    by_path: dict[Path, dict] = {}
+    for rec in records:
+        src = rec.get("SourceFile")
+        if isinstance(src, str):
+            by_path[Path(src)] = rec
+
+    result: dict[Path, MediaExtract] = {}
+    for path in paths:
+        rec = by_path.get(Path(str(path)))
+        if rec is None:
+            # File missing from output — emit a partial that documents the
+            # exiftool pass ran (so the consumer knows we didn't forget)
+            # but no signals were captured. extraction_errors records why.
+            result[path] = MediaExtract(
+                path=path,
+                extracted_by={"exiftool"},
+                extraction_errors=[
+                    f"exiftool returned no record for SourceFile={path}"
+                ],
+            )
+            continue
+        result[path] = _record_to_extract(path, rec)
+
+    return result
+
+
+def _record_to_extract(path: Path, rec: dict) -> "MediaExtract":
+    """Build a partial MediaExtract from one exiftool JSON record."""
+    from scanner.media_extract import MediaExtract
+
+    # Date with source-tag provenance — record which tag produced it so
+    # the date_provenance scorer (PR 3) can weigh DateTimeOriginal vs.
+    # CreateDate fallback differently if it wants.
+    exif_date: Optional[datetime] = None
+    exif_date_tag: Optional[str] = None
+    for key in _JSON_DATE_KEYS:
+        v = rec.get(key)
+        if not isinstance(v, str) or not v:
+            continue
+        parsed = parse_exif_date(v)
+        if parsed is not None:
+            exif_date = parsed
+            exif_date_tag = key
+            break
+
+    # GPS — explicit True/False (never None) so downstream callers can
+    # tell "exiftool checked and there's no GPS" from "exiftool didn't run."
+    gps_present: bool = any(rec.get(t) is not None for t in _GPS_TAGS)
+
+    # XMP DerivedFrom — same explicit-True/False contract.
+    xmp_derived: bool = any(rec.get(t) is not None for t in _XMP_DERIVED_TAGS)
+
+    # XMP Rating — integer or None. Exiftool may emit it as int or string
+    # depending on the file; coerce defensively.
+    raw_rating = rec.get("XMP:Rating")
+    xmp_rating: Optional[int] = None
+    if raw_rating is not None:
+        try:
+            xmp_rating = int(raw_rating)
+        except (ValueError, TypeError):
+            xmp_rating = None
+
+    # Census tag count — count any present tag in the union of image +
+    # video censuses. The scorer normalises against the appropriate
+    # baseline per file_type.
+    exif_tag_count = sum(1 for tag in _CENSUS_TAGS if rec.get(tag) is not None)
+
+    return MediaExtract(
+        path=path,
+        exif_date=exif_date,
+        exif_date_tag=exif_date_tag,
+        exif_tag_count=exif_tag_count,
+        gps_present=gps_present,
+        xmp_derived=xmp_derived,
+        xmp_rating=xmp_rating,
+        extracted_by={"exiftool"},
+    )
+
+
 def _read_chunk(paths: list[Path], et: ExiftoolProcess) -> dict[Path, Optional[datetime]]:
     # ``-j -G``: JSON output with group-0-prefixed keys. Each record carries
     # its own ``SourceFile`` field, so records bind to paths by identity

--- a/scanner/manifest.py
+++ b/scanner/manifest.py
@@ -26,7 +26,11 @@ CREATE TABLE IF NOT EXISTS migration_manifest (
     creation_date    TEXT,
     mtime            TEXT,
     pixel_width      INTEGER,
-    pixel_height     INTEGER
+    pixel_height     INTEGER,
+    exif_tag_count   INTEGER,
+    gps_present      INTEGER NOT NULL DEFAULT 0,
+    xmp_derived      INTEGER NOT NULL DEFAULT 0,
+    score            REAL
 );
 CREATE INDEX IF NOT EXISTS idx_source_hash ON migration_manifest(source_hash);
 CREATE INDEX IF NOT EXISTS idx_phash       ON migration_manifest(phash);
@@ -39,8 +43,9 @@ INSERT INTO migration_manifest
     (source_path, source_label, dest_path, action, source_hash,
      phash, hamming_distance, group_id, reason,
      file_size_bytes, shot_date, creation_date, mtime,
-     pixel_width, pixel_height)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?, ?, ?)
+     pixel_width, pixel_height,
+     exif_tag_count, gps_present, xmp_derived, score)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?)
 """
 
 
@@ -73,6 +78,10 @@ def write_manifest(rows: list[ManifestRow], output: Path) -> None:
                     r.mtime,
                     r.pixel_width,
                     r.pixel_height,
+                    r.exif_tag_count,
+                    int(r.gps_present),
+                    int(r.xmp_derived),
+                    r.score,
                 )
                 for r in rows
             ],

--- a/scanner/media_extract.py
+++ b/scanner/media_extract.py
@@ -1,0 +1,189 @@
+"""Canonical extraction schema for the scoring system (#187 — PR 2).
+
+Multiple tools cover different file types and fields:
+
+* PIL fills sha256, phash, mean_color, pixel_width/height, exif_date for
+  jpeg/png/webp/heic.
+* rawpy fills pixel_width/height for RAW (sensor dims, not thumbnail).
+* exiftool fills exif_date for all files plus the new scoring signals
+  (gps_present, xmp_derived, xmp_rating, exif_tag_count).
+* os.stat fills mtime, ctime, file_size_bytes.
+
+Without a canonical contract, every new scoring signal has to be audited
+across all four extractor paths to confirm it isn't silently dropped for
+some file type. ``MediaExtract`` is that contract.
+
+Sentinel convention (enforced in tests):
+
+  ``None``  — field not attempted by any extractor that owns it.
+              After the full pipeline runs, a None on a field that should
+              have been populated is a *bug* — detectable, testable.
+  ``False`` — field attempted and signal definitively absent.
+  ``True``  — signal present.
+  value     — signal extracted with this value.
+
+``merge_extracts()`` combines partial extracts (one per tool) into one
+canonical ``MediaExtract`` with explicit per-field precedence.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Optional
+
+
+@dataclass
+class MediaExtract:
+    """Canonical output of all extraction tools for one media file.
+
+    Every field is optional so partial extracts (from a single tool) can
+    be constructed without setting fields the tool doesn't fill. The
+    merge step combines partials with explicit precedence; see
+    ``merge_extracts``.
+    """
+
+    # ── Identity ──────────────────────────────────────────────────────────
+    path: Path
+    file_type: str = ""                # 'jpeg' | 'heic' | 'raw' | 'png' | 'mp4' | 'mov' | ...
+
+    # ── Fingerprints (hasher.py — single read_bytes() pass) ──────────────
+    sha256: Optional[str] = None
+    phash: Optional[str] = None
+    mean_color: Optional[str] = None   # "R,G,B"
+
+    # ── Pixel dimensions ──────────────────────────────────────────────────
+    # rawpy values override PIL values for RAW (sensor dims, not thumbnail)
+    pixel_width: Optional[int] = None
+    pixel_height: Optional[int] = None
+
+    # ── Dates ─────────────────────────────────────────────────────────────
+    exif_date: Optional[datetime] = None
+    exif_date_tag: Optional[str] = None  # which exiftool tag produced exif_date;
+                                          # None when PIL was the source (tag not surfaced)
+    mtime: Optional[datetime] = None
+    ctime: Optional[datetime] = None
+
+    # ── File metadata ─────────────────────────────────────────────────────
+    file_size_bytes: Optional[int] = None
+
+    # ── Scoring signals (exiftool extended pass — all file types) ─────────
+    exif_tag_count: Optional[int] = None  # None = exiftool not run; 0 = ran, no census tags found
+    gps_present: Optional[bool] = None    # None = not checked; False = checked, absent; True = present
+    xmp_derived: Optional[bool] = None    # None = not checked; False = checked, absent; True = present
+    xmp_rating: Optional[int] = None      # 0–5 if present; None = not present or not checked
+
+    # ── Provenance (for debugging and auditing) ────────────────────────────
+    extracted_by: set[str] = field(default_factory=set)
+    # Values added by each extractor: "hasher", "pil", "rawpy", "exiftool", "stat"
+    extraction_errors: list[str] = field(default_factory=list)
+    # Non-fatal issues logged here; fatal failures leave the relevant field None
+
+
+# Fields handled by the generic first-non-None precedence in merge_extracts.
+# Explicitly listed so the precedence contract is greppable and reviewable.
+_SIMPLE_FIRST_NON_NONE: tuple[str, ...] = (
+    "sha256",
+    "phash",
+    "mean_color",
+    "mtime",
+    "ctime",
+    "file_size_bytes",
+    "exif_tag_count",
+    "xmp_rating",
+)
+_BOOL_FIRST_NON_NONE: tuple[str, ...] = (
+    "gps_present",
+    "xmp_derived",
+)
+
+
+def merge_extracts(*partials: MediaExtract) -> MediaExtract:
+    """Combine partial MediaExtracts into one canonical instance.
+
+    All partials must share the same ``path`` — that is the merge key.
+    Provenance metadata (``extracted_by``, ``extraction_errors``) is
+    unioned across all partials.
+
+    Precedence rules:
+
+    * ``pixel_width`` / ``pixel_height``: a partial whose ``extracted_by``
+      contains ``"rawpy"`` wins outright (sensor dimensions for RAW files
+      beat PIL's thumbnail dimensions). Otherwise first non-None wins.
+    * ``exif_date`` / ``exif_date_tag``: a partial whose ``extracted_by``
+      contains ``"exiftool"`` wins (exiftool's parsing is more reliable
+      than PIL's IFD walk and honours XMP/QuickTime tags). Otherwise
+      first non-None wins.
+    * All other simple fields: first non-None wins.
+    * Booleans (``gps_present``, ``xmp_derived``): first non-None wins;
+      ``None`` means *not checked* and is skipped, while ``False`` means
+      *checked, absent* and is taken.
+    * ``file_type``: first non-empty wins.
+
+    Raises ``ValueError`` if no partials are provided or if partials
+    reference different paths.
+    """
+    if not partials:
+        raise ValueError("merge_extracts requires at least one partial")
+    paths = {p.path for p in partials}
+    if len(paths) > 1:
+        raise ValueError(
+            f"merge_extracts: all partials must share path; got {sorted(paths)!r}"
+        )
+
+    out = MediaExtract(path=partials[0].path)
+
+    # Provenance union first so the rawpy/exiftool precedence checks can
+    # consult the merged set later if needed.
+    for p in partials:
+        out.extracted_by.update(p.extracted_by)
+        out.extraction_errors.extend(p.extraction_errors)
+
+    # First non-empty wins for file_type.
+    for p in partials:
+        if not out.file_type and p.file_type:
+            out.file_type = p.file_type
+
+    # Simple "first non-None wins" fields.
+    for p in partials:
+        for attr in _SIMPLE_FIRST_NON_NONE:
+            if getattr(out, attr) is None and getattr(p, attr) is not None:
+                setattr(out, attr, getattr(p, attr))
+        for attr in _BOOL_FIRST_NON_NONE:
+            if getattr(out, attr) is None and getattr(p, attr) is not None:
+                setattr(out, attr, getattr(p, attr))
+
+    # pixel_width/height — rawpy wins over PIL (sensor dims, not thumbnail).
+    rawpy_partial = next(
+        (p for p in partials
+         if "rawpy" in p.extracted_by and p.pixel_width is not None),
+        None,
+    )
+    if rawpy_partial is not None:
+        out.pixel_width = rawpy_partial.pixel_width
+        out.pixel_height = rawpy_partial.pixel_height
+    else:
+        for p in partials:
+            if p.pixel_width is not None:
+                out.pixel_width = p.pixel_width
+                out.pixel_height = p.pixel_height
+                break
+
+    # exif_date — exiftool wins over PIL (more reliable parser, XMP-aware).
+    exiftool_date_partial = next(
+        (p for p in partials
+         if "exiftool" in p.extracted_by and p.exif_date is not None),
+        None,
+    )
+    if exiftool_date_partial is not None:
+        out.exif_date = exiftool_date_partial.exif_date
+        out.exif_date_tag = exiftool_date_partial.exif_date_tag
+    else:
+        for p in partials:
+            if p.exif_date is not None:
+                out.exif_date = p.exif_date
+                out.exif_date_tag = p.exif_date_tag
+                break
+
+    return out

--- a/scanner/scoring.py
+++ b/scanner/scoring.py
@@ -1,0 +1,407 @@
+"""Keep-worthiness scoring for duplicate groups (#187 — PR 3).
+
+Pure quality measurement: ``compute_score(row, group_rows, weights)``
+returns a float in ``[0.0, 1.0]`` derived only from the row's own
+attributes plus the group context. No filesystem reads, no subprocess
+calls, no DB access — given the same inputs the function always returns
+the same output. The action layer (PR 6) is responsible for translating
+scores into KEEP/DELETE decisions and for respecting user-intent signals
+(``is_locked``, ``xmp:Rating``) which this module deliberately ignores.
+
+The scorer evolved from two prior systems (see #187 issue body for
+attribution):
+
+* Apple Photos' "highest detail + most metadata" merge framing — keep
+  whatever has the most information.
+* py-image-dedup's open-source multi-factor priority cascade — same
+  signal family but as a strict ordered cascade rather than a weighted
+  sum.
+
+This implementation is a two-tier architecture:
+
+  Tier 1 — Categorical gates applied as absolute deductions
+    format_penalty:   RAW=0.00  TIFF=0.05  HEIC=0.10  PNG=0.12
+                      WebP=0.18  JPEG/Video=0.20  GIF=0.35
+    xmp_derived:      −0.30 if xmpMM:DerivedFrom is present
+
+  Tier 2 — Eight weighted continuous signals (configurable weights)
+    resolution       w=0.25   within-group normalised pixel count
+    exif_complete    w=0.20   census tag count vs. format baseline
+    date_provenance  w=0.15   DateTimeOriginal vs. mtime-derived
+    gps_present      w=0.08   binary
+    filename         w=0.12   penalise copy / (N) / edited / thumb …
+    path             w=0.08   penalise Downloads/, WhatsApp/, temp/ …
+    live_photo       w=0.07   HEIC with MOV peer > orphan HEIC
+    file_size        w=0.05   correlated with resolution within format
+
+Final score = max(0.0, min(1.0, Tier2 − format_penalty − derived_penalty))
+
+Live Photo passenger rule: a ``.mov`` / ``.mp4`` file whose stem matches
+a HEIC sibling in the same group receives ``score = None`` — it is the
+HEIC's passenger, not a ranking candidate. PR 6's action layer skips
+None-score rows when applying decisions.
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from pathlib import Path
+from typing import Iterable, Optional, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from scanner.dedup import ManifestRow
+
+
+# ── Tier 1 — Categorical penalties (absolute deductions, not weight-scaled) ──
+
+FORMAT_PENALTY: dict[str, float] = {
+    # RAW formats — no penalty (maximum information preservation).
+    "nef": 0.00, "cr2": 0.00, "cr3": 0.00, "arw": 0.00,
+    "dng": 0.00, "orf": 0.00, "rw2": 0.00, "raf": 0.00,
+    # Lossless near-RAW.
+    "tiff": 0.05, "tif": 0.05,
+    # Apple lossless-ish (lossy in practice but better than JPEG).
+    "heic": 0.10, "heif": 0.10,
+    # Lossless container, typically a lossy-original derivative.
+    "png": 0.12,
+    # Modern lossy.
+    "webp": 0.18,
+    # Standard lossy + video.
+    "jpeg": 0.20, "jpg": 0.20,
+    "mp4": 0.20, "mov": 0.20,
+    # Legacy / severely limited.
+    "gif": 0.35,
+}
+
+# Penalty applied when xmpMM:DerivedFrom is present — file is definitively
+# a Photoshop/Lightroom-exported derivative, not the original.
+DERIVED_PENALTY: float = 0.30
+
+# Fallback for extensions not in FORMAT_PENALTY (treated like a lossy
+# unknown — neither rewarded nor maximally penalised).
+_DEFAULT_FORMAT_PENALTY: float = 0.20
+
+
+# ── Tier 2 — Default weights for the continuous composite ───────────────────
+
+DEFAULT_WEIGHTS: dict[str, float] = {
+    "resolution":    0.25,
+    "file_size":     0.05,   # low — strongly correlated with resolution same-format
+    "exif_complete": 0.20,
+    "date_prov":     0.15,
+    "gps":           0.08,
+    "filename":      0.12,
+    "path":          0.08,
+    "live_photo":    0.07,
+}  # must sum to 1.00; validate_weights() enforces this for user-supplied dicts
+
+
+# EXIF census baselines per file type. The scorer normalises
+# ``exif_tag_count`` against the appropriate baseline so images and
+# videos are scored on their own scale.
+IMAGE_EXIF_CENSUS_BASELINE: int = 16   # see scanner/exif.py::_CENSUS_TAGS (image set)
+VIDEO_EXIF_CENSUS_BASELINE: int = 9    # see scanner/exif.py::_CENSUS_TAGS (video set)
+
+
+# Filename patterns that mark a file as a likely copy / derivative.
+# Each hit subtracts 0.30 from a base of 1.0; the floor is 0.0.
+#
+# Pattern note: ``\b`` (word boundary) cannot be used because Python's regex
+# engine treats ``_`` as a word character, so ``\bedited\b`` does NOT match
+# ``photo_edited.jpg``. We use ``(?<![A-Za-z])word(?![A-Za-z])`` instead so
+# letters are the only boundary — underscores, hyphens, spaces, digits, and
+# string start/end all count as separators.
+#
+# Pattern note (omission): a trailing ``_\d{4}$`` pattern was considered for
+# catching "_0001"-style derivative suffixes but rejected — it false-positives
+# on camera-native filenames like ``IMG_4567.jpg`` / ``DSC_1234.NEF`` that
+# also end in four digits and are originals, not derivatives. The other six
+# patterns cover the clear copy/edit/screenshot cases.
+_FILENAME_PENALTY_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"(?<![A-Za-z])copy(?![A-Za-z])", re.IGNORECASE),          # "Copy of photo"
+    re.compile(r"\(\d+\)"),                                                # "(1)", "(2)"
+    re.compile(r"(?<![A-Za-z])edited?(?![A-Za-z])", re.IGNORECASE),       # "photo_edited"
+    re.compile(r"(?<![A-Za-z])thumb(?:nail)?(?![A-Za-z])", re.IGNORECASE),# "photo_thumb"
+    re.compile(r"(?<![A-Za-z])compressed(?![A-Za-z])", re.IGNORECASE),    # "_compressed"
+    re.compile(r"(?<![A-Za-z])screenshot(?![A-Za-z])", re.IGNORECASE),    # "Screenshot 2024-..."
+]
+
+# Directory names that mark a file as a likely re-export / sideload.
+# Each hit subtracts 0.25 from a base of 1.0; the floor is 0.0. Compared
+# case-insensitively against substrings of every path segment.
+_BAD_PATH_SEGMENTS: frozenset[str] = frozenset({
+    "downloads",
+    "whatsapp",
+    "screenshots", "screenshot",
+    "recycle.bin", "$recycle.bin",
+    "trash", ".trash",
+    "temp", "tmp",
+    "telegram",
+    "instagram",
+    "messenger",
+})
+
+# Video suffixes used by the Live Photo peer detection.
+_VIDEO_SUFFIXES: frozenset[str] = frozenset({"mov", "mp4"})
+# HEIC suffixes used by the Live Photo peer detection.
+_HEIC_SUFFIXES: frozenset[str] = frozenset({"heic", "heif"})
+
+
+# ── Helpers ─────────────────────────────────────────────────────────────────
+
+
+def _suffix(row: "ManifestRow") -> str:
+    """Lowercase file extension without the leading dot."""
+    return Path(row.source_path).suffix.lstrip(".").lower()
+
+
+def _stem_lower(row: "ManifestRow") -> str:
+    """Lowercase filename stem (case-insensitive match for cross-OS fixtures)."""
+    return Path(row.source_path).stem.lower()
+
+
+def _has_paired_peer_with_suffixes(
+    row: "ManifestRow",
+    group_rows: Iterable["ManifestRow"],
+    suffix_set: frozenset[str],
+) -> bool:
+    """True iff any other row in ``group_rows`` shares this row's stem
+    (case-insensitive) and has a suffix in ``suffix_set``."""
+    stem = _stem_lower(row)
+    for peer in group_rows:
+        if peer.source_path == row.source_path:
+            continue
+        if _stem_lower(peer) == stem and _suffix(peer) in suffix_set:
+            return True
+    return False
+
+
+def validate_weights(weights: dict[str, float]) -> None:
+    """Raise ValueError if ``weights`` is missing keys or doesn't sum to 1.0.
+
+    Called by the scan pipeline / rescore path before invoking the scorer.
+    A bad config produces a clear, early error instead of silently scoring
+    on the wrong axes. Tolerance is ±0.001 to absorb float-summation noise.
+    """
+    missing = set(DEFAULT_WEIGHTS) - set(weights)
+    if missing:
+        raise ValueError(
+            f"scoring weights missing keys: {sorted(missing)} "
+            f"(expected {sorted(DEFAULT_WEIGHTS)})"
+        )
+    total = sum(weights[k] for k in DEFAULT_WEIGHTS)
+    if abs(total - 1.0) > 0.001:
+        raise ValueError(
+            f"scoring weights must sum to 1.0 (got {total:.4f})"
+        )
+
+
+# ── Tier 2 dimension functions (each returns float in [0.0, 1.0]) ───────────
+
+
+def _score_resolution(
+    row: "ManifestRow", group_rows: list["ManifestRow"]
+) -> float:
+    """Within-group min-max normalised pixel count.
+
+    Edge cases:
+    * Row missing pixel_width/height (video, hash failure): 0.0.
+    * No other row in the group has dims: 0.0 — nothing to normalise against.
+    * All rows in the group tied: 1.0 — no discriminating power.
+    """
+    px = (row.pixel_width or 0) * (row.pixel_height or 0)
+    if px == 0:
+        return 0.0
+    group_px = [
+        (r.pixel_width or 0) * (r.pixel_height or 0)
+        for r in group_rows
+        if r.pixel_width and r.pixel_height
+    ]
+    if not group_px:
+        return 0.0
+    lo, hi = min(group_px), max(group_px)
+    if hi == lo:
+        return 1.0
+    return (px - lo) / (hi - lo)
+
+
+def _score_file_size(
+    row: "ManifestRow", group_rows: list["ManifestRow"]
+) -> float:
+    """Within-group min-max normalised file size.
+
+    Low weight in DEFAULT_WEIGHTS (0.05) because resolution and file size
+    are strongly correlated within the same format. The signal is kept
+    for cross-format groups (RAW vs JPEG of the same scene) where file
+    size adds independent information.
+    """
+    size = row.file_size_bytes or 0
+    if size == 0:
+        return 0.0
+    group_sizes = [r.file_size_bytes for r in group_rows if r.file_size_bytes]
+    if not group_sizes:
+        return 0.0
+    lo, hi = min(group_sizes), max(group_sizes)
+    if hi == lo:
+        return 1.0
+    return (size - lo) / (hi - lo)
+
+
+def _score_exif_completeness(row: "ManifestRow") -> float:
+    """Census tag count normalised against the file-type baseline.
+
+    Image baseline: 16 census tags (EXIF + XMP user metadata).
+    Video baseline: 9 census tags (QuickTime + GPSCoordinates).
+    Old manifests with no extended exiftool pass have count=None → 0.0.
+    """
+    count = row.exif_tag_count
+    if count is None:
+        return 0.0
+    baseline = (
+        VIDEO_EXIF_CENSUS_BASELINE
+        if _suffix(row) in _VIDEO_SUFFIXES
+        else IMAGE_EXIF_CENSUS_BASELINE
+    )
+    return min(count / baseline, 1.0)
+
+
+def _score_date_provenance(row: "ManifestRow") -> float:
+    """1.0 if shot_date is real EXIF; 0.3 if shot_date looks mtime-derived;
+    0.0 if no shot_date at all.
+
+    The 2-second tolerance catches the common pattern where a file copy
+    inherits the filesystem timestamp and the scanner stores that as
+    shot_date because no real EXIF DateTimeOriginal exists. Without
+    storing the source tag separately in the DB, this comparison is the
+    best heuristic available.
+    """
+    if row.shot_date is None:
+        return 0.0
+    if row.mtime is not None:
+        try:
+            shot = datetime.fromisoformat(row.shot_date)
+            mt = datetime.fromisoformat(row.mtime)
+            if abs((shot - mt).total_seconds()) < 2.0:
+                return 0.3   # suspicious: shot_date == mtime, likely derived
+        except (ValueError, TypeError):
+            # Malformed date string — fall through to the default below.
+            pass
+    return 1.0
+
+
+def _score_gps(row: "ManifestRow") -> float:
+    """Binary GPS presence — 1.0 if any GPS tag was extracted, else 0.0.
+
+    Precision (DOP) and altitude are intentionally ignored: GPS presence
+    is already a strong rarity signal (< 30% of consumer photos), and
+    altitude is present in < 10% of GPS photos — binary is adequate.
+    """
+    return 1.0 if row.gps_present else 0.0
+
+
+def _score_filename(row: "ManifestRow") -> float:
+    """Penalty score from filename patterns that mark a file as a copy /
+    derivative. Each pattern hit subtracts 0.30 from a 1.0 base; floor 0.0.
+    """
+    stem = Path(row.source_path).stem
+    hits = sum(bool(p.search(stem)) for p in _FILENAME_PENALTY_PATTERNS)
+    return max(0.0, 1.0 - 0.30 * hits)
+
+
+def _score_path(row: "ManifestRow") -> float:
+    """Penalty score from directory path. Each path segment matching a
+    'bad' substring (Downloads, WhatsApp, Screenshots, temp, …)
+    subtracts 0.25 from a 1.0 base; floor 0.0.
+    """
+    parts_lower = [p.lower() for p in Path(row.source_path).parts]
+    hits = sum(
+        1
+        for seg in parts_lower
+        for bad in _BAD_PATH_SEGMENTS
+        if bad in seg
+    )
+    return max(0.0, 1.0 - 0.25 * hits)
+
+
+def _score_live_photo(
+    row: "ManifestRow", group_rows: list["ManifestRow"]
+) -> float:
+    """Live Photo completeness signal for HEIC files.
+
+    * HEIC with a paired MOV/MP4 in the same group: 1.0.
+    * HEIC without a paired video: 0.5 (orphan).
+    * Anything else (JPEG, RAW, PNG, standalone video): 1.0 (dimension N/A).
+
+    The MOV side of a pair is handled separately by ``compute_score``,
+    which returns ``None`` for the MOV — it doesn't compete with its HEIC.
+    """
+    suffix = _suffix(row)
+    if suffix not in _HEIC_SUFFIXES:
+        return 1.0
+    has_video_peer = _has_paired_peer_with_suffixes(
+        row, group_rows, _VIDEO_SUFFIXES
+    )
+    return 1.0 if has_video_peer else 0.5
+
+
+# ── Public API ──────────────────────────────────────────────────────────────
+
+
+def compute_score(
+    row: "ManifestRow",
+    group_rows: list["ManifestRow"],
+    weights: dict[str, float] = DEFAULT_WEIGHTS,
+) -> Optional[float]:
+    """Composite keep-worthiness score in ``[0.0, 1.0]``, or ``None``.
+
+    Returns ``None`` when ``row`` is a Live Photo MOV/MP4 passenger
+    (its stem matches a HEIC sibling in the same group). The MOV
+    inherits its HEIC's KEEP/DELETE decision in the action layer and
+    is not a standalone ranking candidate.
+
+    Pure function: no I/O, no globals. Same (row, group_rows, weights)
+    always produces the same result.
+    """
+    # Live Photo passenger rule.
+    if _suffix(row) in _VIDEO_SUFFIXES and _has_paired_peer_with_suffixes(
+        row, group_rows, _HEIC_SUFFIXES
+    ):
+        return None
+
+    # Tier 1 — categorical penalties (absolute, not weight-scaled).
+    fmt_penalty = FORMAT_PENALTY.get(_suffix(row), _DEFAULT_FORMAT_PENALTY)
+    derived_penalty = DERIVED_PENALTY if row.xmp_derived else 0.0
+
+    # Tier 2 — weighted continuous composite.
+    tier2 = (
+        weights["resolution"]    * _score_resolution(row, group_rows)
+        + weights["file_size"]     * _score_file_size(row, group_rows)
+        + weights["exif_complete"] * _score_exif_completeness(row)
+        + weights["date_prov"]     * _score_date_provenance(row)
+        + weights["gps"]           * _score_gps(row)
+        + weights["filename"]      * _score_filename(row)
+        + weights["path"]          * _score_path(row)
+        + weights["live_photo"]    * _score_live_photo(row, group_rows)
+    )
+
+    return max(0.0, min(1.0, tier2 - fmt_penalty - derived_penalty))
+
+
+def score_group(
+    group_rows: list["ManifestRow"],
+    weights: dict[str, float] = DEFAULT_WEIGHTS,
+) -> dict[str, Optional[float]]:
+    """Score every row in a duplicate group.
+
+    Returns a mapping from ``source_path`` to score (or ``None`` for Live
+    Photo MOV passengers). The action layer (PR 6) walks this dict,
+    skips None entries and locked rows, then applies KEEP/DELETE to the
+    survivors.
+
+    Pure function — sample fixtures and weights, get deterministic scores.
+    """
+    return {
+        r.source_path: compute_score(r, group_rows, weights)
+        for r in group_rows
+    }

--- a/tests/test_manifest_repository.py
+++ b/tests/test_manifest_repository.py
@@ -1184,3 +1184,97 @@ class TestIsLockedPersistence:
         # File doesn't even exist; empty dict should be a guard-clause early return
         ManifestRepository().batch_update_lock_state(str(db), {})
         assert not db.exists()
+
+
+# ---------------------------------------------------------------------------
+# Scoring system schema migration (photo-manager#187 — PR 1)
+# ---------------------------------------------------------------------------
+
+
+class TestScoringSchemaMigration:
+    """Old DBs lacking exif_tag_count / gps_present / xmp_derived / score must
+    auto-migrate on load. New manifests get the columns from the base DDL;
+    older manifests get them via the additive ALTER TABLE list.
+
+    These four columns are added together in PR 1 (#187) so the scoring
+    system has somewhere to write its raw signals and composite score.
+    Old manifests load with gps_present=0, xmp_derived=0, exif_tag_count=NULL,
+    score=NULL — all of which the scorer interprets as 'no signal' (0.0).
+    """
+
+    def test_old_db_without_scoring_columns_auto_migrates(self, tmp_path):
+        """An old DB without any of the four scoring columns gains them on
+        first load. The load itself must not raise; subsequent inspection
+        confirms all four columns are present with the expected types."""
+        cand = tmp_path / "a.jpg"
+        ref = tmp_path / "b.jpg"
+        cand.write_bytes(b""); ref.write_bytes(b"")
+        gid = "/group/a"
+        # _DDL_WITH_IS_LOCKED predates the scoring columns — same shape as a
+        # manifest written before #187.
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": str(cand), "action": "REVIEW_DUPLICATE",
+                  "group_id": gid}),
+            _row({"source_path": str(ref), "action": "MOVE", "group_id": gid,
+                  "hamming_distance": None}),
+        ], ddl=_DDL_WITH_IS_LOCKED)
+
+        # First load triggers the migration (ALTER TABLE ADD COLUMN x4).
+        list(ManifestRepository().load(str(db)))
+
+        # All four columns now exist.
+        conn = sqlite3.connect(db)
+        try:
+            cols = {row[1] for row in conn.execute("PRAGMA table_info(migration_manifest)")}
+        finally:
+            conn.close()
+        for expected in ("exif_tag_count", "gps_present", "xmp_derived", "score"):
+            assert expected in cols, f"Migration did not add column: {expected}"
+
+    def test_old_db_scoring_columns_have_safe_defaults(self, tmp_path):
+        """After migration, pre-existing rows get the documented defaults:
+        gps_present=0, xmp_derived=0, exif_tag_count=NULL, score=NULL.
+        These are the 'no signal' values for an unscored manifest."""
+        cand = tmp_path / "a.jpg"
+        ref = tmp_path / "b.jpg"
+        cand.write_bytes(b""); ref.write_bytes(b"")
+        gid = "/group/a"
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": str(cand), "action": "REVIEW_DUPLICATE",
+                  "group_id": gid}),
+            _row({"source_path": str(ref), "action": "MOVE", "group_id": gid,
+                  "hamming_distance": None}),
+        ], ddl=_DDL_WITH_IS_LOCKED)
+
+        list(ManifestRepository().load(str(db)))  # trigger migration
+
+        conn = sqlite3.connect(db)
+        try:
+            r = conn.execute(
+                "SELECT exif_tag_count, gps_present, xmp_derived, score "
+                "FROM migration_manifest"
+            ).fetchone()
+        finally:
+            conn.close()
+        # exif_tag_count and score nullable; gps_present and xmp_derived
+        # NOT NULL DEFAULT 0 per migration spec.
+        assert r == (None, 0, 0, None)
+
+    def test_migration_is_idempotent(self, tmp_path):
+        """Loading an already-migrated DB must not error — ALTER TABLE ADD
+        COLUMN raises on duplicate columns, which the repository swallows.
+        Re-running load() twice exercises that swallow path."""
+        cand = tmp_path / "a.jpg"
+        ref = tmp_path / "b.jpg"
+        cand.write_bytes(b""); ref.write_bytes(b"")
+        gid = "/group/a"
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": str(cand), "action": "REVIEW_DUPLICATE",
+                  "group_id": gid}),
+            _row({"source_path": str(ref), "action": "MOVE", "group_id": gid,
+                  "hamming_distance": None}),
+        ], ddl=_DDL_WITH_IS_LOCKED)
+
+        # First load adds the columns; second load must not raise.
+        list(ManifestRepository().load(str(db)))
+        list(ManifestRepository().load(str(db)))  # should not raise

--- a/tests/test_media_extract.py
+++ b/tests/test_media_extract.py
@@ -1,0 +1,272 @@
+"""Tests for scanner.media_extract — canonical extraction schema (#187 — PR 2).
+
+The MediaExtract dataclass is the single contract every extractor (PIL,
+rawpy, exiftool, os.stat) writes against, so no scoring signal is silently
+dropped for some file type. ``merge_extracts`` combines partial extracts
+with explicit per-field precedence:
+
+  * pixel_width/height — rawpy > PIL (sensor dims, not thumbnail)
+  * exif_date — exiftool > PIL (more reliable parser, XMP-aware)
+  * everything else — first non-None wins
+  * booleans — None = not checked; False = checked absent; True = present
+
+The sentinel convention is the load-bearing part: tests assert that after
+the full pipeline runs, fields are not silently None when they should be
+False/True. That's the regression we are protecting against.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+from scanner.media_extract import MediaExtract, merge_extracts
+
+
+# ── MediaExtract construction ──────────────────────────────────────────────
+
+
+class TestMediaExtractConstruction:
+    def test_only_path_required(self):
+        """Every other field has a safe default — partial extracts construct
+        with just the path."""
+        ex = MediaExtract(path=Path("/x/a.jpg"))
+        assert ex.path == Path("/x/a.jpg")
+        assert ex.file_type == ""
+        assert ex.sha256 is None
+        assert ex.gps_present is None  # sentinel: not checked
+
+    def test_extracted_by_defaults_empty_set(self):
+        ex = MediaExtract(path=Path("/x/a.jpg"))
+        assert ex.extracted_by == set()
+        assert ex.extraction_errors == []
+
+    def test_extracted_by_per_instance(self):
+        """Mutable default mistakes (shared set across instances) would
+        couple every MediaExtract to every other. Verify isolation."""
+        a = MediaExtract(path=Path("/x/a.jpg"))
+        b = MediaExtract(path=Path("/x/b.jpg"))
+        a.extracted_by.add("pil")
+        assert "pil" not in b.extracted_by
+
+
+# ── merge_extracts: basic mechanics ────────────────────────────────────────
+
+
+class TestMergeExtractsBasics:
+    def test_no_partials_raises(self):
+        with pytest.raises(ValueError, match="requires at least one"):
+            merge_extracts()
+
+    def test_different_paths_raises(self):
+        a = MediaExtract(path=Path("/x/a.jpg"))
+        b = MediaExtract(path=Path("/x/b.jpg"))
+        with pytest.raises(ValueError, match="must share path"):
+            merge_extracts(a, b)
+
+    def test_single_partial_returns_equivalent(self):
+        """Merging one partial returns its values (new instance, same data)."""
+        a = MediaExtract(
+            path=Path("/x/a.jpg"),
+            sha256="deadbeef",
+            phash="aabbcc",
+            extracted_by={"pil", "hasher"},
+        )
+        merged = merge_extracts(a)
+        assert merged.path == a.path
+        assert merged.sha256 == "deadbeef"
+        assert merged.phash == "aabbcc"
+        assert merged.extracted_by == {"pil", "hasher"}
+
+    def test_provenance_union(self):
+        """extracted_by and extraction_errors are unioned across partials."""
+        a = MediaExtract(
+            path=Path("/x/a.jpg"),
+            extracted_by={"hasher", "pil"},
+            extraction_errors=["pil decode warning"],
+        )
+        b = MediaExtract(
+            path=Path("/x/a.jpg"),
+            extracted_by={"exiftool"},
+            extraction_errors=["exiftool no GPS"],
+        )
+        merged = merge_extracts(a, b)
+        assert merged.extracted_by == {"hasher", "pil", "exiftool"}
+        assert merged.extraction_errors == ["pil decode warning", "exiftool no GPS"]
+
+    def test_file_type_first_non_empty_wins(self):
+        a = MediaExtract(path=Path("/x/a.jpg"))  # file_type=""
+        b = MediaExtract(path=Path("/x/a.jpg"), file_type="jpeg")
+        merged = merge_extracts(a, b)
+        assert merged.file_type == "jpeg"
+
+
+# ── merge_extracts: simple-field precedence ─────────────────────────────────
+
+
+class TestMergeExtractsSimpleFields:
+    def test_first_non_none_wins_for_sha256(self):
+        a = MediaExtract(path=Path("/x/a.jpg"), sha256="aaa")
+        b = MediaExtract(path=Path("/x/a.jpg"), sha256="bbb")
+        merged = merge_extracts(a, b)
+        assert merged.sha256 == "aaa"
+
+    def test_none_skipped_for_phash(self):
+        """A None partial should not overwrite a later non-None partial."""
+        a = MediaExtract(path=Path("/x/a.jpg"))  # phash=None
+        b = MediaExtract(path=Path("/x/a.jpg"), phash="abcd")
+        merged = merge_extracts(a, b)
+        assert merged.phash == "abcd"
+
+    def test_file_size_from_stat_partial(self):
+        a = MediaExtract(path=Path("/x/a.jpg"), extracted_by={"hasher"})
+        b = MediaExtract(
+            path=Path("/x/a.jpg"),
+            file_size_bytes=12345,
+            extracted_by={"stat"},
+        )
+        merged = merge_extracts(a, b)
+        assert merged.file_size_bytes == 12345
+
+
+# ── merge_extracts: rawpy beats PIL for pixel dimensions ────────────────────
+
+
+class TestMergeExtractsRawpyPrecedence:
+    def test_rawpy_dims_override_pil_dims(self):
+        """For a RAW file, PIL reads the thumbnail (e.g. 1024×768) while
+        rawpy reads the sensor (e.g. 6000×4000). rawpy must win."""
+        pil_partial = MediaExtract(
+            path=Path("/x/photo.nef"),
+            pixel_width=1024, pixel_height=768,
+            extracted_by={"hasher", "pil"},
+        )
+        rawpy_partial = MediaExtract(
+            path=Path("/x/photo.nef"),
+            pixel_width=6000, pixel_height=4000,
+            extracted_by={"rawpy"},
+        )
+        merged = merge_extracts(pil_partial, rawpy_partial)
+        assert merged.pixel_width == 6000
+        assert merged.pixel_height == 4000
+
+    def test_pil_only_wins_when_no_rawpy(self):
+        pil_partial = MediaExtract(
+            path=Path("/x/photo.jpg"),
+            pixel_width=4032, pixel_height=3024,
+            extracted_by={"hasher", "pil"},
+        )
+        merged = merge_extracts(pil_partial)
+        assert merged.pixel_width == 4032
+        assert merged.pixel_height == 3024
+
+    def test_rawpy_partial_with_none_dims_skipped(self):
+        """If the rawpy partial has None dims (failed extract), PIL's dims
+        are used as fallback."""
+        pil_partial = MediaExtract(
+            path=Path("/x/photo.nef"),
+            pixel_width=1024, pixel_height=768,
+            extracted_by={"hasher", "pil"},
+        )
+        rawpy_partial = MediaExtract(
+            path=Path("/x/photo.nef"),
+            extracted_by={"rawpy"},
+            extraction_errors=["rawpy LibRawError"],
+        )
+        merged = merge_extracts(pil_partial, rawpy_partial)
+        assert merged.pixel_width == 1024
+        assert merged.pixel_height == 768
+
+
+# ── merge_extracts: exiftool beats PIL for exif_date ────────────────────────
+
+
+class TestMergeExtractsExifDatePrecedence:
+    def test_exiftool_date_overrides_pil_date(self):
+        pil_partial = MediaExtract(
+            path=Path("/x/a.jpg"),
+            exif_date=datetime(2020, 1, 1, 0, 0, 0),
+            extracted_by={"hasher", "pil"},
+        )
+        exiftool_partial = MediaExtract(
+            path=Path("/x/a.jpg"),
+            exif_date=datetime(2024, 6, 15, 10, 30, 0),
+            exif_date_tag="EXIF:DateTimeOriginal",
+            extracted_by={"exiftool"},
+        )
+        merged = merge_extracts(pil_partial, exiftool_partial)
+        assert merged.exif_date == datetime(2024, 6, 15, 10, 30, 0)
+        assert merged.exif_date_tag == "EXIF:DateTimeOriginal"
+
+    def test_pil_date_used_when_exiftool_no_date(self):
+        """exiftool extraction may produce no date for malformed EXIF — fall
+        back to PIL's date if it found one."""
+        pil_partial = MediaExtract(
+            path=Path("/x/a.jpg"),
+            exif_date=datetime(2024, 6, 15, 10, 30, 0),
+            extracted_by={"hasher", "pil"},
+        )
+        exiftool_partial = MediaExtract(
+            path=Path("/x/a.jpg"),
+            extracted_by={"exiftool"},   # exif_date=None
+        )
+        merged = merge_extracts(pil_partial, exiftool_partial)
+        assert merged.exif_date == datetime(2024, 6, 15, 10, 30, 0)
+        # PIL doesn't surface the tag name; exiftool partial had no date.
+        assert merged.exif_date_tag is None
+
+
+# ── merge_extracts: boolean sentinels (None vs False vs True) ───────────────
+
+
+class TestMergeExtractsBooleanSentinels:
+    def test_none_means_not_checked_skipped_in_merge(self):
+        """A partial whose gps_present is None must NOT overwrite a partial
+        with an explicit False — None means 'not checked', False is data."""
+        unchecked = MediaExtract(path=Path("/x/a.jpg"), extracted_by={"hasher"})
+        # gps_present defaults to None
+        checked_absent = MediaExtract(
+            path=Path("/x/a.jpg"),
+            gps_present=False,
+            extracted_by={"exiftool"},
+        )
+        merged = merge_extracts(unchecked, checked_absent)
+        assert merged.gps_present is False  # NOT None
+
+    def test_false_is_taken_not_skipped(self):
+        """The classic mistake: treating False like None and skipping it.
+        merge_extracts must take False as a real value."""
+        a = MediaExtract(
+            path=Path("/x/a.jpg"),
+            gps_present=False,
+            extracted_by={"exiftool"},
+        )
+        b = MediaExtract(path=Path("/x/a.jpg"), extracted_by={"hasher"})
+        merged = merge_extracts(a, b)
+        assert merged.gps_present is False
+
+    def test_first_true_wins(self):
+        a = MediaExtract(
+            path=Path("/x/a.jpg"),
+            gps_present=True,
+            extracted_by={"exiftool"},
+        )
+        b = MediaExtract(
+            path=Path("/x/a.jpg"),
+            gps_present=False,
+            extracted_by={"other"},
+        )
+        merged = merge_extracts(a, b)
+        assert merged.gps_present is True
+
+    def test_xmp_derived_sentinel_preserved(self):
+        a = MediaExtract(path=Path("/x/a.jpg"))  # xmp_derived=None
+        b = MediaExtract(
+            path=Path("/x/a.jpg"),
+            xmp_derived=False,
+            extracted_by={"exiftool"},
+        )
+        merged = merge_extracts(a, b)
+        assert merged.xmp_derived is False

--- a/tests/test_scanner_exif.py
+++ b/tests/test_scanner_exif.py
@@ -984,3 +984,311 @@ class TestRealExiftoolFixtures:
         get removed."""
         assert (_FIXTURE_DIR / "exif_edge_batch.txt").exists()
         assert (_FIXTURE_DIR / "mixed_batch.txt").exists()
+
+
+# ── batch_read_extracts (#187 — PR 2) ──────────────────────────────────────
+
+
+class TestBatchReadExtracts:
+    """Extended exiftool batch for the scoring system.
+
+    Critical sentinel contract: after this function runs, ``gps_present`` and
+    ``xmp_derived`` are *never* None — they are always explicit booleans
+    (False = checked and absent, True = present). A None on either field
+    post-pipeline is the silent-dropout regression we are protecting against.
+    """
+
+    def test_empty_paths_returns_empty(self):
+        from scanner.exif import batch_read_extracts
+        et = MagicMock()
+        result = batch_read_extracts([], et)
+        assert result == {}
+        et.execute.assert_not_called()
+
+    def test_gps_present_true_when_latitude_in_record(self):
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([
+            (paths[0], {
+                "EXIF:GPSLatitude": "37 deg 46' 0.00\" N",
+                "EXIF:GPSLongitude": "122 deg 25' 0.00\" W",
+            }),
+        ])
+        result = batch_read_extracts(paths, et)
+        assert result[paths[0]].gps_present is True
+
+    def test_gps_present_false_when_no_gps_tags(self):
+        """Silent-dropout regression: an image without GPS must yield
+        gps_present=False (not None), proving the exiftool pass ran."""
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([
+            (paths[0], {"EXIF:DateTimeOriginal": "2024:06:15 10:30:00"}),
+        ])
+        result = batch_read_extracts(paths, et)
+        assert result[paths[0]].gps_present is False  # NOT None
+
+    def test_gps_present_true_for_video_quicktime_coords(self):
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/clip.mov")]
+        et = _make_mock_et([
+            (paths[0], {"QuickTime:GPSCoordinates": "37.7,-122.4"}),
+        ])
+        result = batch_read_extracts(paths, et)
+        assert result[paths[0]].gps_present is True
+
+    def test_xmp_derived_true_when_derivedfrom_present(self):
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/edited.jpg")]
+        et = _make_mock_et([
+            (paths[0], {"XMP:DerivedFrom": "uuid:original-abc-123"}),
+        ])
+        result = batch_read_extracts(paths, et)
+        assert result[paths[0]].xmp_derived is True
+
+    def test_xmp_derived_false_when_absent(self):
+        """Silent-dropout regression for xmp_derived."""
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([(paths[0], None)])
+        result = batch_read_extracts(paths, et)
+        assert result[paths[0]].xmp_derived is False  # NOT None
+
+    def test_xmp_rating_parsed_as_int(self):
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([
+            (paths[0], {"XMP:Rating": 5}),
+        ])
+        result = batch_read_extracts(paths, et)
+        assert result[paths[0]].xmp_rating == 5
+
+    def test_xmp_rating_string_coerced(self):
+        """exiftool sometimes emits Rating as string; defensive coerce."""
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([
+            (paths[0], {"XMP:Rating": "4"}),
+        ])
+        result = batch_read_extracts(paths, et)
+        assert result[paths[0]].xmp_rating == 4
+
+    def test_xmp_rating_none_when_absent(self):
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([(paths[0], None)])
+        result = batch_read_extracts(paths, et)
+        assert result[paths[0]].xmp_rating is None
+
+    def test_exif_tag_count_counts_census_tags(self):
+        """Count includes only tags in the documented census set
+        (image + video tags). Non-census tags like ``EXIF:CreateDate``
+        do not contribute even when present in the record."""
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([
+            (paths[0], {
+                "EXIF:DateTimeOriginal": "2024:06:15 10:30:00",
+                "EXIF:Make": "Canon",
+                "EXIF:Model": "EOS 5D",
+                "EXIF:ISO": "400",
+                # EXIF:CreateDate is in the date fallback chain but NOT in
+                # the census — counting it would double-credit dates.
+                "EXIF:CreateDate": "2024:06:15 10:30:00",
+            }),
+        ])
+        result = batch_read_extracts(paths, et)
+        assert result[paths[0]].exif_tag_count == 4
+
+    def test_exif_tag_count_zero_when_no_census_tags(self):
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([(paths[0], None)])
+        result = batch_read_extracts(paths, et)
+        assert result[paths[0]].exif_tag_count == 0
+
+    def test_exif_date_tag_records_source_tag(self):
+        """When DateTimeOriginal produces the date, exif_date_tag carries
+        the exact tag name so the date_provenance scorer (PR 3) can
+        weight DateTimeOriginal-derived dates higher than CreateDate
+        fallbacks."""
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([
+            (paths[0], {"EXIF:DateTimeOriginal": "2024:06:15 10:30:00"}),
+        ])
+        result = batch_read_extracts(paths, et)
+        assert result[paths[0]].exif_date == datetime(2024, 6, 15, 10, 30, 0)
+        assert result[paths[0]].exif_date_tag == "EXIF:DateTimeOriginal"
+
+    def test_exif_date_tag_fallback_path(self):
+        """When DateTimeOriginal is absent, the tag name reflects which
+        tag actually produced the date (CreateDate, QuickTime:CreateDate,
+        etc.)."""
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([
+            (paths[0], {"EXIF:CreateDate": "2024:01:01 08:00:00"}),
+        ])
+        result = batch_read_extracts(paths, et)
+        assert result[paths[0]].exif_date == datetime(2024, 1, 1, 8, 0, 0)
+        assert result[paths[0]].exif_date_tag == "EXIF:CreateDate"
+
+    def test_extracted_by_marks_exiftool(self):
+        """Every MediaExtract returned must have ``"exiftool"`` in
+        extracted_by — that's how merge_extracts knows this partial came
+        from exiftool and applies the exiftool-wins-on-exif_date rule."""
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([(paths[0], None)])
+        result = batch_read_extracts(paths, et)
+        assert "exiftool" in result[paths[0]].extracted_by
+
+    def test_missing_record_returns_partial_with_error(self):
+        """If exiftool returns no record for a path (e.g. file vanished
+        mid-batch), we still emit a MediaExtract with extracted_by={
+        'exiftool'} and an error message — never silently drop the path."""
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([])  # empty output — no records for any path
+        result = batch_read_extracts(paths, et)
+        assert paths[0] in result
+        assert "exiftool" in result[paths[0]].extracted_by
+        assert len(result[paths[0]].extraction_errors) == 1
+        # All signals stay None for missing records (the scorer treats them
+        # as "no signal").
+        assert result[paths[0]].gps_present is None
+
+    def test_chunking_calls_execute_multiple_times(self):
+        """Same chunking semantics as batch_read_dates — chunk_size paths
+        per execute call."""
+        import json as _json
+        from scanner.exif import batch_read_extracts
+
+        paths = [Path(f"/fake/{i}.jpg") for i in range(5)]
+
+        def fake_execute(args):
+            chunk_paths = [a for a in args if not a.startswith("-")]
+            records = [{"SourceFile": p} for p in chunk_paths]
+            return _json.dumps(records)
+
+        et = MagicMock()
+        et.execute.side_effect = fake_execute
+
+        batch_read_extracts(paths, et, chunk_size=2)
+        assert et.execute.call_count == 3  # ceil(5/2)
+
+    def test_args_omit_fast_flag(self):
+        """Critical: the extended batch must NOT use ``-fast``. GPS and
+        XMP tags live in segments past the first IFD that ``-fast`` skips,
+        so including it would silently zero out gps_present / xmp_derived
+        for every file. Regression-protect that decision."""
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([(paths[0], None)])
+        batch_read_extracts(paths, et)
+        called_args = et.execute.call_args[0][0]
+        assert "-fast" not in called_args
+
+    def test_args_include_gps_and_xmp_selectors(self):
+        """Sanity check that the new tag selectors actually reach exiftool.
+        If someone removes ``-GPSLatitude`` later, gps_present would always
+        be False — caught here at the args layer instead of in production."""
+        from scanner.exif import batch_read_extracts
+        paths = [Path("/fake/img.jpg")]
+        et = _make_mock_et([(paths[0], None)])
+        batch_read_extracts(paths, et)
+        called_args = et.execute.call_args[0][0]
+        # GPS
+        assert "-GPSLatitude" in called_args
+        assert "-QuickTime:GPSCoordinates" in called_args
+        # XMP provenance + rating
+        assert "-XMP-xmpMM:DerivedFrom" in called_args
+        assert "-XMP:Rating" in called_args
+
+
+# ── HashResult.to_media_extract adapter (#187 — PR 2) ──────────────────────
+
+
+class TestHashResultToMediaExtract:
+    """HashResult is the existing single-read hasher output. The adapter
+    converts it into a partial MediaExtract that merge_extracts can combine
+    with the exiftool partial.
+
+    extracted_by must reflect which tools actually contributed data so the
+    merge step's rawpy-wins-on-dims rule fires correctly.
+    """
+
+    def test_jpeg_extract_marks_hasher_and_pil(self):
+        from scanner.dedup import HashResult
+        from scanner.walker import FileRecord
+        rec = FileRecord(
+            path=Path("/x/a.jpg"), source_label="src",
+            file_type="jpeg",
+        )
+        hr = HashResult(
+            record=rec, sha256="abc", phash="defg",
+            exif_date=datetime(2024, 1, 1, 12, 0, 0),
+            mean_color="100,120,140",
+            pixel_width=4032, pixel_height=3024,
+        )
+        me = hr.to_media_extract()
+        assert me.path == Path("/x/a.jpg")
+        assert me.file_type == "jpeg"
+        assert me.sha256 == "abc"
+        assert me.phash == "defg"
+        assert me.mean_color == "100,120,140"
+        assert me.pixel_width == 4032
+        assert me.extracted_by == {"hasher", "pil"}
+
+    def test_raw_extract_marks_rawpy(self):
+        """For RAW files with dims, rawpy must be in extracted_by so
+        merge_extracts picks rawpy's sensor dims over PIL's thumbnail."""
+        from scanner.dedup import HashResult
+        from scanner.walker import FileRecord
+        rec = FileRecord(
+            path=Path("/x/photo.nef"), source_label="src",
+            file_type="raw",
+        )
+        hr = HashResult(
+            record=rec, sha256="abc", phash="thumbphash",
+            exif_date=None,  # RAW dates come from exiftool, not PIL
+            pixel_width=6000, pixel_height=4000,
+        )
+        me = hr.to_media_extract()
+        assert "rawpy" in me.extracted_by
+        assert "pil" in me.extracted_by   # phash means PIL also ran
+        assert "hasher" in me.extracted_by
+
+    def test_video_extract_marks_only_hasher(self):
+        """Video files: only sha256 is computed (streamed); no PIL, no rawpy."""
+        from scanner.dedup import HashResult
+        from scanner.walker import FileRecord
+        rec = FileRecord(
+            path=Path("/x/clip.mov"), source_label="src",
+            file_type="mov",
+        )
+        hr = HashResult(
+            record=rec, sha256="abc", phash=None,
+            exif_date=None,
+        )
+        me = hr.to_media_extract()
+        assert me.extracted_by == {"hasher"}
+
+    def test_no_exif_date_tag_from_pil(self):
+        """PIL doesn't surface which EXIF IFD/tag produced the date, so
+        exif_date_tag is None on a PIL-only partial. The exiftool partial
+        fills it in during merge."""
+        from scanner.dedup import HashResult
+        from scanner.walker import FileRecord
+        rec = FileRecord(
+            path=Path("/x/a.jpg"), source_label="src",
+            file_type="jpeg",
+        )
+        hr = HashResult(
+            record=rec, sha256="abc", phash="defg",
+            exif_date=datetime(2024, 1, 1, 12, 0, 0),
+        )
+        me = hr.to_media_extract()
+        assert me.exif_date == datetime(2024, 1, 1, 12, 0, 0)
+        assert me.exif_date_tag is None

--- a/tests/test_scanner_manifest.py
+++ b/tests/test_scanner_manifest.py
@@ -296,3 +296,108 @@ class TestManifestSchemaColumns:
         )
         result = _make_row(hr, "MOVE")
         assert result.shot_date is None
+
+
+# ── Scoring system schema (#187 — PR 1) ────────────────────────────────────
+
+class TestScoringSchemaColumns:
+    """Scoring system adds 4 columns: exif_tag_count, gps_present, xmp_derived, score.
+
+    Raw signals (exif_tag_count, gps_present, xmp_derived) are populated by the
+    extended exiftool pass in PR 2. The composite score is written by the scorer
+    in PR 3/4. PR 1 establishes the schema and ManifestRow plumbing only — all
+    four columns default to NULL or 0 until later PRs populate them.
+    """
+
+    def _cols(self, out: Path) -> set[str]:
+        with sqlite3.connect(out) as conn:
+            return {row[1] for row in conn.execute("PRAGMA table_info(migration_manifest)").fetchall()}
+
+    def test_manifest_has_exif_tag_count_column(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        write_manifest([], out)
+        assert "exif_tag_count" in self._cols(out)
+
+    def test_manifest_has_gps_present_column(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        write_manifest([], out)
+        assert "gps_present" in self._cols(out)
+
+    def test_manifest_has_xmp_derived_column(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        write_manifest([], out)
+        assert "xmp_derived" in self._cols(out)
+
+    def test_manifest_has_score_column(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        write_manifest([], out)
+        assert "score" in self._cols(out)
+
+    def test_write_manifest_stores_exif_tag_count(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        row = ManifestRow(
+            source_path="/a.jpg", source_label="iphone",
+            dest_path=None, action="MOVE", source_hash="abc",
+            phash=None, hamming_distance=None, duplicate_of=None, reason="",
+            exif_tag_count=12,
+        )
+        write_manifest([row], out)
+        with sqlite3.connect(out) as conn:
+            val = conn.execute("SELECT exif_tag_count FROM migration_manifest").fetchone()[0]
+        assert val == 12
+
+    def test_write_manifest_stores_gps_present_true(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        row = ManifestRow(
+            source_path="/a.jpg", source_label="iphone",
+            dest_path=None, action="MOVE", source_hash="abc",
+            phash=None, hamming_distance=None, duplicate_of=None, reason="",
+            gps_present=True,
+        )
+        write_manifest([row], out)
+        with sqlite3.connect(out) as conn:
+            val = conn.execute("SELECT gps_present FROM migration_manifest").fetchone()[0]
+        assert val == 1
+
+    def test_write_manifest_stores_xmp_derived_true(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        row = ManifestRow(
+            source_path="/a.jpg", source_label="iphone",
+            dest_path=None, action="MOVE", source_hash="abc",
+            phash=None, hamming_distance=None, duplicate_of=None, reason="",
+            xmp_derived=True,
+        )
+        write_manifest([row], out)
+        with sqlite3.connect(out) as conn:
+            val = conn.execute("SELECT xmp_derived FROM migration_manifest").fetchone()[0]
+        assert val == 1
+
+    def test_write_manifest_stores_score(self, tmp_path):
+        out = tmp_path / "manifest.sqlite"
+        row = ManifestRow(
+            source_path="/a.jpg", source_label="iphone",
+            dest_path=None, action="REVIEW_DUPLICATE", source_hash="abc",
+            phash=None, hamming_distance=None, duplicate_of=None, reason="",
+            score=0.875,
+        )
+        write_manifest([row], out)
+        with sqlite3.connect(out) as conn:
+            val = conn.execute("SELECT score FROM migration_manifest").fetchone()[0]
+        assert val == pytest.approx(0.875)
+
+    def test_write_manifest_defaults_gps_and_xmp_to_zero(self, tmp_path):
+        """Existing callers that don't set the new fields get safe defaults
+        (gps_present=0, xmp_derived=0, exif_tag_count=NULL, score=NULL)."""
+        out = tmp_path / "manifest.sqlite"
+        row = ManifestRow(
+            source_path="/a.jpg", source_label="iphone",
+            dest_path=None, action="MOVE", source_hash="abc",
+            phash=None, hamming_distance=None, duplicate_of=None, reason="",
+        )
+        write_manifest([row], out)
+        with sqlite3.connect(out) as conn:
+            r = conn.execute(
+                "SELECT exif_tag_count, gps_present, xmp_derived, score "
+                "FROM migration_manifest"
+            ).fetchone()
+        assert r == (None, 0, 0, None)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -1,0 +1,597 @@
+"""Tests for scanner.scoring — keep-worthiness composite scorer (#187 — PR 3).
+
+Test philosophy (per CLAUDE.md):
+
+* Each test catches a real bug. No tests that only exist to bump coverage.
+* Edge cases use realistic inputs (None pixel_width on a video file, etc.),
+  not synthetic monkeypatched failures.
+* The scorer is a pure function — all tests construct ``ManifestRow``
+  fixtures in memory. No filesystem access is involved or expected.
+
+Coverage scope:
+
+* Each of the 8 Tier 2 dimensions (resolution, file_size, exif_complete,
+  date_prov, gps, filename, path, live_photo) with happy paths + edge cases.
+* Tier 1 penalties: format penalty lookup + xmp_derived deduction.
+* Live Photo MOV passenger rule (``score = None``).
+* Composite ``compute_score`` clamps to [0.0, 1.0] and uses weights.
+* Configurable weights: rejects missing keys, rejects bad sum.
+* ``score_group`` returns a dict keyed by source_path.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Optional
+
+import pytest
+
+from scanner.dedup import ManifestRow
+from scanner.scoring import (
+    DEFAULT_WEIGHTS,
+    DERIVED_PENALTY,
+    FORMAT_PENALTY,
+    IMAGE_EXIF_CENSUS_BASELINE,
+    VIDEO_EXIF_CENSUS_BASELINE,
+    _score_date_provenance,
+    _score_exif_completeness,
+    _score_file_size,
+    _score_filename,
+    _score_gps,
+    _score_live_photo,
+    _score_path,
+    _score_resolution,
+    compute_score,
+    score_group,
+    validate_weights,
+)
+
+
+# ── Test fixture helper ────────────────────────────────────────────────────
+
+
+def _row(
+    source_path: str,
+    *,
+    pixel_width: Optional[int] = None,
+    pixel_height: Optional[int] = None,
+    file_size_bytes: Optional[int] = None,
+    shot_date: Optional[str] = None,
+    mtime: Optional[str] = None,
+    exif_tag_count: Optional[int] = None,
+    gps_present: bool = False,
+    xmp_derived: bool = False,
+    group_id: Optional[str] = "/group/x",
+) -> ManifestRow:
+    """Build a ManifestRow with only the fields the scorer reads.
+
+    Other fields (source_label, action, source_hash, …) are filled with
+    benign placeholders. Constructing one of these never touches the
+    filesystem — that's the point of the in-memory test pattern.
+    """
+    return ManifestRow(
+        source_path=source_path,
+        source_label="src",
+        dest_path=None,
+        action="REVIEW_DUPLICATE",
+        source_hash="0",
+        phash=None,
+        hamming_distance=None,
+        duplicate_of=None,
+        reason="",
+        pixel_width=pixel_width,
+        pixel_height=pixel_height,
+        file_size_bytes=file_size_bytes,
+        shot_date=shot_date,
+        mtime=mtime,
+        group_id=group_id,
+        exif_tag_count=exif_tag_count,
+        gps_present=gps_present,
+        xmp_derived=xmp_derived,
+    )
+
+
+# ── Tier 2 dimension 1: resolution ─────────────────────────────────────────
+
+
+class TestResolutionScore:
+    def test_highest_in_group_gets_one(self):
+        big = _row("/x/big.jpg", pixel_width=6000, pixel_height=4000)
+        small = _row("/x/small.jpg", pixel_width=1024, pixel_height=768)
+        assert _score_resolution(big, [big, small]) == 1.0
+
+    def test_lowest_in_group_gets_zero(self):
+        big = _row("/x/big.jpg", pixel_width=6000, pixel_height=4000)
+        small = _row("/x/small.jpg", pixel_width=1024, pixel_height=768)
+        assert _score_resolution(small, [big, small]) == 0.0
+
+    def test_tied_resolutions_score_one(self):
+        a = _row("/x/a.jpg", pixel_width=4000, pixel_height=3000)
+        b = _row("/x/b.jpg", pixel_width=4000, pixel_height=3000)
+        assert _score_resolution(a, [a, b]) == 1.0
+        assert _score_resolution(b, [a, b]) == 1.0
+
+    def test_video_with_none_dims_scores_zero(self):
+        """Realistic case: a .mov in a group of images. Video files have
+        no pixel_width — scorer must not crash."""
+        img = _row("/x/photo.jpg", pixel_width=4000, pixel_height=3000)
+        vid = _row("/x/clip.mov")  # pixel_width=None by default
+        assert _score_resolution(vid, [img, vid]) == 0.0
+
+    def test_single_row_group_scores_one(self):
+        """Edge: rescore on an isolated group of 1 row (should not crash
+        and should not produce zero-by-default)."""
+        only = _row("/x/only.jpg", pixel_width=4000, pixel_height=3000)
+        assert _score_resolution(only, [only]) == 1.0
+
+    def test_proportional_score_in_middle(self):
+        """Linear interpolation between min and max."""
+        small = _row("/x/small.jpg", pixel_width=1000, pixel_height=1000)   # 1M
+        mid = _row("/x/mid.jpg", pixel_width=2000, pixel_height=1000)       # 2M
+        big = _row("/x/big.jpg", pixel_width=3000, pixel_height=1000)       # 3M
+        # Range = 2M; mid is at +1M from min → 0.5
+        assert _score_resolution(mid, [small, mid, big]) == pytest.approx(0.5)
+
+
+# ── Tier 2 dimension 2: file_size ──────────────────────────────────────────
+
+
+class TestFileSizeScore:
+    def test_largest_in_group_gets_one(self):
+        big = _row("/x/big.jpg", file_size_bytes=5_000_000)
+        small = _row("/x/small.jpg", file_size_bytes=500_000)
+        assert _score_file_size(big, [big, small]) == 1.0
+        assert _score_file_size(small, [big, small]) == 0.0
+
+    def test_none_file_size_scores_zero(self):
+        a = _row("/x/a.jpg", file_size_bytes=1_000_000)
+        b = _row("/x/b.jpg")  # file_size_bytes=None
+        assert _score_file_size(b, [a, b]) == 0.0
+
+    def test_all_same_size_scores_one(self):
+        a = _row("/x/a.jpg", file_size_bytes=1_000_000)
+        b = _row("/x/b.jpg", file_size_bytes=1_000_000)
+        assert _score_file_size(a, [a, b]) == 1.0
+
+
+# ── Tier 2 dimension 3: EXIF completeness ──────────────────────────────────
+
+
+class TestExifCompletenessScore:
+    def test_full_image_census(self):
+        img = _row("/x/a.jpg", exif_tag_count=IMAGE_EXIF_CENSUS_BASELINE)
+        assert _score_exif_completeness(img) == 1.0
+
+    def test_partial_image_census(self):
+        img = _row("/x/a.jpg", exif_tag_count=8)
+        # 8 / 16 = 0.5
+        assert _score_exif_completeness(img) == 0.5
+
+    def test_zero_image_census(self):
+        img = _row("/x/a.jpg", exif_tag_count=0)
+        assert _score_exif_completeness(img) == 0.0
+
+    def test_over_image_baseline_capped_at_one(self):
+        """If a file has more census tags than the baseline (rare), cap."""
+        img = _row("/x/a.jpg", exif_tag_count=20)
+        assert _score_exif_completeness(img) == 1.0
+
+    def test_video_uses_video_baseline(self):
+        """Video baseline is 9, not 16 — a video with 9 tags scores 1.0."""
+        vid = _row("/x/clip.mov", exif_tag_count=VIDEO_EXIF_CENSUS_BASELINE)
+        assert _score_exif_completeness(vid) == 1.0
+
+    def test_none_tag_count_scores_zero(self):
+        """Old manifests pre-PR-2 have NULL exif_tag_count — scorer treats
+        as 'no signal' (0.0) so old data degrades gracefully."""
+        img = _row("/x/a.jpg")  # exif_tag_count=None
+        assert _score_exif_completeness(img) == 0.0
+
+
+# ── Tier 2 dimension 4: date provenance ────────────────────────────────────
+
+
+class TestDateProvenanceScore:
+    def test_real_exif_date_scores_one(self):
+        """shot_date is set and differs from mtime → 1.0 (genuine EXIF)."""
+        row = _row(
+            "/x/a.jpg",
+            shot_date="2024-06-15T10:30:00",
+            mtime="2025-01-01T12:00:00",
+        )
+        assert _score_date_provenance(row) == 1.0
+
+    def test_no_shot_date_scores_zero(self):
+        row = _row("/x/a.jpg", shot_date=None, mtime="2025-01-01T12:00:00")
+        assert _score_date_provenance(row) == 0.0
+
+    def test_shot_date_matches_mtime_scores_suspicious(self):
+        """When shot_date == mtime exactly, it's likely mtime-derived
+        (file copy inherited filesystem timestamp). Score 0.3 reflects
+        the suspicion without zeroing it out completely."""
+        row = _row(
+            "/x/a.jpg",
+            shot_date="2024-06-15T10:30:00",
+            mtime="2024-06-15T10:30:00",
+        )
+        assert _score_date_provenance(row) == 0.3
+
+    def test_close_match_within_tolerance_scores_suspicious(self):
+        """Tolerance is 2 seconds — a 1-second delta still flags as
+        mtime-derived (filesystem-write second-precision rounding)."""
+        row = _row(
+            "/x/a.jpg",
+            shot_date="2024-06-15T10:30:01",
+            mtime="2024-06-15T10:30:00",
+        )
+        assert _score_date_provenance(row) == 0.3
+
+    def test_exceeds_tolerance_scores_real(self):
+        row = _row(
+            "/x/a.jpg",
+            shot_date="2024-06-15T10:30:05",
+            mtime="2024-06-15T10:30:00",
+        )
+        assert _score_date_provenance(row) == 1.0
+
+    def test_no_mtime_still_scores_real(self):
+        """Old manifests may have shot_date but no mtime — give benefit
+        of the doubt and score 1.0."""
+        row = _row("/x/a.jpg", shot_date="2024-06-15T10:30:00", mtime=None)
+        assert _score_date_provenance(row) == 1.0
+
+    def test_malformed_date_strings_recover_gracefully(self):
+        """Defensive: a corrupted shot_date / mtime should not crash the
+        whole scoring pipeline. Falls through to the 'real' score."""
+        row = _row(
+            "/x/a.jpg",
+            shot_date="not-a-date",
+            mtime="2024-06-15T10:30:00",
+        )
+        assert _score_date_provenance(row) == 1.0
+
+
+# ── Tier 2 dimension 5: GPS ────────────────────────────────────────────────
+
+
+class TestGpsScore:
+    def test_gps_present_scores_one(self):
+        row = _row("/x/a.jpg", gps_present=True)
+        assert _score_gps(row) == 1.0
+
+    def test_gps_absent_scores_zero(self):
+        row = _row("/x/a.jpg", gps_present=False)
+        assert _score_gps(row) == 0.0
+
+
+# ── Tier 2 dimension 6: filename ──────────────────────────────────────────
+
+
+class TestFilenameScore:
+    def test_clean_filename_scores_one(self):
+        row = _row("/x/IMG_4567.jpg")
+        assert _score_filename(row) == 1.0
+
+    def test_copy_pattern_penalised(self):
+        row = _row("/x/Copy of photo.jpg")
+        assert _score_filename(row) == pytest.approx(0.7)
+
+    def test_paren_number_pattern_penalised(self):
+        """The classic "(1)" suffix from OS file-copy renames."""
+        row = _row("/x/photo (1).jpg")
+        assert _score_filename(row) == pytest.approx(0.7)
+
+    def test_edited_pattern_penalised(self):
+        row = _row("/x/photo_edited.jpg")
+        assert _score_filename(row) == pytest.approx(0.7)
+
+    def test_screenshot_pattern_penalised(self):
+        row = _row("/x/Screenshot 2024-01-01.png")
+        assert _score_filename(row) == pytest.approx(0.7)
+
+    def test_thumbnail_pattern_penalised(self):
+        row = _row("/x/photo_thumb.jpg")
+        assert _score_filename(row) == pytest.approx(0.7)
+
+    def test_multiple_patterns_compound(self):
+        """Two hits stack: 1.0 - 2*0.30 = 0.4."""
+        row = _row("/x/Copy of photo (1).jpg")
+        assert _score_filename(row) == pytest.approx(0.4)
+
+    def test_score_floor_at_zero(self):
+        """Many penalty hits should clamp at 0.0, not go negative."""
+        row = _row("/x/Copy of edited screenshot (1)_compressed.jpg")
+        assert _score_filename(row) == 0.0
+
+
+# ── Tier 2 dimension 7: path ────────────────────────────────────────────────
+
+
+class TestPathScore:
+    def test_clean_path_scores_one(self):
+        row = _row("/Users/me/Photos/2024/IMG_4567.jpg")
+        assert _score_path(row) == 1.0
+
+    def test_downloads_folder_penalised(self):
+        row = _row("/Users/me/Downloads/photo.jpg")
+        assert _score_path(row) == pytest.approx(0.75)
+
+    def test_whatsapp_folder_penalised(self):
+        row = _row("/Users/me/WhatsApp Images/photo.jpg")
+        assert _score_path(row) == pytest.approx(0.75)
+
+    def test_multiple_bad_segments_compound(self):
+        row = _row("/Users/me/Downloads/WhatsApp Images/photo.jpg")
+        # Two hits at -0.25 each → 0.5
+        assert _score_path(row) == pytest.approx(0.5)
+
+    def test_case_insensitive_match(self):
+        """Filesystems vary on case sensitivity — match must work
+        regardless of how the OS rendered the path."""
+        row = _row("/Users/me/DOWNLOADS/photo.jpg")
+        assert _score_path(row) == pytest.approx(0.75)
+
+
+# ── Tier 2 dimension 8: Live Photo completeness ─────────────────────────────
+
+
+class TestLivePhotoScore:
+    def test_heic_with_mov_peer_scores_one(self):
+        heic = _row("/x/IMG_001.heic")
+        mov = _row("/x/IMG_001.mov")
+        assert _score_live_photo(heic, [heic, mov]) == 1.0
+
+    def test_orphan_heic_scores_half(self):
+        heic = _row("/x/IMG_001.heic")
+        other = _row("/x/IMG_002.jpg")  # different stem
+        assert _score_live_photo(heic, [heic, other]) == 0.5
+
+    def test_jpeg_not_applicable_full_marks(self):
+        """Non-HEIC files always score 1.0 — the dimension is N/A."""
+        row = _row("/x/photo.jpg")
+        assert _score_live_photo(row, [row]) == 1.0
+
+    def test_case_insensitive_stem_match(self):
+        """A file named IMG_001.HEIC and another named img_001.MOV are
+        still a pair — Windows fixtures may produce mixed case."""
+        heic = _row("/x/IMG_001.HEIC")
+        mov = _row("/x/img_001.MOV")
+        assert _score_live_photo(heic, [heic, mov]) == 1.0
+
+    def test_mp4_peer_also_counts(self):
+        """Some Live Photo pairs use .mp4 instead of .mov."""
+        heic = _row("/x/IMG_001.heic")
+        mp4 = _row("/x/IMG_001.mp4")
+        assert _score_live_photo(heic, [heic, mp4]) == 1.0
+
+
+# ── Live Photo MOV passenger rule (compute_score returns None) ─────────────
+
+
+class TestLivePhotoMovPassengerRule:
+    """A MOV/MP4 whose stem matches a HEIC in the same group is a
+    passenger — it inherits the HEIC's KEEP/DELETE decision in the
+    action layer and is not scored as a ranking candidate. The scorer
+    enforces this by returning ``None`` for such rows.
+    """
+
+    def test_mov_with_heic_peer_returns_none(self):
+        heic = _row("/x/IMG_001.heic")
+        mov = _row("/x/IMG_001.mov")
+        assert compute_score(mov, [heic, mov]) is None
+
+    def test_mp4_with_heic_peer_returns_none(self):
+        heic = _row("/x/IMG_001.heic")
+        mp4 = _row("/x/IMG_001.mp4")
+        assert compute_score(mp4, [heic, mp4]) is None
+
+    def test_standalone_mov_returns_float(self):
+        """A .mov with no HEIC peer is a regular candidate — it gets
+        scored normally (and absorbs the video format penalty)."""
+        mov = _row("/x/clip.mov")
+        score = compute_score(mov, [mov])
+        assert isinstance(score, float)
+        assert 0.0 <= score <= 1.0
+
+    def test_heic_in_pair_still_scored(self):
+        """The HEIC side of the pair *is* scored — only the MOV passenger
+        gets None. The HEIC's score factors in its live_photo bonus."""
+        heic = _row("/x/IMG_001.heic")
+        mov = _row("/x/IMG_001.mov")
+        heic_score = compute_score(heic, [heic, mov])
+        assert isinstance(heic_score, float)
+
+
+# ── Tier 1 — Format penalty ─────────────────────────────────────────────────
+
+
+class TestFormatPenalty:
+    """Format penalty is a lookup table: RAW=0, lossless mid, JPEG/video
+    high, GIF highest. The values themselves are the contract — encoded
+    here so a future drive-by edit that changes them is caught."""
+
+    def test_raw_no_penalty(self):
+        assert FORMAT_PENALTY["nef"] == 0.0
+        assert FORMAT_PENALTY["cr2"] == 0.0
+        assert FORMAT_PENALTY["dng"] == 0.0
+
+    def test_heic_low_penalty(self):
+        assert FORMAT_PENALTY["heic"] == 0.10
+
+    def test_jpeg_standard_penalty(self):
+        assert FORMAT_PENALTY["jpeg"] == 0.20
+        assert FORMAT_PENALTY["jpg"] == 0.20
+
+    def test_gif_highest_penalty(self):
+        assert FORMAT_PENALTY["gif"] == 0.35
+
+    def test_unknown_extension_gets_default_penalty(self):
+        """A file with an unknown extension defaults to the JPEG-equivalent
+        penalty (lossy unknown) rather than 0 or the GIF max. Caught here
+        because a typo in the lookup default would silently advantage
+        unknown-format files."""
+        row = _row("/x/weird.xyz")
+        score = compute_score(row, [row])
+        # Score = max(0.0, 1.0_baseline_components - 0.20_default - ...)
+        # The exact value isn't the test here — what we verify is the
+        # *fallback path runs* (no KeyError).
+        assert isinstance(score, float)
+
+
+# ── Tier 1 — xmp_derived penalty ────────────────────────────────────────────
+
+
+class TestXmpDerivedPenalty:
+    def test_derived_penalty_constant(self):
+        """The −0.30 constant is the documented contract."""
+        assert DERIVED_PENALTY == 0.30
+
+    def test_derived_file_scores_lower_than_undefined(self):
+        """A file flagged as xmpMM:DerivedFrom should score at least 0.30
+        lower than the same file without the flag, all else equal."""
+        non_derived = _row(
+            "/x/a.jpg",
+            pixel_width=4000, pixel_height=3000,
+            file_size_bytes=2_000_000,
+            exif_tag_count=12,
+            shot_date="2024-06-15T10:30:00",
+            mtime="2025-01-01T12:00:00",
+            gps_present=True,
+            xmp_derived=False,
+        )
+        derived = _row(
+            "/x/b.jpg",
+            pixel_width=4000, pixel_height=3000,
+            file_size_bytes=2_000_000,
+            exif_tag_count=12,
+            shot_date="2024-06-15T10:30:00",
+            mtime="2025-01-01T12:00:00",
+            gps_present=True,
+            xmp_derived=True,
+        )
+        s_non = compute_score(non_derived, [non_derived, derived])
+        s_der = compute_score(derived, [non_derived, derived])
+        # Same files at same resolution → within-group dims tie; difference
+        # comes entirely from the derived penalty.
+        assert s_non - s_der == pytest.approx(0.30)
+
+
+# ── compute_score — composite behaviour ────────────────────────────────────
+
+
+class TestComputeScoreComposite:
+    def test_score_always_in_zero_one(self):
+        """No matter the penalties or weight extremes, final score must
+        clamp to [0.0, 1.0]."""
+        worst = _row(
+            "/Users/me/Downloads/Copy of photo (1)_edited.jpg",
+            pixel_width=100, pixel_height=100,
+            file_size_bytes=1000,
+            exif_tag_count=0,
+            shot_date=None,
+            gps_present=False,
+            xmp_derived=True,
+        )
+        score = compute_score(worst, [worst])
+        assert 0.0 <= score <= 1.0
+
+    def test_best_case_image_scores_high(self):
+        """A high-resolution RAW with full EXIF, GPS, clean name, real
+        DateTimeOriginal should score near the top of the band."""
+        best = _row(
+            "/Photos/2024/IMG_4567.nef",
+            pixel_width=6000, pixel_height=4000,
+            file_size_bytes=30_000_000,
+            exif_tag_count=14,
+            shot_date="2024-06-15T10:30:00",
+            mtime="2025-01-01T12:00:00",
+            gps_present=True,
+            xmp_derived=False,
+        )
+        # Score must be > 0.85 — confirms the dimensions sum near their
+        # weights and no penalty applies.
+        score = compute_score(best, [best])
+        assert score > 0.85
+
+    def test_raw_beats_jpeg_same_content(self):
+        """The structural rationale for Tier 1: a RAW should beat a JPEG
+        of the same scene because RAW = 0 penalty, JPEG = 0.20 penalty.
+        No accumulation of weak Tier 2 signals can override that gap when
+        both files share identical Tier 2 inputs."""
+        common = dict(
+            pixel_width=6000, pixel_height=4000,
+            file_size_bytes=30_000_000,
+            exif_tag_count=14,
+            shot_date="2024-06-15T10:30:00",
+            mtime="2025-01-01T12:00:00",
+            gps_present=True,
+            xmp_derived=False,
+        )
+        raw = _row("/x/photo.nef", **common)
+        jpg = _row("/x/photo.jpg", **common)
+        s_raw = compute_score(raw, [raw, jpg])
+        s_jpg = compute_score(jpg, [raw, jpg])
+        # Format penalty delta: 0.20 (JPEG) - 0.00 (RAW) = 0.20.
+        # Both files have identical Tier 2 (same pixels, same EXIF, etc.)
+        # so the score gap is exactly the penalty gap.
+        assert s_raw - s_jpg == pytest.approx(0.20)
+
+
+# ── validate_weights ───────────────────────────────────────────────────────
+
+
+class TestValidateWeights:
+    def test_default_weights_valid(self):
+        """The shipped DEFAULT_WEIGHTS must pass its own validator —
+        protects against a typo where someone updates DEFAULT_WEIGHTS
+        without re-checking the sum."""
+        validate_weights(DEFAULT_WEIGHTS)  # should not raise
+
+    def test_missing_key_rejected(self):
+        bad = dict(DEFAULT_WEIGHTS)
+        del bad["gps"]
+        with pytest.raises(ValueError, match="missing keys"):
+            validate_weights(bad)
+
+    def test_bad_sum_rejected(self):
+        bad = {k: 0.5 for k in DEFAULT_WEIGHTS}  # 8 * 0.5 = 4.0
+        with pytest.raises(ValueError, match="must sum to 1.0"):
+            validate_weights(bad)
+
+    def test_within_tolerance_accepted(self):
+        """Float-summation noise is normal: 8 weights summing to 1.0 by
+        hand often ends up at 0.9999... The ±0.001 tolerance covers it."""
+        weights = dict(DEFAULT_WEIGHTS)
+        weights["resolution"] = 0.2495  # creates ~0.9995 sum
+        weights["file_size"] = 0.0505
+        validate_weights(weights)  # should not raise
+
+
+# ── score_group ────────────────────────────────────────────────────────────
+
+
+class TestScoreGroup:
+    def test_returns_dict_keyed_by_source_path(self):
+        a = _row("/x/a.jpg", pixel_width=4000, pixel_height=3000)
+        b = _row("/x/b.jpg", pixel_width=2000, pixel_height=1500)
+        out = score_group([a, b])
+        assert set(out.keys()) == {"/x/a.jpg", "/x/b.jpg"}
+
+    def test_includes_none_for_live_photo_mov(self):
+        """The dict still contains the MOV passenger — its value is None,
+        not absent. The action layer iterates the full dict and skips
+        Nones explicitly so missing keys would silently break logic."""
+        heic = _row("/x/IMG_001.heic")
+        mov = _row("/x/IMG_001.mov")
+        out = score_group([heic, mov])
+        assert "/x/IMG_001.mov" in out
+        assert out["/x/IMG_001.mov"] is None
+        assert isinstance(out["/x/IMG_001.heic"], float)
+
+    def test_deterministic_across_calls(self):
+        """Pure function — same inputs always produce the same output."""
+        a = _row("/x/a.jpg", pixel_width=4000, pixel_height=3000)
+        b = _row("/x/b.jpg", pixel_width=2000, pixel_height=1500)
+        first = score_group([a, b])
+        second = score_group([a, b])
+        assert first == second


### PR DESCRIPTION
## Summary

PR 3 of 7 for #187. **Stacked on top of #200** (base = PR 2 branch);
this diff shows only PR 3's incremental work.

Pure scoring logic — `scanner/scoring.py` is a function of
`(ManifestRow, group_rows, weights)` that returns a float in `[0.0, 1.0]`
(or `None` for Live Photo MOV passengers). No I/O, no globals, no DB
access. The action layer (PR 6) will translate scores into KEEP/DELETE
decisions and respect user-intent signals (`is_locked`, `xmp:Rating`)
which this module deliberately ignores.

## Architecture

Two-tier per the design:

```
Tier 1 — Categorical penalties (absolute, not weight-scaled):
    Format: RAW=0.00  TIFF=0.05  HEIC=0.10  PNG=0.12  WebP=0.18
            JPEG/Video=0.20  GIF=0.35
    xmp_derived present: -0.30

Tier 2 — Eight weighted continuous signals (configurable):
    resolution (0.25), exif_complete (0.20), date_prov (0.15),
    filename (0.12), gps (0.08), path (0.08), live_photo (0.07),
    file_size (0.05)

Final = max(0.0, min(1.0, Tier2 - format_penalty - derived_penalty))
```

`validate_weights()` enforces sum-to-1.0 (±0.001 tolerance) and key
completeness — misconfigured `settings.json` produces a clear early
error instead of silent wrong scoring.

## Bugs caught by the test suite

Two regex bugs in the plan's pseudocode that tests caught before any
fixture / scan integration:

1. **`\b` word boundaries don't span underscores in Python regex.**
   `\bedited\b` does NOT match `photo_edited.jpg` because `_` is a word
   character. Switched to `(?<![A-Za-z])...(?![A-Za-z])` lookaround.
2. **Trailing `_\d{4}$` pattern false-positives camera-native names.**
   `IMG_4567.jpg` / `DSC_1234.NEF` end in four digits and are *originals*,
   not derivatives. Dropped the pattern entirely — the other six cover
   the clear copy/edit cases without false positives.

Both bugs would have silently produced wrong scores in production. The
tests caught them in one run.

## Test plan

- [x] 63 new tests in `tests/test_scoring.py` covering:
  - Each of the 8 Tier 2 dimensions (happy path + edge cases)
  - Each Tier 1 penalty value (RAW=0, HEIC=0.10, JPEG=0.20, GIF=0.35)
  - `xmp_derived` deduction
  - Live Photo MOV passenger rule (`score = None`)
  - Score clamping to `[0.0, 1.0]`
  - "RAW beats JPEG of same content" — the structural rationale for Tier 1
  - `validate_weights` rejects missing keys + bad sums
  - `score_group` returns dict keyed by `source_path`, includes None entries
- [x] Full suite: 1079 passed, 2 skipped, coverage 88.94%
  (`scanner/scoring.py` 97% — well above 70% floor; 2 uncovered lines
  are defensive guards against malformed `group_rows` inputs)
- [x] All `ManifestRow` fixtures constructed in memory — no filesystem
  access, proving the function is pure

## What this PR does NOT do

- No scan-pipeline integration yet (**PR 4**: call `score_group` after
  `classify()` and write the result to `ManifestRow.score`)
- No DB writes from the scorer (PR 4)
- No UI changes (PR 5: COL_SCORE)
- No right-click action (PR 6)

[docs-not-needed: pure-logic module not yet wired into any user-visible
flow. README's scanning/scoring section will be updated in PR 4 when
the scan pipeline actually invokes the scorer.]

🤖 Generated with [Claude Code](https://claude.com/claude-code)