### PR TITLE
feat(scoring): wire scoring into scan pipeline + rescore API (#187)

### DIFF
--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -68,9 +68,10 @@ class ScanWorker(QThread):
         from concurrent.futures import ThreadPoolExecutor, as_completed
         from scanner.walker import scan_sources
         from scanner.hasher import compute_hashes
-        from scanner.exif import ExiftoolProcess, batch_read_dates, parse_exif_date
+        from scanner.exif import ExiftoolProcess, batch_read_extracts, parse_exif_date
         from scanner.dedup import HashResult, classify
         from scanner.manifest import write_manifest, print_summary
+        from scanner.scoring import apply_scoring_to_rows
         import io
         from contextlib import redirect_stdout
 
@@ -105,7 +106,6 @@ class ScanWorker(QThread):
         # One file read per image: SHA-256, pHash, and EXIF date for JPEG/PNG
         # are extracted from the same in-memory buffer.
         chunk_size = 500
-        _EXIFTOOL_TYPES = frozenset(("heic", "raw", "mov", "mp4"))
         cancel_flag = threading.Event()
         skipped: list[tuple[Path, str, str]] = []  # (path, exc type, exc msg)
 
@@ -181,29 +181,42 @@ class ScanWorker(QThread):
             if len(skipped) > 10:
                 self._emit(f"    … and {len(skipped) - 10:,} more")
 
-        # --- 3. exiftool for HEIC / RAW / MOV / MP4 only ---
-        # JPEG and PNG dates already populated from the PIL pass above.
-        et_records = [r for r in hash_results if r.exif_date is None
-                      and r.record.file_type in _EXIFTOOL_TYPES]
+        # --- 3. exiftool for ALL non-skip files ---
+        # Previously this ran only for HEIC/RAW/MOV/MP4 (formats whose dates
+        # PIL cannot extract). For the #187 scoring system every file needs
+        # a full census tag count + GPS / xmpMM:DerivedFrom presence, so
+        # the exiftool pass now covers everything (except file_type="skip").
+        # PIL dates from the hash pass are preserved — exiftool dates only
+        # fill in when PIL didn't find one.
+        et_records = [r for r in hash_results if r.record.file_type != "skip"]
+        extracts: dict = {}
         if et_records:
             et_paths = [r.record.path for r in et_records]
             n_chunks = (len(et_paths) + chunk_size - 1) // chunk_size
-            self._emit(f"EXIF via exiftool for {len(et_paths):,} non-JPEG files ({n_chunks} chunk(s))…")
+            self._emit(
+                f"EXIF + scoring signals via exiftool for {len(et_paths):,} files"
+                f" ({n_chunks} chunk(s))…"
+            )
             try:
                 with ExiftoolProcess() as et:
-                    dates: dict = {}
                     for i in range(0, len(et_paths), chunk_size):
                         chunk = et_paths[i: i + chunk_size]
-                        dates.update(batch_read_dates(chunk, et, chunk_size=chunk_size))
+                        extracts.update(batch_read_extracts(chunk, et, chunk_size=chunk_size))
                         done_et = min(i + chunk_size, len(et_paths))
                         self._emit(f"  EXIF {done_et:,}/{len(et_paths):,}")
-                found = sum(1 for v in dates.values() if v)
-                self._emit(f"  EXIF done — {found:,} dates found")
+                found_dates = sum(1 for e in extracts.values() if e.exif_date is not None)
+                with_gps = sum(1 for e in extracts.values() if e.gps_present)
+                self._emit(f"  EXIF done — {found_dates:,} dates, {with_gps:,} with GPS")
+                # Backfill exif_date for records where PIL didn't find one.
                 for r in et_records:
-                    r.exif_date = dates.get(r.record.path)
+                    if r.exif_date is None:
+                        extract = extracts.get(r.record.path)
+                        if extract is not None:
+                            r.exif_date = extract.exif_date
             except FileNotFoundError:
                 self._emit(
-                    "WARNING: exiftool not found on PATH — EXIF dates for HEIC/RAW/video unavailable.\n"
+                    "WARNING: exiftool not found on PATH — EXIF dates for HEIC/RAW/video"
+                    " and scoring signals (GPS, EXIF census, XMP provenance) unavailable.\n"
                     "Install from https://exiftool.org/ and add to PATH."
                 )
 
@@ -215,6 +228,13 @@ class ScanWorker(QThread):
             mean_color_threshold=self.mean_color_threshold,
             source_priority=self.source_priority,
         )
+
+        # --- 4.5: score within each duplicate group (#187) ---
+        # Mutates rows in place: copies exif_tag_count / gps_present /
+        # xmp_derived from extracts into ManifestRow, then assigns
+        # compute_score(...) per group. Isolated rows (group_id is None)
+        # stay unscored — no peers to compete with.
+        apply_scoring_to_rows(rows, extracts)
 
         # Capture print_summary output and re-emit as progress
         buf = io.StringIO()

--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -336,6 +336,108 @@ class ManifestRepository:
         finally:
             conn.close()
 
+    def rescore(
+        self,
+        manifest_path: str,
+        weights: "dict[str, float] | None" = None,
+    ) -> int:
+        """Recompute composite scores from cached raw signals (#187).
+
+        Reads every grouped row's scoring-relevant columns
+        (``pixel_width/height``, ``file_size_bytes``, ``shot_date``,
+        ``mtime``, ``exif_tag_count``, ``gps_present``, ``xmp_derived``,
+        plus ``source_path`` and ``group_id``), runs the scorer in
+        memory, and writes the new ``score`` values back with a single
+        batched UPDATE.
+
+        **No file I/O.** No exiftool subprocess, no Pillow open. Use
+        when the user changes ``scoring.weights`` in settings.json —
+        avoids a full re-scan, which on a NAS library can take 10+ min.
+
+        Returns the count of rows whose score was written. Isolated rows
+        (``group_id IS NULL``) are skipped — they have no peers to score
+        against. Live Photo MOV passengers receive score=NULL by the
+        scorer's own rule and that NULL is written back.
+        """
+        from collections import defaultdict
+        from scanner.dedup import ManifestRow
+        from scanner.scoring import DEFAULT_WEIGHTS, score_group, validate_weights
+
+        if weights is None:
+            weights = DEFAULT_WEIGHTS
+        validate_weights(weights)
+
+        # Load only the columns the scorer reads — keeps the in-memory
+        # rebuild cheap. ``ManifestRow`` requires source_label, action,
+        # source_hash, phash, hamming_distance, duplicate_of, reason —
+        # those don't affect scoring but the dataclass demands them, so
+        # we fill placeholders.
+        conn = _connect(manifest_path)
+        try:
+            rows_data = conn.execute(
+                """
+                SELECT source_path, action, group_id,
+                       pixel_width, pixel_height, file_size_bytes,
+                       shot_date, mtime,
+                       exif_tag_count, gps_present, xmp_derived
+                FROM   migration_manifest
+                WHERE  group_id IS NOT NULL
+                """
+            ).fetchall()
+        finally:
+            conn.close()
+
+        rows = [
+            ManifestRow(
+                source_path=r[0],
+                source_label="",           # placeholder — not used by scorer
+                dest_path=None,
+                action=r[1],
+                source_hash="",            # placeholder
+                phash=None,
+                hamming_distance=None,
+                duplicate_of=None,
+                reason="",
+                pixel_width=r[3],
+                pixel_height=r[4],
+                file_size_bytes=r[5],
+                shot_date=r[6],
+                mtime=r[7],
+                group_id=r[2],
+                exif_tag_count=r[8],
+                gps_present=bool(r[9]),
+                xmp_derived=bool(r[10]),
+            )
+            for r in rows_data
+        ]
+
+        # Group by group_id, score each group, collect (score, path) tuples
+        # for the batch UPDATE.
+        groups: dict[str, list[ManifestRow]] = defaultdict(list)
+        for row in rows:
+            groups[row.group_id].append(row)
+
+        updates: list[tuple] = []
+        for group_rows in groups.values():
+            scores = score_group(group_rows, weights)
+            for row in group_rows:
+                updates.append((scores[row.source_path], row.source_path))
+
+        if not updates:
+            return 0
+
+        conn = _connect(manifest_path)
+        try:
+            conn.executemany(
+                "UPDATE migration_manifest SET score = ? WHERE source_path = ?",
+                updates,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        logger.info("Rescored {} rows in {}", len(updates), manifest_path)
+        return len(updates)
+
     def mark_executed(self, manifest_path: str, file_paths: list[str]) -> None:
         """Mark a list of rows as executed=1."""
         conn = _connect(manifest_path)

--- a/scan.py
+++ b/scan.py
@@ -131,9 +131,10 @@ def main() -> int:
     from concurrent.futures import ThreadPoolExecutor, as_completed
     from scanner.walker import scan_sources
     from scanner.hasher import compute_hashes
-    from scanner.exif import ExiftoolProcess, batch_read_dates, parse_exif_date
+    from scanner.exif import ExiftoolProcess, batch_read_extracts, parse_exif_date
     from scanner.dedup import HashResult, classify
     from scanner.manifest import write_manifest, print_summary
+    from scanner.scoring import apply_scoring_to_rows
 
     print("Read-only scan — no files will be moved or deleted.", flush=True)
     print("MOVE / SKIP / REVIEW in the results are planned actions only.\n", flush=True)
@@ -159,7 +160,6 @@ def main() -> int:
     # are all extracted from the same in-memory buffer.
     # HEIC / RAW / MOV / MP4 return no date here — a targeted exiftool batch follows.
     chunk_size = 500
-    _EXIFTOOL_TYPES = frozenset(("heic", "raw", "mov", "mp4"))
 
     print(f"Hashing {len(records):,} files (workers={args.workers})…", flush=True)
     hash_results: list[HashResult] = [None] * len(records)  # type: ignore[list-item]
@@ -202,36 +202,60 @@ def main() -> int:
         if len(skipped) > 10:
             print(f"    … and {len(skipped) - 10:,} more", file=sys.stderr, flush=True)
 
-    # --- exiftool for HEIC / RAW / MOV / MP4 only ---
-    # JPEG and PNG dates are already populated from the PIL pass above.
-    et_records = [r for r in hash_results if r.exif_date is None
-                  and r.record.file_type in _EXIFTOOL_TYPES]
+    # --- exiftool for ALL non-skip files ---
+    # Previously this ran only for HEIC/RAW/MOV/MP4 (formats whose dates
+    # PIL cannot extract). For the #187 scoring system every file needs a
+    # full census tag count + GPS / xmpMM:DerivedFrom presence, so the
+    # exiftool pass now covers everything (except file_type="skip").
+    # PIL dates from the hash pass above are preserved — exiftool dates
+    # only fill in when PIL didn't find one.
+    et_records = [r for r in hash_results if r.record.file_type != "skip"]
+    extracts: dict = {}
     if et_records:
         et_paths = [r.record.path for r in et_records]
         n_chunks = (len(et_paths) + chunk_size - 1) // chunk_size
-        print(f"EXIF via exiftool for {len(et_paths):,} non-JPEG files ({n_chunks} chunk(s))…",
-              flush=True)
+        print(
+            f"EXIF + scoring signals via exiftool for {len(et_paths):,} files "
+            f"({n_chunks} chunk(s))…",
+            flush=True,
+        )
         try:
             with ExiftoolProcess() as et:
-                dates: dict = {}
                 for i in range(0, len(et_paths), chunk_size):
                     chunk = et_paths[i: i + chunk_size]
-                    dates.update(batch_read_dates(chunk, et, chunk_size=chunk_size))
+                    extracts.update(batch_read_extracts(chunk, et, chunk_size=chunk_size))
                     done_et = min(i + chunk_size, len(et_paths))
                     print(f"  EXIF {done_et:,}/{len(et_paths):,}", end="\r", flush=True)
-            found = sum(1 for v in dates.values() if v)
-            print(f"  EXIF done — {found:,} dates found", flush=True)
+            found_dates = sum(1 for e in extracts.values() if e.exif_date is not None)
+            with_gps = sum(1 for e in extracts.values() if e.gps_present)
+            print(
+                f"  EXIF done — {found_dates:,} dates, {with_gps:,} with GPS",
+                flush=True,
+            )
+            # Backfill exif_date for records where PIL didn't find one.
+            # PIL's value (when present) wins because it's already on the
+            # record; we only fill the None slots.
             for r in et_records:
-                r.exif_date = dates.get(r.record.path)
+                if r.exif_date is None:
+                    extract = extracts.get(r.record.path)
+                    if extract is not None:
+                        r.exif_date = extract.exif_date
         except FileNotFoundError:
             print(
-                "\nWARNING: exiftool not found on PATH — EXIF dates for HEIC/RAW/video unavailable.\n"
+                "\nWARNING: exiftool not found on PATH — EXIF dates for HEIC/RAW/video"
+                " and scoring signals (GPS, EXIF census, XMP provenance) unavailable.\n"
                 "Install from https://exiftool.org/ and ensure it is in your PATH.",
                 file=sys.stderr,
             )
 
     print("Classifying…", flush=True)
     rows = classify(hash_results, threshold=args.threshold, source_priority=source_priority)
+
+    # --- Phase 4.5: score within each duplicate group (#187) ---
+    # Mutates rows in place: copies exif_tag_count / gps_present / xmp_derived
+    # from extracts into ManifestRow, then assigns compute_score(...) per group.
+    # Isolated rows (group_id is None) stay unscored — no peers to compete with.
+    apply_scoring_to_rows(rows, extracts)
 
     print_summary(rows, skipped=len(skipped))
 

--- a/scanner/scoring.py
+++ b/scanner/scoring.py
@@ -51,6 +51,7 @@ from typing import Iterable, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from scanner.dedup import ManifestRow
+    from scanner.media_extract import MediaExtract
 
 
 # ── Tier 1 — Categorical penalties (absolute deductions, not weight-scaled) ──
@@ -405,3 +406,62 @@ def score_group(
         r.source_path: compute_score(r, group_rows, weights)
         for r in group_rows
     }
+
+
+def apply_scoring_to_rows(
+    rows: "list[ManifestRow]",
+    extracts: "dict[Path, MediaExtract]",
+    weights: dict[str, float] = DEFAULT_WEIGHTS,
+) -> None:
+    """Wire MediaExtract scoring signals into ManifestRows + assign scores.
+
+    Two-phase mutation of ``rows`` in place:
+
+    Phase A — Backfill raw signals from the exiftool extract dict:
+        ``exif_tag_count``, ``gps_present``, ``xmp_derived`` move from
+        the MediaExtract (PR 2 output) onto ManifestRow (PR 1 column).
+        The MediaExtract sentinel ``None`` (not checked) is preserved as
+        the column default — only definite True/False / int values
+        overwrite. Rows whose path is missing from ``extracts`` (exiftool
+        skipped or failed for that file) keep their default ManifestRow
+        values; the scorer treats those as 'no signal' (0.0).
+
+    Phase B — Compute and assign composite scores per group:
+        Rows are grouped by ``group_id`` (None / isolated rows stay
+        unscored). Within each group, ``score_group`` produces the dict;
+        ``ManifestRow.score`` is set per row. Live Photo MOV passengers
+        receive ``None`` (passed through from score_group); the action
+        layer (PR 6) will skip them when applying decisions.
+
+    Pure-with-mutation: same inputs always produce the same row state.
+    No I/O. Tested via ``test_apply_scoring_to_rows`` with synthetic
+    ManifestRow + MediaExtract fixtures.
+    """
+    from collections import defaultdict
+
+    # Phase A: backfill raw scoring signals from exiftool extracts.
+    for row in rows:
+        extract = extracts.get(Path(row.source_path))
+        if extract is None:
+            continue
+        if extract.exif_tag_count is not None:
+            row.exif_tag_count = extract.exif_tag_count
+        # MediaExtract uses Optional[bool] (None=not checked). ManifestRow's
+        # column is NOT NULL DEFAULT 0 — collapse None to the existing
+        # default rather than overwriting.
+        if extract.gps_present is not None:
+            row.gps_present = bool(extract.gps_present)
+        if extract.xmp_derived is not None:
+            row.xmp_derived = bool(extract.xmp_derived)
+
+    # Phase B: compute scores within each duplicate group. Isolated rows
+    # (group_id is None) intentionally stay unscored — they have no peers
+    # to compete with.
+    groups: dict[str, list] = defaultdict(list)
+    for row in rows:
+        if row.group_id:
+            groups[row.group_id].append(row)
+    for group_rows in groups.values():
+        scores = score_group(group_rows, weights)
+        for row in group_rows:
+            row.score = scores[row.source_path]

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -595,3 +595,354 @@ class TestScoreGroup:
         first = score_group([a, b])
         second = score_group([a, b])
         assert first == second
+
+
+# ── apply_scoring_to_rows — PR 4 pipeline merge + score helper ─────────────
+
+
+class TestApplyScoringToRows:
+    """The bridge from PR 2's MediaExtract dict (exiftool batch output) to
+    PR 1's ManifestRow scoring columns + PR 3's composite score. Mutates
+    rows in place; no I/O. Tests construct synthetic ManifestRows and
+    MediaExtracts so the function's purity is provable.
+    """
+
+    def _extract(
+        self,
+        path_str: str,
+        *,
+        gps_present=None,
+        xmp_derived=None,
+        exif_tag_count=None,
+    ):
+        from pathlib import Path
+        from scanner.media_extract import MediaExtract
+        return MediaExtract(
+            path=Path(path_str),
+            gps_present=gps_present,
+            xmp_derived=xmp_derived,
+            exif_tag_count=exif_tag_count,
+            extracted_by={"exiftool"},
+        )
+
+    def test_backfills_raw_signals_from_extracts(self):
+        from pathlib import Path
+        from scanner.scoring import apply_scoring_to_rows
+        row = _row("/x/a.jpg", pixel_width=4000, pixel_height=3000)
+        extracts = {
+            Path("/x/a.jpg"): self._extract(
+                "/x/a.jpg",
+                gps_present=True,
+                xmp_derived=False,
+                exif_tag_count=12,
+            )
+        }
+        apply_scoring_to_rows([row], extracts)
+        assert row.gps_present is True
+        assert row.xmp_derived is False
+        assert row.exif_tag_count == 12
+
+    def test_none_extracts_preserve_defaults(self):
+        """A MediaExtract with gps_present=None (extractor didn't check)
+        must NOT overwrite ManifestRow.gps_present's default (False).
+        The whole point of MediaExtract's sentinel convention."""
+        from pathlib import Path
+        from scanner.scoring import apply_scoring_to_rows
+        row = _row("/x/a.jpg", pixel_width=4000, pixel_height=3000)
+        extracts = {
+            Path("/x/a.jpg"): self._extract(
+                "/x/a.jpg",
+                gps_present=None,
+                xmp_derived=None,
+                exif_tag_count=None,
+            )
+        }
+        apply_scoring_to_rows([row], extracts)
+        # Defaults from ManifestRow: gps_present=False, xmp_derived=False,
+        # exif_tag_count=None.
+        assert row.gps_present is False
+        assert row.xmp_derived is False
+        assert row.exif_tag_count is None
+
+    def test_missing_extract_skips_row(self):
+        """A row whose path is absent from the extracts dict (exiftool
+        skipped or failed for that file) keeps its ManifestRow defaults.
+        The scorer reads those as 'no signal'."""
+        from scanner.scoring import apply_scoring_to_rows
+        row = _row("/x/a.jpg", pixel_width=4000, pixel_height=3000)
+        apply_scoring_to_rows([row], {})  # empty extracts
+        assert row.exif_tag_count is None
+        assert row.gps_present is False
+        assert row.xmp_derived is False
+
+    def test_assigns_score_within_groups(self):
+        from pathlib import Path
+        from scanner.scoring import apply_scoring_to_rows
+        big = _row(
+            "/x/big.jpg", group_id="g1",
+            pixel_width=6000, pixel_height=4000,
+            file_size_bytes=5_000_000,
+        )
+        small = _row(
+            "/x/small.jpg", group_id="g1",
+            pixel_width=1024, pixel_height=768,
+            file_size_bytes=500_000,
+        )
+        apply_scoring_to_rows([big, small], extracts={})
+        assert big.score is not None
+        assert small.score is not None
+        # Bigger pixels + larger size in same group → bigger score.
+        assert big.score > small.score
+
+    def test_isolated_rows_left_unscored(self):
+        """A row with group_id=None has no peers — score stays None
+        because there's nothing to compete with."""
+        from scanner.scoring import apply_scoring_to_rows
+        row = _row("/x/lone.jpg", group_id=None,
+                    pixel_width=4000, pixel_height=3000)
+        apply_scoring_to_rows([row], extracts={})
+        assert row.score is None
+
+    def test_live_photo_mov_gets_none_score(self):
+        from scanner.scoring import apply_scoring_to_rows
+        heic = _row("/x/IMG_001.heic", group_id="g1")
+        mov = _row("/x/IMG_001.mov", group_id="g1")
+        apply_scoring_to_rows([heic, mov], extracts={})
+        assert mov.score is None
+        assert isinstance(heic.score, float)
+
+    def test_does_not_overwrite_existing_default_with_extract_default(self):
+        """gps_present default is False on ManifestRow. If extract says
+        explicitly False (checked + absent), the row gets False. If extract
+        says None (not checked), the row stays at its default False. Both
+        end up at False here — the distinction matters once we have a
+        row that started with True (e.g. set by an earlier pass)."""
+        from pathlib import Path
+        from scanner.scoring import apply_scoring_to_rows
+        row = _row("/x/a.jpg", group_id="g1")
+        row.gps_present = True   # simulate prior-set state
+        extracts = {
+            Path("/x/a.jpg"): self._extract("/x/a.jpg", gps_present=None)
+        }
+        apply_scoring_to_rows([row], extracts)
+        # None extract value should NOT clobber the existing True.
+        assert row.gps_present is True
+
+
+# ── ManifestRepository.rescore — re-compute scores without re-scanning ─────
+
+
+class TestManifestRepositoryRescore:
+    """Rescore reads cached raw signals from the DB, recomputes composite
+    scores in memory, and writes the new values back via a single batched
+    UPDATE. No file I/O, no exiftool. The test path exercises the
+    round-trip: write rows → rescore → read scores back.
+    """
+
+    def _make_manifest_with_scoring(self, tmp_path, rows: list[ManifestRow]):
+        """Use the real write_manifest() so the DB shape matches production."""
+        from scanner.manifest import write_manifest
+        out = tmp_path / "manifest.sqlite"
+        write_manifest(rows, out)
+        return out
+
+    def test_rescore_assigns_scores_from_cached_signals(self, tmp_path):
+        """Two rows in the same group, only signals in the DB — rescore
+        should produce a score for both, with the better signal winning."""
+        from infrastructure.manifest_repository import ManifestRepository
+        import sqlite3
+
+        rows = [
+            ManifestRow(
+                source_path="/x/big.jpg", source_label="src",
+                dest_path=None, action="REVIEW_DUPLICATE",
+                source_hash="aaa", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                pixel_width=6000, pixel_height=4000,
+                file_size_bytes=5_000_000,
+                group_id="g1",
+                exif_tag_count=12, gps_present=True, xmp_derived=False,
+            ),
+            ManifestRow(
+                source_path="/x/small.jpg", source_label="src",
+                dest_path=None, action="REVIEW_DUPLICATE",
+                source_hash="bbb", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                pixel_width=1024, pixel_height=768,
+                file_size_bytes=500_000,
+                group_id="g1",
+                exif_tag_count=2, gps_present=False, xmp_derived=False,
+            ),
+        ]
+        db = self._make_manifest_with_scoring(tmp_path, rows)
+
+        n = ManifestRepository().rescore(str(db))
+        assert n == 2
+
+        conn = sqlite3.connect(db)
+        try:
+            scores = dict(conn.execute(
+                "SELECT source_path, score FROM migration_manifest"
+            ).fetchall())
+        finally:
+            conn.close()
+        assert scores["/x/big.jpg"] is not None
+        assert scores["/x/small.jpg"] is not None
+        assert scores["/x/big.jpg"] > scores["/x/small.jpg"]
+
+    def test_rescore_skips_isolated_rows(self, tmp_path):
+        """Rows with group_id=NULL are not scored — they have no peers."""
+        from infrastructure.manifest_repository import ManifestRepository
+        import sqlite3
+
+        rows = [
+            ManifestRow(
+                source_path="/x/alone.jpg", source_label="src",
+                dest_path=None, action="MOVE",
+                source_hash="aaa", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                pixel_width=4000, pixel_height=3000,
+                group_id=None,
+            ),
+        ]
+        db = self._make_manifest_with_scoring(tmp_path, rows)
+        n = ManifestRepository().rescore(str(db))
+        assert n == 0
+
+        conn = sqlite3.connect(db)
+        try:
+            score = conn.execute(
+                "SELECT score FROM migration_manifest WHERE source_path = ?",
+                ("/x/alone.jpg",),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert score is None
+
+    def test_rescore_writes_null_for_live_photo_mov(self, tmp_path):
+        """The Live Photo MOV passenger rule (compute_score returns None)
+        must survive the round-trip into the DB as a NULL."""
+        from infrastructure.manifest_repository import ManifestRepository
+        import sqlite3
+
+        rows = [
+            ManifestRow(
+                source_path="/x/IMG_001.heic", source_label="src",
+                dest_path=None, action="MOVE",
+                source_hash="aaa", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                pixel_width=4000, pixel_height=3000,
+                group_id="g1",
+            ),
+            ManifestRow(
+                source_path="/x/IMG_001.mov", source_label="src",
+                dest_path=None, action="MOVE",
+                source_hash="bbb", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                group_id="g1",
+            ),
+        ]
+        db = self._make_manifest_with_scoring(tmp_path, rows)
+        ManifestRepository().rescore(str(db))
+
+        conn = sqlite3.connect(db)
+        try:
+            mov_score = conn.execute(
+                "SELECT score FROM migration_manifest WHERE source_path = ?",
+                ("/x/IMG_001.mov",),
+            ).fetchone()[0]
+            heic_score = conn.execute(
+                "SELECT score FROM migration_manifest WHERE source_path = ?",
+                ("/x/IMG_001.heic",),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert mov_score is None   # passenger rule
+        assert heic_score is not None
+
+    def test_rescore_validates_weights(self, tmp_path):
+        """Bad weights → clear error, not silent wrong scoring. Covers
+        both branches of validate_weights: missing keys + bad sum."""
+        from infrastructure.manifest_repository import ManifestRepository
+
+        rows = [
+            ManifestRow(
+                source_path="/x/a.jpg", source_label="src",
+                dest_path=None, action="MOVE",
+                source_hash="aaa", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                group_id="g1",
+            ),
+        ]
+        db = self._make_manifest_with_scoring(tmp_path, rows)
+
+        # Missing keys path:
+        with pytest.raises(ValueError, match="missing keys"):
+            ManifestRepository().rescore(str(db), weights={"resolution": 0.5})
+
+        # Bad sum path (all keys present, but they sum to 4.0):
+        bad_sum = {k: 0.5 for k in DEFAULT_WEIGHTS}
+        with pytest.raises(ValueError, match="must sum to 1.0"):
+            ManifestRepository().rescore(str(db), weights=bad_sum)
+
+    def test_rescore_uses_provided_weights(self, tmp_path):
+        """Calling rescore with custom weights must affect the result —
+        otherwise the API would be silently broken."""
+        from infrastructure.manifest_repository import ManifestRepository
+        import sqlite3
+
+        rows = [
+            ManifestRow(
+                source_path="/x/big.jpg", source_label="src",
+                dest_path=None, action="REVIEW_DUPLICATE",
+                source_hash="aaa", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                pixel_width=6000, pixel_height=4000,
+                group_id="g1",
+                gps_present=False,
+            ),
+            ManifestRow(
+                source_path="/x/small.jpg", source_label="src",
+                dest_path=None, action="REVIEW_DUPLICATE",
+                source_hash="bbb", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                pixel_width=1024, pixel_height=768,
+                group_id="g1",
+                gps_present=True,
+            ),
+        ]
+        db = self._make_manifest_with_scoring(tmp_path, rows)
+
+        # Default weights → resolution wins, big > small.
+        ManifestRepository().rescore(str(db))
+        conn = sqlite3.connect(db)
+        try:
+            default = dict(conn.execute(
+                "SELECT source_path, score FROM migration_manifest"
+            ).fetchall())
+        finally:
+            conn.close()
+        assert default["/x/big.jpg"] > default["/x/small.jpg"]
+
+        # GPS-heavy weights — small has GPS, big does not. Big still has
+        # 0.25 resolution advantage but small now claims 0.85 GPS. With
+        # tied other dims, small should overtake.
+        gps_heavy = {
+            "resolution":    0.05,
+            "file_size":     0.02,
+            "exif_complete": 0.05,
+            "date_prov":     0.02,
+            "gps":           0.80,
+            "filename":      0.03,
+            "path":          0.02,
+            "live_photo":    0.01,
+        }
+        ManifestRepository().rescore(str(db), weights=gps_heavy)
+        conn = sqlite3.connect(db)
+        try:
+            tuned = dict(conn.execute(
+                "SELECT source_path, score FROM migration_manifest"
+            ).fetchall())
+        finally:
+            conn.close()
+        assert tuned["/x/small.jpg"] > tuned["/x/big.jpg"]


### PR DESCRIPTION
## Summary

PR 4 of 7 for #187 — the scoring system is now **live end-to-end** in
the pipeline. Stacked on top of #202 (base = PR 3 branch); diff shows
only PR 4's incremental work.

Three integration points:

### 1. `scanner.scoring.apply_scoring_to_rows()` — new helper

Merges MediaExtract scoring signals (`gps_present`, `xmp_derived`,
`exif_tag_count` from PR 2's exiftool batch) onto `ManifestRow` (PR 1's
columns), then computes composite scores per group via PR 3's
`score_group()`. Mutates rows in place; no I/O. Isolated rows (no
`group_id`) intentionally stay unscored.

### 2. `scan.py` + `scan_worker.py` — Phase 4.5 wired in

The exiftool batch now runs for **all** non-skip files, not just
HEIC/RAW/MOV/MP4. Previously the filter excluded JPEG/PNG because PIL
handles their dates faster; now those files also need the exiftool
census for scoring.

```
Before: batch_read_dates(et_paths) → dict[Path, datetime|None]
After:  batch_read_extracts(et_paths) → dict[Path, MediaExtract]
                                         (dates + GPS + census + XMP)
```

PIL-derived dates still win when present (fast path preserved). New cost:
~3-5× more exiftool work per file because `batch_read_extracts` drops
`-fast` — GPS / XMP segments live past the first IFD. Acceptable as a
one-time scan cost; rescore is zero-I/O.

After `classify()`, the orchestrator calls
`apply_scoring_to_rows(rows, extracts)` — Phase 4.5 in the design diagram.
The `score` field on each `ManifestRow` is populated before
`write_manifest` runs, so the composite score is written in the same
INSERT batch.

### 3. `ManifestRepository.rescore(manifest_path, weights)` — new method

Recomputes composite scores for every grouped row from cached raw
signals. **No exiftool, no Pillow, no `os.stat`.** One SELECT + score
in memory + one batched UPDATE. For 100k rows this is ~1-3 seconds.

Used when the user changes `scoring.weights` in `settings.json` (PR 5.5)
— avoids a full re-scan on a NAS library. Validates weights via
`scoring.validate_weights` so a malformed config produces a clear early
`ValueError`, not silent wrong scoring.

## Round-trip contracts

- **Live Photo MOV passenger rule survives:** `compute_score` returns
  `None` for MOV files paired with HEIC in the same group, that `None`
  becomes `NULL` in the DB, rescore correctly preserves `NULL`.
- **Sentinel non-overwrite:** an extract with `gps_present=None`
  (extractor didn't check) does NOT clobber a `ManifestRow.gps_present`
  that was set by an earlier pass. Test asserts this explicitly.

## Test plan

12 new tests in `test_scoring.py`:

**`apply_scoring_to_rows`** (7):
- Backfills raw signals from extracts
- None-extract values preserve ManifestRow defaults
- Missing-extract paths skip (no crash)
- Assigns scores within groups (bigger pixels → bigger score)
- Isolated rows (group_id=None) stay unscored
- Live Photo MOV gets None score
- Sentinel non-overwrite (existing True survives None extract)

**`rescore`** (5):
- Assigns scores from cached signals
- Skips isolated rows (no peers)
- Writes NULL for Live Photo MOV
- Validates weights (both missing-keys and bad-sum branches)
- Respects custom weights — GPS-heavy weights flip the winner

Full suite: **1091 passed, 2 skipped, coverage 89.06%**
- `scanner/scoring.py`: 98%
- `infrastructure/manifest_repository.py`: 99%
- `app/views/workers/scan_worker.py`: 90%
- All well above the 70% per-file floor.

## What this PR does NOT do

- No UI changes yet (**PR 5**: `COL_SCORE` column + within-group sort)
- No right-click action (**PR 6**: "Apply best-copy decisions to group")
- No `settings.json` weights UI (**PR 5.5**: configurable weights)
- No QA fixtures / scenario (**PR 7**)

[qa-not-needed: scan_worker.py only got internal pipeline plumbing —
no new button/dialog/menu/status-bar behavior. The user-visible scan
log gets one slightly-changed status line ("EXIF + scoring signals via
exiftool…") but the existing s01_happy_path scenario already exercises
the full scan path. The dedicated qa/scenarios/s42_scoring.py scenario
is in PR 7's scope, after PR 5 adds the user-visible COL_SCORE column.]

[docs-not-needed: scoring is now wired into scan, but no user-visible
column exists yet (PR 5 adds it). The README's Performance / Architecture
sections will be updated in PR 5 when COL_SCORE makes the feature
user-visible end-to-end.]

🤖 Generated with [Claude Code](https://claude.com/claude-code)