### PR TITLE
feat(scoring): COL_SCORE column + within-group score-DESC sort (#187)

### DIFF
--- a/app/viewmodels/main_vm.py
+++ b/app/viewmodels/main_vm.py
@@ -41,8 +41,17 @@ class MainVM:
         for item in items:
             grouped[item.group_number].append(item)
         self.groups = [PhotoGroup(group_number=k, items=v) for k, v in sorted(grouped.items())]
-        if self._default_sort:
-            self._sorter.sort(self.groups, self._default_sort)
+        # Compose the within-group sort: score-DESC is the design default
+        # for #187 ("highest-quality copy at the top of each group"). User-
+        # configured ``sorting.defaults`` from settings.json act as
+        # secondary tiebreakers. If the user has explicitly set ``score``
+        # as one of their default sorts (any direction), respect that
+        # choice and skip the implicit prepend.
+        sort_keys: list[tuple[str, bool]] = list(self._default_sort)
+        if not any(field == "score" for field, _ in sort_keys):
+            sort_keys = [("score", False)] + sort_keys
+        if sort_keys:
+            self._sorter.sort(self.groups, sort_keys)
 
     def remove_deleted_and_prune(
         self, deleted_paths: list[str], prune_singles: bool = True

--- a/app/views/constants.py
+++ b/app/views/constants.py
@@ -23,7 +23,11 @@ COL_GROUP_COUNT: int = 6
 COL_CREATION_DATE: int = 7
 COL_SHOT_DATE: int = 8
 COL_RESOLUTION: int = 9
-NUM_COLUMNS: int = 10
+# COL_SCORE was appended at index 10 for #187 (keep-worthiness scoring).
+# All prior column indices are unchanged so existing sort-state config
+# in settings.json and any user muscle memory keep working.
+COL_SCORE: int = 10
+NUM_COLUMNS: int = 11
 
 
 # Data roles
@@ -56,6 +60,7 @@ def headers() -> list[str]:
         t("column.creation_date"),
         t("column.shot_date"),
         t("column.resolution"),
+        t("column.score"),
     ]
 
 

--- a/app/views/tree_model_builder.py
+++ b/app/views/tree_model_builder.py
@@ -15,6 +15,7 @@ from app.views.constants import (
     COL_LOCK,
     COL_NAME,
     COL_RESOLUTION,
+    COL_SCORE,
     COL_SHOT_DATE,
     COL_SIZE_BYTES,
     PATH_ROLE,
@@ -99,6 +100,27 @@ def _file_similarity(action: str, record: object) -> str:
     return t("tree.similarity_ref")
 
 
+# Sentinel SORT_ROLE value for unscored rows (Live Photo MOV passengers,
+# isolated rows, old manifests pre-#187). Set lower than any real score
+# (which is in [0.0, 1.0]) so unscored rows sort to the bottom under
+# descending order. -1.0 is the chosen sentinel — any negative would
+# work; -1 makes the convention explicit when reading sort code.
+_UNSCORED_SORT_VALUE: float = -1.0
+
+
+def _score_display(score: float | None) -> str:
+    """Format a score for the COL_SCORE cell.
+
+    Two-decimal float for real scores (e.g. ``"0.87"``); em-dash for
+    unscored rows. Em-dash distinguishes a deliberate None (passenger,
+    isolated, unscored manifest) from a missing render — the user reads
+    ``"—"`` as 'no score' rather than 'broken display'.
+    """
+    if score is None:
+        return "—"
+    return f"{score:.2f}"
+
+
 def build_model(
     groups: Iterable[object],
 ) -> tuple[QStandardItemModel, QSortFilterProxyModel | None]:
@@ -129,6 +151,7 @@ def build_model(
             QStandardItem(""),                       # COL_CREATION_DATE (7)
             QStandardItem(""),                       # COL_SHOT_DATE  (8)
             QStandardItem(""),                       # COL_RESOLUTION (9) — group level empty
+            QStandardItem(""),                       # COL_SCORE      (10) — group level empty; sort role = max
         ]
         for it in group_row:
             it.setEditable(False)
@@ -217,6 +240,21 @@ def build_model(
             group_row[COL_RESOLUTION].setData(max(megapixels, default=0), SORT_ROLE)
         except Exception:
             pass
+        try:
+            # Group-level Score sort: max score across files in the group.
+            # Unscored rows (score is None) contribute the sentinel so a
+            # group containing only unscored rows sorts to the bottom under
+            # descending order, like its individual rows do.
+            file_scores = [
+                getattr(it, "score", None) for it in items_list
+            ]
+            real_scores = [s for s in file_scores if s is not None]
+            group_row[COL_SCORE].setData(
+                max(real_scores) if real_scores else _UNSCORED_SORT_VALUE,
+                SORT_ROLE,
+            )
+        except Exception:
+            pass
 
         model.appendRow(group_row)
 
@@ -232,6 +270,8 @@ def build_model(
             px_h = getattr(p, "pixel_height", None)
             resolution_txt = f"{px_w}×{px_h}" if px_w and px_h else ""
             resolution_mp = (px_w or 0) * (px_h or 0)
+            score_val = getattr(p, "score", None)
+            score_txt = _score_display(score_val)
 
             # Col 0 at file row: similarity % for duplicates, "Ref" for the source file
             file_action = getattr(p, "action", "") or ""
@@ -255,6 +295,7 @@ def build_model(
                 QStandardItem(creation_txt),         # COL_CREATION_DATE (7)
                 QStandardItem(shot_txt),             # COL_SHOT_DATE  (8)
                 QStandardItem(resolution_txt),       # COL_RESOLUTION (9)
+                QStandardItem(score_txt),            # COL_SCORE      (10)
             ]
 
             try:
@@ -297,6 +338,16 @@ def build_model(
                 pass
             try:
                 child_row[COL_RESOLUTION].setData(resolution_mp, SORT_ROLE)
+            except Exception:
+                pass
+            try:
+                # Score sort: float when present, sentinel _UNSCORED_SORT_VALUE
+                # (-1.0) when None so unscored rows sort below real-score rows
+                # under descending order.
+                child_row[COL_SCORE].setData(
+                    float(score_val) if score_val is not None else _UNSCORED_SORT_VALUE,
+                    SORT_ROLE,
+                )
             except Exception:
                 pass
             try:

--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -68,9 +68,10 @@ class ScanWorker(QThread):
         from concurrent.futures import ThreadPoolExecutor, as_completed
         from scanner.walker import scan_sources
         from scanner.hasher import compute_hashes
-        from scanner.exif import ExiftoolProcess, batch_read_dates, parse_exif_date
+        from scanner.exif import ExiftoolProcess, batch_read_extracts, parse_exif_date
         from scanner.dedup import HashResult, classify
         from scanner.manifest import write_manifest, print_summary
+        from scanner.scoring import apply_scoring_to_rows
         import io
         from contextlib import redirect_stdout
 
@@ -105,7 +106,6 @@ class ScanWorker(QThread):
         # One file read per image: SHA-256, pHash, and EXIF date for JPEG/PNG
         # are extracted from the same in-memory buffer.
         chunk_size = 500
-        _EXIFTOOL_TYPES = frozenset(("heic", "raw", "mov", "mp4"))
         cancel_flag = threading.Event()
         skipped: list[tuple[Path, str, str]] = []  # (path, exc type, exc msg)
 
@@ -181,29 +181,42 @@ class ScanWorker(QThread):
             if len(skipped) > 10:
                 self._emit(f"    … and {len(skipped) - 10:,} more")
 
-        # --- 3. exiftool for HEIC / RAW / MOV / MP4 only ---
-        # JPEG and PNG dates already populated from the PIL pass above.
-        et_records = [r for r in hash_results if r.exif_date is None
-                      and r.record.file_type in _EXIFTOOL_TYPES]
+        # --- 3. exiftool for ALL non-skip files ---
+        # Previously this ran only for HEIC/RAW/MOV/MP4 (formats whose dates
+        # PIL cannot extract). For the #187 scoring system every file needs
+        # a full census tag count + GPS / xmpMM:DerivedFrom presence, so
+        # the exiftool pass now covers everything (except file_type="skip").
+        # PIL dates from the hash pass are preserved — exiftool dates only
+        # fill in when PIL didn't find one.
+        et_records = [r for r in hash_results if r.record.file_type != "skip"]
+        extracts: dict = {}
         if et_records:
             et_paths = [r.record.path for r in et_records]
             n_chunks = (len(et_paths) + chunk_size - 1) // chunk_size
-            self._emit(f"EXIF via exiftool for {len(et_paths):,} non-JPEG files ({n_chunks} chunk(s))…")
+            self._emit(
+                f"EXIF + scoring signals via exiftool for {len(et_paths):,} files"
+                f" ({n_chunks} chunk(s))…"
+            )
             try:
                 with ExiftoolProcess() as et:
-                    dates: dict = {}
                     for i in range(0, len(et_paths), chunk_size):
                         chunk = et_paths[i: i + chunk_size]
-                        dates.update(batch_read_dates(chunk, et, chunk_size=chunk_size))
+                        extracts.update(batch_read_extracts(chunk, et, chunk_size=chunk_size))
                         done_et = min(i + chunk_size, len(et_paths))
                         self._emit(f"  EXIF {done_et:,}/{len(et_paths):,}")
-                found = sum(1 for v in dates.values() if v)
-                self._emit(f"  EXIF done — {found:,} dates found")
+                found_dates = sum(1 for e in extracts.values() if e.exif_date is not None)
+                with_gps = sum(1 for e in extracts.values() if e.gps_present)
+                self._emit(f"  EXIF done — {found_dates:,} dates, {with_gps:,} with GPS")
+                # Backfill exif_date for records where PIL didn't find one.
                 for r in et_records:
-                    r.exif_date = dates.get(r.record.path)
+                    if r.exif_date is None:
+                        extract = extracts.get(r.record.path)
+                        if extract is not None:
+                            r.exif_date = extract.exif_date
             except FileNotFoundError:
                 self._emit(
-                    "WARNING: exiftool not found on PATH — EXIF dates for HEIC/RAW/video unavailable.\n"
+                    "WARNING: exiftool not found on PATH — EXIF dates for HEIC/RAW/video"
+                    " and scoring signals (GPS, EXIF census, XMP provenance) unavailable.\n"
                     "Install from https://exiftool.org/ and add to PATH."
                 )
 
@@ -215,6 +228,13 @@ class ScanWorker(QThread):
             mean_color_threshold=self.mean_color_threshold,
             source_priority=self.source_priority,
         )
+
+        # --- 4.5: score within each duplicate group (#187) ---
+        # Mutates rows in place: copies exif_tag_count / gps_present /
+        # xmp_derived from extracts into ManifestRow, then assigns
+        # compute_score(...) per group. Isolated rows (group_id is None)
+        # stay unscored — no peers to compete with.
+        apply_scoring_to_rows(rows, extracts)
 
         # Capture print_summary output and re-emit as progress
         buf = io.StringIO()

--- a/core/models.py
+++ b/core/models.py
@@ -33,6 +33,11 @@ class PhotoRecord:
     # User's planned file operation (delete | keep | "" = undecided)
     user_decision: str = ""
     hamming_distance: int | None = None
+    # Keep-worthiness score in [0.0, 1.0] (#187). None for isolated rows
+    # (no peers to score against) and Live Photo MOV passengers (inherit
+    # their HEIC's decision). Computed at scan time by scanner.scoring;
+    # re-computable without re-scan via ManifestRepository.rescore().
+    score: float | None = None
 
 
 @dataclass

--- a/core/services/sort_service.py
+++ b/core/services/sort_service.py
@@ -26,7 +26,33 @@ class SortService:
         if not sort_keys:
             return
 
-        for group in groups:
+        # Make ``groups`` materialisable: callers pass a list, but the
+        # ``Iterable`` annotation allows generators which we'd otherwise
+        # exhaust during type detection and have nothing left to sort.
+        groups_list = list(groups)
+
+        # Detect each sort field's type from the first non-None value seen
+        # across all items. None values are then substituted with the
+        # type-appropriate zero (numeric → 0, string → "") so a field with
+        # mixed None and non-None values (e.g. ``score`` on Live Photo
+        # MOV passengers + scored rows in the same group) sorts without
+        # the float-vs-tuple TypeError that the previous implementation
+        # produced. See #187 PR 5.
+        field_is_numeric: dict[str, bool] = {}
+        for field_name, _ in sort_keys:
+            for group in groups_list:
+                for item in group.items:
+                    v = getattr(item, field_name, None)
+                    if v is not None:
+                        field_is_numeric[field_name] = isinstance(v, (int, float))
+                        break
+                if field_name in field_is_numeric:
+                    break
+            # All values None for this field → treat as numeric (0
+            # default keeps the sort deterministic).
+            field_is_numeric.setdefault(field_name, True)
+
+        for group in groups_list:
             # Build a decorated list with adjusted values for per-key order
             decorated: list[tuple[tuple[Any, ...], PhotoRecord]] = []
             for item in group.items:
@@ -34,7 +60,7 @@ class SortService:
                 for field_name, ascending in sort_keys:
                     value = getattr(item, field_name, None)
                     if value is None:
-                        value = 0 if isinstance(value, (int, float)) else ""
+                        value = 0 if field_is_numeric[field_name] else ""
                     if isinstance(value, (int, float)):
                         row.append(value if ascending else -value)
                     else:

--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -336,6 +336,108 @@ class ManifestRepository:
         finally:
             conn.close()
 
+    def rescore(
+        self,
+        manifest_path: str,
+        weights: "dict[str, float] | None" = None,
+    ) -> int:
+        """Recompute composite scores from cached raw signals (#187).
+
+        Reads every grouped row's scoring-relevant columns
+        (``pixel_width/height``, ``file_size_bytes``, ``shot_date``,
+        ``mtime``, ``exif_tag_count``, ``gps_present``, ``xmp_derived``,
+        plus ``source_path`` and ``group_id``), runs the scorer in
+        memory, and writes the new ``score`` values back with a single
+        batched UPDATE.
+
+        **No file I/O.** No exiftool subprocess, no Pillow open. Use
+        when the user changes ``scoring.weights`` in settings.json —
+        avoids a full re-scan, which on a NAS library can take 10+ min.
+
+        Returns the count of rows whose score was written. Isolated rows
+        (``group_id IS NULL``) are skipped — they have no peers to score
+        against. Live Photo MOV passengers receive score=NULL by the
+        scorer's own rule and that NULL is written back.
+        """
+        from collections import defaultdict
+        from scanner.dedup import ManifestRow
+        from scanner.scoring import DEFAULT_WEIGHTS, score_group, validate_weights
+
+        if weights is None:
+            weights = DEFAULT_WEIGHTS
+        validate_weights(weights)
+
+        # Load only the columns the scorer reads — keeps the in-memory
+        # rebuild cheap. ``ManifestRow`` requires source_label, action,
+        # source_hash, phash, hamming_distance, duplicate_of, reason —
+        # those don't affect scoring but the dataclass demands them, so
+        # we fill placeholders.
+        conn = _connect(manifest_path)
+        try:
+            rows_data = conn.execute(
+                """
+                SELECT source_path, action, group_id,
+                       pixel_width, pixel_height, file_size_bytes,
+                       shot_date, mtime,
+                       exif_tag_count, gps_present, xmp_derived
+                FROM   migration_manifest
+                WHERE  group_id IS NOT NULL
+                """
+            ).fetchall()
+        finally:
+            conn.close()
+
+        rows = [
+            ManifestRow(
+                source_path=r[0],
+                source_label="",           # placeholder — not used by scorer
+                dest_path=None,
+                action=r[1],
+                source_hash="",            # placeholder
+                phash=None,
+                hamming_distance=None,
+                duplicate_of=None,
+                reason="",
+                pixel_width=r[3],
+                pixel_height=r[4],
+                file_size_bytes=r[5],
+                shot_date=r[6],
+                mtime=r[7],
+                group_id=r[2],
+                exif_tag_count=r[8],
+                gps_present=bool(r[9]),
+                xmp_derived=bool(r[10]),
+            )
+            for r in rows_data
+        ]
+
+        # Group by group_id, score each group, collect (score, path) tuples
+        # for the batch UPDATE.
+        groups: dict[str, list[ManifestRow]] = defaultdict(list)
+        for row in rows:
+            groups[row.group_id].append(row)
+
+        updates: list[tuple] = []
+        for group_rows in groups.values():
+            scores = score_group(group_rows, weights)
+            for row in group_rows:
+                updates.append((scores[row.source_path], row.source_path))
+
+        if not updates:
+            return 0
+
+        conn = _connect(manifest_path)
+        try:
+            conn.executemany(
+                "UPDATE migration_manifest SET score = ? WHERE source_path = ?",
+                updates,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+        logger.info("Rescored {} rows in {}", len(updates), manifest_path)
+        return len(updates)
+
     def mark_executed(self, manifest_path: str, file_paths: list[str]) -> None:
         """Mark a list of rows as executed=1."""
         conn = _connect(manifest_path)

--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -53,7 +53,8 @@ _LOAD_ALL_SQL = """
 SELECT id, source_path, source_label, group_id, hamming_distance, reason,
        action, executed, user_decision, is_locked,
        file_size_bytes, shot_date, creation_date, mtime,
-       pixel_width, pixel_height
+       pixel_width, pixel_height,
+       score
 FROM   migration_manifest
 WHERE  executed = 0
 ORDER  BY
@@ -128,6 +129,7 @@ def _photo_record(
     hamming_distance: "int | None" = None,
     db_pixel_width: "int | None" = None,
     db_pixel_height: "int | None" = None,
+    db_score: "float | None" = None,
 ) -> PhotoRecord:
     """Build a PhotoRecord, preferring cached DB metadata over filesystem reads.
 
@@ -191,6 +193,7 @@ def _photo_record(
         hamming_distance=hamming_distance,
         pixel_width=db_pixel_width,
         pixel_height=db_pixel_height,
+        score=db_score,
     )
 
 
@@ -273,6 +276,7 @@ class ManifestRepository:
                         hamming_distance=row["hamming_distance"],
                         db_pixel_width=row["pixel_width"],
                         db_pixel_height=row["pixel_height"],
+                        db_score=row["score"],
                     )
                 except Exception as exc:  # pylint: disable=broad-exception-caught
                     logger.warning("Skipping {}: {}", source_path, exc)

--- a/scan.py
+++ b/scan.py
@@ -131,9 +131,10 @@ def main() -> int:
     from concurrent.futures import ThreadPoolExecutor, as_completed
     from scanner.walker import scan_sources
     from scanner.hasher import compute_hashes
-    from scanner.exif import ExiftoolProcess, batch_read_dates, parse_exif_date
+    from scanner.exif import ExiftoolProcess, batch_read_extracts, parse_exif_date
     from scanner.dedup import HashResult, classify
     from scanner.manifest import write_manifest, print_summary
+    from scanner.scoring import apply_scoring_to_rows
 
     print("Read-only scan — no files will be moved or deleted.", flush=True)
     print("MOVE / SKIP / REVIEW in the results are planned actions only.\n", flush=True)
@@ -159,7 +160,6 @@ def main() -> int:
     # are all extracted from the same in-memory buffer.
     # HEIC / RAW / MOV / MP4 return no date here — a targeted exiftool batch follows.
     chunk_size = 500
-    _EXIFTOOL_TYPES = frozenset(("heic", "raw", "mov", "mp4"))
 
     print(f"Hashing {len(records):,} files (workers={args.workers})…", flush=True)
     hash_results: list[HashResult] = [None] * len(records)  # type: ignore[list-item]
@@ -202,36 +202,60 @@ def main() -> int:
         if len(skipped) > 10:
             print(f"    … and {len(skipped) - 10:,} more", file=sys.stderr, flush=True)
 
-    # --- exiftool for HEIC / RAW / MOV / MP4 only ---
-    # JPEG and PNG dates are already populated from the PIL pass above.
-    et_records = [r for r in hash_results if r.exif_date is None
-                  and r.record.file_type in _EXIFTOOL_TYPES]
+    # --- exiftool for ALL non-skip files ---
+    # Previously this ran only for HEIC/RAW/MOV/MP4 (formats whose dates
+    # PIL cannot extract). For the #187 scoring system every file needs a
+    # full census tag count + GPS / xmpMM:DerivedFrom presence, so the
+    # exiftool pass now covers everything (except file_type="skip").
+    # PIL dates from the hash pass above are preserved — exiftool dates
+    # only fill in when PIL didn't find one.
+    et_records = [r for r in hash_results if r.record.file_type != "skip"]
+    extracts: dict = {}
     if et_records:
         et_paths = [r.record.path for r in et_records]
         n_chunks = (len(et_paths) + chunk_size - 1) // chunk_size
-        print(f"EXIF via exiftool for {len(et_paths):,} non-JPEG files ({n_chunks} chunk(s))…",
-              flush=True)
+        print(
+            f"EXIF + scoring signals via exiftool for {len(et_paths):,} files "
+            f"({n_chunks} chunk(s))…",
+            flush=True,
+        )
         try:
             with ExiftoolProcess() as et:
-                dates: dict = {}
                 for i in range(0, len(et_paths), chunk_size):
                     chunk = et_paths[i: i + chunk_size]
-                    dates.update(batch_read_dates(chunk, et, chunk_size=chunk_size))
+                    extracts.update(batch_read_extracts(chunk, et, chunk_size=chunk_size))
                     done_et = min(i + chunk_size, len(et_paths))
                     print(f"  EXIF {done_et:,}/{len(et_paths):,}", end="\r", flush=True)
-            found = sum(1 for v in dates.values() if v)
-            print(f"  EXIF done — {found:,} dates found", flush=True)
+            found_dates = sum(1 for e in extracts.values() if e.exif_date is not None)
+            with_gps = sum(1 for e in extracts.values() if e.gps_present)
+            print(
+                f"  EXIF done — {found_dates:,} dates, {with_gps:,} with GPS",
+                flush=True,
+            )
+            # Backfill exif_date for records where PIL didn't find one.
+            # PIL's value (when present) wins because it's already on the
+            # record; we only fill the None slots.
             for r in et_records:
-                r.exif_date = dates.get(r.record.path)
+                if r.exif_date is None:
+                    extract = extracts.get(r.record.path)
+                    if extract is not None:
+                        r.exif_date = extract.exif_date
         except FileNotFoundError:
             print(
-                "\nWARNING: exiftool not found on PATH — EXIF dates for HEIC/RAW/video unavailable.\n"
+                "\nWARNING: exiftool not found on PATH — EXIF dates for HEIC/RAW/video"
+                " and scoring signals (GPS, EXIF census, XMP provenance) unavailable.\n"
                 "Install from https://exiftool.org/ and ensure it is in your PATH.",
                 file=sys.stderr,
             )
 
     print("Classifying…", flush=True)
     rows = classify(hash_results, threshold=args.threshold, source_priority=source_priority)
+
+    # --- Phase 4.5: score within each duplicate group (#187) ---
+    # Mutates rows in place: copies exif_tag_count / gps_present / xmp_derived
+    # from extracts into ManifestRow, then assigns compute_score(...) per group.
+    # Isolated rows (group_id is None) stay unscored — no peers to compete with.
+    apply_scoring_to_rows(rows, extracts)
 
     print_summary(rows, skipped=len(skipped))
 

--- a/scanner/scoring.py
+++ b/scanner/scoring.py
@@ -51,6 +51,7 @@ from typing import Iterable, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
     from scanner.dedup import ManifestRow
+    from scanner.media_extract import MediaExtract
 
 
 # ── Tier 1 — Categorical penalties (absolute deductions, not weight-scaled) ──
@@ -405,3 +406,62 @@ def score_group(
         r.source_path: compute_score(r, group_rows, weights)
         for r in group_rows
     }
+
+
+def apply_scoring_to_rows(
+    rows: "list[ManifestRow]",
+    extracts: "dict[Path, MediaExtract]",
+    weights: dict[str, float] = DEFAULT_WEIGHTS,
+) -> None:
+    """Wire MediaExtract scoring signals into ManifestRows + assign scores.
+
+    Two-phase mutation of ``rows`` in place:
+
+    Phase A — Backfill raw signals from the exiftool extract dict:
+        ``exif_tag_count``, ``gps_present``, ``xmp_derived`` move from
+        the MediaExtract (PR 2 output) onto ManifestRow (PR 1 column).
+        The MediaExtract sentinel ``None`` (not checked) is preserved as
+        the column default — only definite True/False / int values
+        overwrite. Rows whose path is missing from ``extracts`` (exiftool
+        skipped or failed for that file) keep their default ManifestRow
+        values; the scorer treats those as 'no signal' (0.0).
+
+    Phase B — Compute and assign composite scores per group:
+        Rows are grouped by ``group_id`` (None / isolated rows stay
+        unscored). Within each group, ``score_group`` produces the dict;
+        ``ManifestRow.score`` is set per row. Live Photo MOV passengers
+        receive ``None`` (passed through from score_group); the action
+        layer (PR 6) will skip them when applying decisions.
+
+    Pure-with-mutation: same inputs always produce the same row state.
+    No I/O. Tested via ``test_apply_scoring_to_rows`` with synthetic
+    ManifestRow + MediaExtract fixtures.
+    """
+    from collections import defaultdict
+
+    # Phase A: backfill raw scoring signals from exiftool extracts.
+    for row in rows:
+        extract = extracts.get(Path(row.source_path))
+        if extract is None:
+            continue
+        if extract.exif_tag_count is not None:
+            row.exif_tag_count = extract.exif_tag_count
+        # MediaExtract uses Optional[bool] (None=not checked). ManifestRow's
+        # column is NOT NULL DEFAULT 0 — collapse None to the existing
+        # default rather than overwriting.
+        if extract.gps_present is not None:
+            row.gps_present = bool(extract.gps_present)
+        if extract.xmp_derived is not None:
+            row.xmp_derived = bool(extract.xmp_derived)
+
+    # Phase B: compute scores within each duplicate group. Isolated rows
+    # (group_id is None) intentionally stay unscored — they have no peers
+    # to compete with.
+    groups: dict[str, list] = defaultdict(list)
+    for row in rows:
+        if row.group_id:
+            groups[row.group_id].append(row)
+    for group_rows in groups.values():
+        scores = score_group(group_rows, weights)
+        for row in group_rows:
+            row.score = scores[row.source_path]

--- a/tests/test_main_vm.py
+++ b/tests/test_main_vm.py
@@ -263,3 +263,82 @@ class TestPendingDecisionCount:
             _rec("/b.jpg", 1, user_decision="move"),
         )
         assert vm.pending_decision_count == 2
+
+
+# ── Within-group score-DESC default sort (#187 — PR 5) ─────────────────────
+
+
+def _scored_rec(path: str, *, score: float | None, group: int = 1) -> PhotoRecord:
+    return PhotoRecord(
+        group_number=group,
+        is_mark=False,
+        is_locked=False,
+        folder_path="/folder",
+        file_path=path,
+        capture_date=datetime(2024, 1, 1),
+        modified_date=datetime(2024, 1, 1),
+        file_size_bytes=1024,
+        score=score,
+    )
+
+
+class TestWithinGroupScoreSort:
+    """The MainVM's _group_records prepends ("score", False) as the design
+    default for #187 so the highest-scoring copy lands at the top of each
+    group. User-configured sorts act as secondary tiebreakers; an explicit
+    user sort on the score field (either direction) suppresses the prepend.
+    """
+
+    def test_default_sort_orders_by_score_desc(self):
+        """No user-configured sort — score-DESC is the implicit default."""
+        repo = _mock_repo(
+            _scored_rec("/low.jpg", score=0.3),
+            _scored_rec("/high.jpg", score=0.9),
+            _scored_rec("/mid.jpg", score=0.6),
+        )
+        vm = MainVM()
+        vm.load_from_repo(repo, "/manifest.sqlite")
+        paths = [r.file_path for r in vm.groups[0].items]
+        assert paths == ["/high.jpg", "/mid.jpg", "/low.jpg"]
+
+    def test_none_score_sorts_to_bottom_under_desc(self):
+        """A row with score=None (Live Photo MOV passenger, isolated, or
+        old manifest) must sort below real scores under descending order.
+        Previously this would TypeError because SortService substituted
+        ``""`` for None on a numeric field — the regression-test contract."""
+        repo = _mock_repo(
+            _scored_rec("/unscored.jpg", score=None),
+            _scored_rec("/scored.jpg", score=0.5),
+        )
+        vm = MainVM()
+        vm.load_from_repo(repo, "/manifest.sqlite")
+        paths = [r.file_path for r in vm.groups[0].items]
+        assert paths == ["/scored.jpg", "/unscored.jpg"]
+
+    def test_user_configured_score_sort_overrides_default(self):
+        """A user who explicitly configures ``score`` (any direction) takes
+        full control — the implicit DESC prepend is skipped so the user's
+        chosen direction wins."""
+        repo = _mock_repo(
+            _scored_rec("/low.jpg", score=0.3),
+            _scored_rec("/high.jpg", score=0.9),
+        )
+        vm = MainVM(default_sort=[("score", True)])   # explicit ascending
+        vm.load_from_repo(repo, "/manifest.sqlite")
+        paths = [r.file_path for r in vm.groups[0].items]
+        assert paths == ["/low.jpg", "/high.jpg"]
+
+    def test_user_configured_non_score_sort_becomes_tiebreaker(self):
+        """A user's sort on a non-score field acts as the secondary key:
+        score-DESC first, user's field second."""
+        repo = _mock_repo(
+            _scored_rec("/path_b.jpg", score=0.8),
+            _scored_rec("/path_a.jpg", score=0.8),  # tied score
+            _scored_rec("/path_c.jpg", score=0.5),
+        )
+        vm = MainVM(default_sort=[("file_path", True)])
+        vm.load_from_repo(repo, "/manifest.sqlite")
+        paths = [r.file_path for r in vm.groups[0].items]
+        # Score-DESC primary: the two 0.8s before the 0.5. Then path-ASC
+        # as tiebreaker on the 0.8 rows: a before b.
+        assert paths == ["/path_a.jpg", "/path_b.jpg", "/path_c.jpg"]

--- a/tests/test_manifest_repository.py
+++ b/tests/test_manifest_repository.py
@@ -1278,3 +1278,72 @@ class TestScoringSchemaMigration:
         # First load adds the columns; second load must not raise.
         list(ManifestRepository().load(str(db)))
         list(ManifestRepository().load(str(db)))  # should not raise
+
+    def test_score_loads_from_db_into_photo_record(self, tmp_path):
+        """The score column is read from the manifest and threaded onto
+        PhotoRecord.score so the UI can display / sort it. PR 5 contract."""
+        cand = tmp_path / "a.jpg"
+        ref = tmp_path / "b.jpg"
+        cand.write_bytes(b""); ref.write_bytes(b"")
+        gid = "/group/a"
+        # Use the production write path so the score column is in the DDL.
+        from scanner.dedup import ManifestRow
+        from scanner.manifest import write_manifest
+
+        rows = [
+            ManifestRow(
+                source_path=str(cand), source_label="src",
+                dest_path=None, action="REVIEW_DUPLICATE",
+                source_hash="aaa", phash=None, hamming_distance=5,
+                duplicate_of=None, reason="",
+                group_id=gid, score=0.87,
+            ),
+            ManifestRow(
+                source_path=str(ref), source_label="src",
+                dest_path=None, action="MOVE",
+                source_hash="bbb", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                group_id=gid, score=0.42,
+            ),
+        ]
+        db = tmp_path / "m.sqlite"
+        write_manifest(rows, db)
+
+        records = {r.file_path: r for r in ManifestRepository().load(str(db))}
+        assert records[str(cand)].score == pytest.approx(0.87)
+        assert records[str(ref)].score == pytest.approx(0.42)
+
+    def test_score_loads_as_none_when_null(self, tmp_path):
+        """Live Photo MOV passengers and isolated rows get score=NULL in
+        the DB. The load path must preserve None on PhotoRecord, not
+        coerce to 0.0 (which would silently re-introduce 'unscored ties
+        with worst score' bug)."""
+        cand = tmp_path / "a.heic"
+        ref = tmp_path / "a.mov"
+        cand.write_bytes(b""); ref.write_bytes(b"")
+        gid = "/group/a"
+        from scanner.dedup import ManifestRow
+        from scanner.manifest import write_manifest
+
+        rows = [
+            ManifestRow(
+                source_path=str(cand), source_label="src",
+                dest_path=None, action="MOVE",
+                source_hash="aaa", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                group_id=gid, score=0.75,
+            ),
+            ManifestRow(
+                source_path=str(ref), source_label="src",
+                dest_path=None, action="MOVE",
+                source_hash="bbb", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                group_id=gid, score=None,  # Live Photo MOV passenger
+            ),
+        ]
+        db = tmp_path / "m.sqlite"
+        write_manifest(rows, db)
+
+        records = {r.file_path: r for r in ManifestRepository().load(str(db))}
+        assert records[str(ref)].score is None
+        assert records[str(cand)].score == pytest.approx(0.75)

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -595,3 +595,354 @@ class TestScoreGroup:
         first = score_group([a, b])
         second = score_group([a, b])
         assert first == second
+
+
+# ── apply_scoring_to_rows — PR 4 pipeline merge + score helper ─────────────
+
+
+class TestApplyScoringToRows:
+    """The bridge from PR 2's MediaExtract dict (exiftool batch output) to
+    PR 1's ManifestRow scoring columns + PR 3's composite score. Mutates
+    rows in place; no I/O. Tests construct synthetic ManifestRows and
+    MediaExtracts so the function's purity is provable.
+    """
+
+    def _extract(
+        self,
+        path_str: str,
+        *,
+        gps_present=None,
+        xmp_derived=None,
+        exif_tag_count=None,
+    ):
+        from pathlib import Path
+        from scanner.media_extract import MediaExtract
+        return MediaExtract(
+            path=Path(path_str),
+            gps_present=gps_present,
+            xmp_derived=xmp_derived,
+            exif_tag_count=exif_tag_count,
+            extracted_by={"exiftool"},
+        )
+
+    def test_backfills_raw_signals_from_extracts(self):
+        from pathlib import Path
+        from scanner.scoring import apply_scoring_to_rows
+        row = _row("/x/a.jpg", pixel_width=4000, pixel_height=3000)
+        extracts = {
+            Path("/x/a.jpg"): self._extract(
+                "/x/a.jpg",
+                gps_present=True,
+                xmp_derived=False,
+                exif_tag_count=12,
+            )
+        }
+        apply_scoring_to_rows([row], extracts)
+        assert row.gps_present is True
+        assert row.xmp_derived is False
+        assert row.exif_tag_count == 12
+
+    def test_none_extracts_preserve_defaults(self):
+        """A MediaExtract with gps_present=None (extractor didn't check)
+        must NOT overwrite ManifestRow.gps_present's default (False).
+        The whole point of MediaExtract's sentinel convention."""
+        from pathlib import Path
+        from scanner.scoring import apply_scoring_to_rows
+        row = _row("/x/a.jpg", pixel_width=4000, pixel_height=3000)
+        extracts = {
+            Path("/x/a.jpg"): self._extract(
+                "/x/a.jpg",
+                gps_present=None,
+                xmp_derived=None,
+                exif_tag_count=None,
+            )
+        }
+        apply_scoring_to_rows([row], extracts)
+        # Defaults from ManifestRow: gps_present=False, xmp_derived=False,
+        # exif_tag_count=None.
+        assert row.gps_present is False
+        assert row.xmp_derived is False
+        assert row.exif_tag_count is None
+
+    def test_missing_extract_skips_row(self):
+        """A row whose path is absent from the extracts dict (exiftool
+        skipped or failed for that file) keeps its ManifestRow defaults.
+        The scorer reads those as 'no signal'."""
+        from scanner.scoring import apply_scoring_to_rows
+        row = _row("/x/a.jpg", pixel_width=4000, pixel_height=3000)
+        apply_scoring_to_rows([row], {})  # empty extracts
+        assert row.exif_tag_count is None
+        assert row.gps_present is False
+        assert row.xmp_derived is False
+
+    def test_assigns_score_within_groups(self):
+        from pathlib import Path
+        from scanner.scoring import apply_scoring_to_rows
+        big = _row(
+            "/x/big.jpg", group_id="g1",
+            pixel_width=6000, pixel_height=4000,
+            file_size_bytes=5_000_000,
+        )
+        small = _row(
+            "/x/small.jpg", group_id="g1",
+            pixel_width=1024, pixel_height=768,
+            file_size_bytes=500_000,
+        )
+        apply_scoring_to_rows([big, small], extracts={})
+        assert big.score is not None
+        assert small.score is not None
+        # Bigger pixels + larger size in same group → bigger score.
+        assert big.score > small.score
+
+    def test_isolated_rows_left_unscored(self):
+        """A row with group_id=None has no peers — score stays None
+        because there's nothing to compete with."""
+        from scanner.scoring import apply_scoring_to_rows
+        row = _row("/x/lone.jpg", group_id=None,
+                    pixel_width=4000, pixel_height=3000)
+        apply_scoring_to_rows([row], extracts={})
+        assert row.score is None
+
+    def test_live_photo_mov_gets_none_score(self):
+        from scanner.scoring import apply_scoring_to_rows
+        heic = _row("/x/IMG_001.heic", group_id="g1")
+        mov = _row("/x/IMG_001.mov", group_id="g1")
+        apply_scoring_to_rows([heic, mov], extracts={})
+        assert mov.score is None
+        assert isinstance(heic.score, float)
+
+    def test_does_not_overwrite_existing_default_with_extract_default(self):
+        """gps_present default is False on ManifestRow. If extract says
+        explicitly False (checked + absent), the row gets False. If extract
+        says None (not checked), the row stays at its default False. Both
+        end up at False here — the distinction matters once we have a
+        row that started with True (e.g. set by an earlier pass)."""
+        from pathlib import Path
+        from scanner.scoring import apply_scoring_to_rows
+        row = _row("/x/a.jpg", group_id="g1")
+        row.gps_present = True   # simulate prior-set state
+        extracts = {
+            Path("/x/a.jpg"): self._extract("/x/a.jpg", gps_present=None)
+        }
+        apply_scoring_to_rows([row], extracts)
+        # None extract value should NOT clobber the existing True.
+        assert row.gps_present is True
+
+
+# ── ManifestRepository.rescore — re-compute scores without re-scanning ─────
+
+
+class TestManifestRepositoryRescore:
+    """Rescore reads cached raw signals from the DB, recomputes composite
+    scores in memory, and writes the new values back via a single batched
+    UPDATE. No file I/O, no exiftool. The test path exercises the
+    round-trip: write rows → rescore → read scores back.
+    """
+
+    def _make_manifest_with_scoring(self, tmp_path, rows: list[ManifestRow]):
+        """Use the real write_manifest() so the DB shape matches production."""
+        from scanner.manifest import write_manifest
+        out = tmp_path / "manifest.sqlite"
+        write_manifest(rows, out)
+        return out
+
+    def test_rescore_assigns_scores_from_cached_signals(self, tmp_path):
+        """Two rows in the same group, only signals in the DB — rescore
+        should produce a score for both, with the better signal winning."""
+        from infrastructure.manifest_repository import ManifestRepository
+        import sqlite3
+
+        rows = [
+            ManifestRow(
+                source_path="/x/big.jpg", source_label="src",
+                dest_path=None, action="REVIEW_DUPLICATE",
+                source_hash="aaa", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                pixel_width=6000, pixel_height=4000,
+                file_size_bytes=5_000_000,
+                group_id="g1",
+                exif_tag_count=12, gps_present=True, xmp_derived=False,
+            ),
+            ManifestRow(
+                source_path="/x/small.jpg", source_label="src",
+                dest_path=None, action="REVIEW_DUPLICATE",
+                source_hash="bbb", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                pixel_width=1024, pixel_height=768,
+                file_size_bytes=500_000,
+                group_id="g1",
+                exif_tag_count=2, gps_present=False, xmp_derived=False,
+            ),
+        ]
+        db = self._make_manifest_with_scoring(tmp_path, rows)
+
+        n = ManifestRepository().rescore(str(db))
+        assert n == 2
+
+        conn = sqlite3.connect(db)
+        try:
+            scores = dict(conn.execute(
+                "SELECT source_path, score FROM migration_manifest"
+            ).fetchall())
+        finally:
+            conn.close()
+        assert scores["/x/big.jpg"] is not None
+        assert scores["/x/small.jpg"] is not None
+        assert scores["/x/big.jpg"] > scores["/x/small.jpg"]
+
+    def test_rescore_skips_isolated_rows(self, tmp_path):
+        """Rows with group_id=NULL are not scored — they have no peers."""
+        from infrastructure.manifest_repository import ManifestRepository
+        import sqlite3
+
+        rows = [
+            ManifestRow(
+                source_path="/x/alone.jpg", source_label="src",
+                dest_path=None, action="MOVE",
+                source_hash="aaa", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                pixel_width=4000, pixel_height=3000,
+                group_id=None,
+            ),
+        ]
+        db = self._make_manifest_with_scoring(tmp_path, rows)
+        n = ManifestRepository().rescore(str(db))
+        assert n == 0
+
+        conn = sqlite3.connect(db)
+        try:
+            score = conn.execute(
+                "SELECT score FROM migration_manifest WHERE source_path = ?",
+                ("/x/alone.jpg",),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert score is None
+
+    def test_rescore_writes_null_for_live_photo_mov(self, tmp_path):
+        """The Live Photo MOV passenger rule (compute_score returns None)
+        must survive the round-trip into the DB as a NULL."""
+        from infrastructure.manifest_repository import ManifestRepository
+        import sqlite3
+
+        rows = [
+            ManifestRow(
+                source_path="/x/IMG_001.heic", source_label="src",
+                dest_path=None, action="MOVE",
+                source_hash="aaa", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                pixel_width=4000, pixel_height=3000,
+                group_id="g1",
+            ),
+            ManifestRow(
+                source_path="/x/IMG_001.mov", source_label="src",
+                dest_path=None, action="MOVE",
+                source_hash="bbb", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                group_id="g1",
+            ),
+        ]
+        db = self._make_manifest_with_scoring(tmp_path, rows)
+        ManifestRepository().rescore(str(db))
+
+        conn = sqlite3.connect(db)
+        try:
+            mov_score = conn.execute(
+                "SELECT score FROM migration_manifest WHERE source_path = ?",
+                ("/x/IMG_001.mov",),
+            ).fetchone()[0]
+            heic_score = conn.execute(
+                "SELECT score FROM migration_manifest WHERE source_path = ?",
+                ("/x/IMG_001.heic",),
+            ).fetchone()[0]
+        finally:
+            conn.close()
+        assert mov_score is None   # passenger rule
+        assert heic_score is not None
+
+    def test_rescore_validates_weights(self, tmp_path):
+        """Bad weights → clear error, not silent wrong scoring. Covers
+        both branches of validate_weights: missing keys + bad sum."""
+        from infrastructure.manifest_repository import ManifestRepository
+
+        rows = [
+            ManifestRow(
+                source_path="/x/a.jpg", source_label="src",
+                dest_path=None, action="MOVE",
+                source_hash="aaa", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                group_id="g1",
+            ),
+        ]
+        db = self._make_manifest_with_scoring(tmp_path, rows)
+
+        # Missing keys path:
+        with pytest.raises(ValueError, match="missing keys"):
+            ManifestRepository().rescore(str(db), weights={"resolution": 0.5})
+
+        # Bad sum path (all keys present, but they sum to 4.0):
+        bad_sum = {k: 0.5 for k in DEFAULT_WEIGHTS}
+        with pytest.raises(ValueError, match="must sum to 1.0"):
+            ManifestRepository().rescore(str(db), weights=bad_sum)
+
+    def test_rescore_uses_provided_weights(self, tmp_path):
+        """Calling rescore with custom weights must affect the result —
+        otherwise the API would be silently broken."""
+        from infrastructure.manifest_repository import ManifestRepository
+        import sqlite3
+
+        rows = [
+            ManifestRow(
+                source_path="/x/big.jpg", source_label="src",
+                dest_path=None, action="REVIEW_DUPLICATE",
+                source_hash="aaa", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                pixel_width=6000, pixel_height=4000,
+                group_id="g1",
+                gps_present=False,
+            ),
+            ManifestRow(
+                source_path="/x/small.jpg", source_label="src",
+                dest_path=None, action="REVIEW_DUPLICATE",
+                source_hash="bbb", phash=None, hamming_distance=None,
+                duplicate_of=None, reason="",
+                pixel_width=1024, pixel_height=768,
+                group_id="g1",
+                gps_present=True,
+            ),
+        ]
+        db = self._make_manifest_with_scoring(tmp_path, rows)
+
+        # Default weights → resolution wins, big > small.
+        ManifestRepository().rescore(str(db))
+        conn = sqlite3.connect(db)
+        try:
+            default = dict(conn.execute(
+                "SELECT source_path, score FROM migration_manifest"
+            ).fetchall())
+        finally:
+            conn.close()
+        assert default["/x/big.jpg"] > default["/x/small.jpg"]
+
+        # GPS-heavy weights — small has GPS, big does not. Big still has
+        # 0.25 resolution advantage but small now claims 0.85 GPS. With
+        # tied other dims, small should overtake.
+        gps_heavy = {
+            "resolution":    0.05,
+            "file_size":     0.02,
+            "exif_complete": 0.05,
+            "date_prov":     0.02,
+            "gps":           0.80,
+            "filename":      0.03,
+            "path":          0.02,
+            "live_photo":    0.01,
+        }
+        ManifestRepository().rescore(str(db), weights=gps_heavy)
+        conn = sqlite3.connect(db)
+        try:
+            tuned = dict(conn.execute(
+                "SELECT source_path, score FROM migration_manifest"
+            ).fetchall())
+        finally:
+            conn.close()
+        assert tuned["/x/small.jpg"] > tuned["/x/big.jpg"]

--- a/tests/test_sort_service.py
+++ b/tests/test_sort_service.py
@@ -6,7 +6,12 @@ from core.models import PhotoGroup, PhotoRecord
 from core.services.sort_service import SortService
 
 
-def _rec(path: str, size: int = 0, folder: str = "") -> PhotoRecord:
+def _rec(
+    path: str,
+    size: int = 0,
+    folder: str = "",
+    score: float | None = 0.0,
+) -> PhotoRecord:
     return PhotoRecord(
         group_number=1,
         is_mark=False,
@@ -16,6 +21,7 @@ def _rec(path: str, size: int = 0, folder: str = "") -> PhotoRecord:
         capture_date=None,
         modified_date=None,
         file_size_bytes=size,
+        score=score,
     )
 
 
@@ -68,3 +74,34 @@ class TestSortService:
         SortService().sort([g1, g2], [("file_size_bytes", True)])
         assert [r.file_size_bytes for r in g1.items] == [1, 2]
         assert [r.file_size_bytes for r in g2.items] == [3, 4]
+
+    def test_none_on_numeric_field_substitutes_zero(self):
+        """Previously this case raised TypeError: a numeric field with
+        mixed None / float values would build sort tuples of
+        ``(-0.8,)`` vs ``((1, ""),)`` and Python 3 refuses to order
+        float against tuple. The regression-test contract from #187 PR 5:
+        None substitutes the type-appropriate zero so the sort works
+        end-to-end."""
+        # ``score`` is float|None on PhotoRecord — exercise it directly.
+        g = _group(
+            _rec("/a.jpg", score=0.8),
+            _rec("/b.jpg", score=None),
+            _rec("/c.jpg", score=0.5),
+        )
+        SortService().sort([g], [("score", False)])  # descending
+        paths = [r.file_path for r in g.items]
+        # 0.8 first, 0.5 next, None (substituted to 0) last under desc.
+        assert paths == ["/a.jpg", "/c.jpg", "/b.jpg"]
+
+    def test_all_none_on_numeric_field_does_not_crash(self):
+        """If every item has None for the sort field (e.g. an old manifest
+        loaded before scoring was wired in), sort must still be
+        deterministic — not raise."""
+        g = _group(
+            _rec("/a.jpg", score=None),
+            _rec("/b.jpg", score=None),
+        )
+        SortService().sort([g], [("score", False)])
+        # No assertion on order — just verify no exception was raised
+        # and the items are still present.
+        assert len(g.items) == 2

--- a/tests/test_tree_model_builder.py
+++ b/tests/test_tree_model_builder.py
@@ -298,3 +298,95 @@ class TestLockColumnInBuiltModel:
                 assert sort_val == 1
             elif name_item.data(PATH_ROLE) == "/p/free.jpg":
                 assert sort_val == 0
+
+
+# ── COL_SCORE — #187 PR 5 ──────────────────────────────────────────────────
+
+
+class TestScoreColumn:
+    """COL_SCORE displays a 2-decimal float for scored rows and an em-dash
+    for unscored rows (Live Photo MOV passengers, isolated rows, old
+    manifests). The SORT_ROLE carries the numeric value so within-group
+    and inter-group sort by score work correctly under the proxy.
+    """
+
+    def test_score_cell_text_for_scored_row(self):
+        from app.views.constants import COL_SCORE, SORT_ROLE
+        from app.views.tree_model_builder import build_model
+
+        a = _rec(file_path="/p/a.jpg", score=0.87)
+        b = _rec(file_path="/p/b.jpg", score=0.42)
+        g = _group([a, b])
+        model, _ = build_model([g])
+        group_row = model.item(0, 0)
+        # Two file rows under the group
+        assert group_row.rowCount() == 2
+        for r in range(group_row.rowCount()):
+            score_item = group_row.child(r, COL_SCORE)
+            # Real scores render with two decimals
+            assert score_item.text() in {"0.87", "0.42"}
+
+    def test_score_cell_text_for_none_score(self):
+        """Unscored rows (None) render as em-dash, not empty / not '0.00'."""
+        from app.views.constants import COL_SCORE
+        from app.views.tree_model_builder import build_model
+
+        a = _rec(file_path="/p/a.jpg", score=None)
+        g = _group([a])
+        model, _ = build_model([g])
+        group_row = model.item(0, 0)
+        score_item = group_row.child(0, COL_SCORE)
+        assert score_item.text() == "—"
+
+    def test_score_sort_role_is_float_for_scored_rows(self):
+        from app.views.constants import COL_SCORE, SORT_ROLE
+        from app.views.tree_model_builder import build_model
+
+        a = _rec(file_path="/p/a.jpg", score=0.87)
+        g = _group([a])
+        model, _ = build_model([g])
+        group_row = model.item(0, 0)
+        score_item = group_row.child(0, COL_SCORE)
+        assert score_item.data(SORT_ROLE) == pytest.approx(0.87)
+
+    def test_score_sort_role_for_unscored_is_below_zero(self):
+        """Unscored rows must sort below any real-score row under
+        descending order. A negative sentinel guarantees that."""
+        from app.views.constants import COL_SCORE, SORT_ROLE
+        from app.views.tree_model_builder import build_model
+
+        a = _rec(file_path="/p/a.jpg", score=None)
+        g = _group([a])
+        model, _ = build_model([g])
+        group_row = model.item(0, 0)
+        score_item = group_row.child(0, COL_SCORE)
+        sort_val = score_item.data(SORT_ROLE)
+        assert isinstance(sort_val, float)
+        assert sort_val < 0.0  # sentinel below the [0.0, 1.0] real-score range
+
+    def test_group_header_score_is_max_in_group(self):
+        """Group-level COL_SCORE.SORT_ROLE = max score across files so
+        the column header sort orders groups by their best member."""
+        from app.views.constants import COL_SCORE, SORT_ROLE
+        from app.views.tree_model_builder import build_model
+
+        low = _rec(file_path="/p/low.jpg", score=0.30)
+        high = _rec(file_path="/p/high.jpg", score=0.90)
+        g = _group([low, high])
+        model, _ = build_model([g])
+        group_row_score_item = model.item(0, COL_SCORE)
+        assert group_row_score_item.data(SORT_ROLE) == pytest.approx(0.90)
+
+    def test_group_header_score_is_negative_when_all_unscored(self):
+        """A group whose every file is unscored (Live Photo group with
+        only MOV passengers, or old manifests) gets the negative sentinel
+        at group level too — sorts below scored groups under desc."""
+        from app.views.constants import COL_SCORE, SORT_ROLE
+        from app.views.tree_model_builder import build_model
+
+        only_none = _rec(file_path="/p/x.mov", score=None)
+        g = _group([only_none])
+        model, _ = build_model([g])
+        group_row_score_item = model.item(0, COL_SCORE)
+        sort_val = group_row_score_item.data(SORT_ROLE)
+        assert sort_val < 0.0

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -74,6 +74,7 @@ column:
   creation_date: "Creation Date"
   shot_date: "Shot Date"
   resolution: "Resolution"
+  score: "Score"
 
 # Tree row values — the "Group 5" label and similarity tags shown in
 # the main tree view next to each group / file.

--- a/translations/zh_TW.yml
+++ b/translations/zh_TW.yml
@@ -62,6 +62,7 @@ column:
   creation_date: "建立日期"
   shot_date: "拍攝日期"
   resolution: "解析度"
+  score: "分數"
 
 tree:
   group_label: "群組 {n}"


### PR DESCRIPTION
## Summary

PR 5 of 7 for #187 — the scoring system becomes **user-visible**.
Stacked on top of #203 (base = PR 4 branch).

### UI changes

- **`COL_SCORE = 10`** (NUM_COLUMNS 10 → 11). Appended at the end so
  all prior column indices stay stable — existing `settings.json` sort
  state and user muscle memory keep working.
- **`column.score` translation** ("Score" / "分數") in en.yml + zh_TW.yml.
- **`PhotoRecord.score: float | None`** — None for unscored (Live Photo
  MOV passenger, isolated row, or old manifest pre-#187).
- **`ManifestRepository.load()`** selects + threads `score` onto
  `PhotoRecord.score`.
- **`tree_model_builder`**:
  - File rows render score as `"0.87"` (two decimals) or `"—"` for None
  - `SORT_ROLE` is float for scored rows, `-1.0` sentinel for None so
    unscored rows sort below the `[0.0, 1.0]` valid range under desc
  - Group header `COL_SCORE.SORT_ROLE` = max score across files, so
    clicking the column header orders **groups** by their best member

### Within-group sort

`MainVM._group_records()` prepends `("score", False)` to the
SortService sort_keys list. The implicit default is "highest-quality
copy at the top of each group." User-configured `sorting.defaults` from
`settings.json` act as secondary tiebreakers. A user who explicitly
configures `score` themselves (either direction) takes full control —
implicit prepend is skipped.

### SortService bug fix (load-bearing)

Previously, when `value is None` for a numeric field, SortService
substituted `""` (string). Combining with float values from peer items
produced a sort tuple of mixed `(-0.8,)` vs `((1, ""),)` — Python 3's
sort then raised `TypeError` on the heterogeneous comparison.

The bug was latent because no existing field mixed None with numeric.
PR 5's `score` field is exactly that pattern, so the bug had to be
fixed before within-group score sort could work.

Fix: detect each sort field's type from the first non-None value across
all items, then substitute None with the type-appropriate zero (numeric
→ `0`, string → `""`). The existing string-None test passes unchanged.

## Test plan

14 new tests:

- **test_tree_model_builder (6):** COL_SCORE cell rendering (decimal
  float / em-dash) + SORT_ROLE (float / sentinel) at file and group
  levels.
- **test_main_vm (4):** score-DESC default, None-sorts-to-bottom,
  user-explicit-score override, non-score user sort as tiebreaker.
- **test_sort_service (2):** regression tests — None on numeric field
  substitutes 0; all-None column doesn't crash.
- **test_manifest_repository (2):** round-trip tests — score loads
  correctly, NULL preserves as None (not coerced to 0).

Full suite: **1105 passed, 2 skipped, coverage 89.11%**. All touched
files above the 70% per-file floor.

## What this PR does NOT do

- No right-click "Apply best-copy" action (**PR 6**)
- No `settings.json` weights UI (PR 5.5 — can be combined with PR 6)
- No dedicated QA scenario (**PR 7**: s42_scoring.py)
- No README schema/architecture updates — coming in PR 7 with the QA
  fixtures so docs and scenarios change together

[qa-not-needed: PR 7 adds the dedicated s42_scoring.py scenario that
exercises the full COL_SCORE + within-group sort end-to-end. PR 5
itself is plumbing — existing s01_happy_path / s12_save_manifest /
s15_context_menu scenarios all run against the updated column layout
unchanged (NUM_COLUMNS=11), which is the regression-protection that
matters here.]

[docs-not-needed: README schema/architecture text references the column
set abstractly; concrete updates land in PR 7 alongside the QA scenario
so docs + tests update together.]

🤖 Generated with [Claude Code](https://claude.com/claude-code)