### PR TITLE
fix(lock-confirm): pass total delete count to lock-confirm dialog (#207)

### DIFF
--- a/app/views/dialogs/execute_action_dialog.py
+++ b/app/views/dialogs/execute_action_dialog.py
@@ -366,7 +366,7 @@ class ExecuteActionDialog(QDialog):
         return False
 
     def _ask_lock_confirm(
-        self, *, paths: list[str], decision_for_label: str
+        self, *, paths: list[str], decision_for_label: str, affected_count: int | None = None
     ) -> int:
         """Show the locked-rows confirm dialog for ``paths`` (all locked).
 
@@ -384,7 +384,7 @@ class ExecuteActionDialog(QDialog):
         verdict = LockedRowsConfirmDialog.ask(
             self,
             action_label=_decision_display_label(decision_for_label),
-            affected_count=len(paths),
+            affected_count=affected_count if affected_count is not None else len(paths),
             locked_paths=paths,
         )
         if verdict == LockedRowsConfirmDialog.APPLY_ALL_UNLOCKED:
@@ -529,7 +529,9 @@ class ExecuteActionDialog(QDialog):
         apply_paths = matched_paths
         if locked_paths:
             verdict = self._ask_lock_confirm(
-                paths=locked_paths, decision_for_label=new_decision
+                paths=locked_paths,
+                decision_for_label=new_decision,
+                affected_count=len(matched_paths),
             )
             if verdict == _DIALOG_VERDICT_CANCEL:
                 return
@@ -605,6 +607,12 @@ class ExecuteActionDialog(QDialog):
         # any destructive action runs. This replaces the silent
         # filter at delete_service:50 (which never fired in the GUI
         # path anyway — _on_execute deletes directly, see below).
+        total_delete_count = sum(
+            1
+            for group in self._groups
+            for rec in getattr(group, "items", [])
+            if getattr(rec, "user_decision", "") == "delete"
+        )
         locked_delete_paths = [
             rec.file_path
             for group in self._groups
@@ -614,7 +622,9 @@ class ExecuteActionDialog(QDialog):
         ]
         if locked_delete_paths:
             verdict = self._ask_lock_confirm(
-                paths=locked_delete_paths, decision_for_label="delete"
+                paths=locked_delete_paths,
+                decision_for_label="delete",
+                affected_count=total_delete_count,
             )
             if verdict == _DIALOG_VERDICT_CANCEL:
                 return

--- a/tests/test_execute_action_dialog.py
+++ b/tests/test_execute_action_dialog.py
@@ -1004,6 +1004,34 @@ class TestExecuteRequestedLockConfirm:
         finally:
             dlg.close()
 
+    def test_lock_confirm_receives_total_delete_count_not_just_locked_count(self, qapp):
+        """#207 — when 1 of 3 delete-decision rows is locked, the lock-confirm dialog
+        must receive affected_count=3 (total deletes), not affected_count=1 (locked
+        only). Without this, unlocked_count=0 and the dialog fires the all-locked
+        branch, disabling "Apply to Unlocked Only"."""
+        from app.views.dialogs.execute_action_dialog import ExecuteActionDialog
+        from app.views.dialogs.locked_rows_confirm_dialog import LockedRowsConfirmDialog
+
+        r1 = _rec("/a.jpg", "delete")
+        r2 = _rec("/b.jpg", "delete")
+        r3 = _rec("/c.jpg", "delete")
+        r3.is_locked = True
+        groups = [_group(r1, r2, r3)]
+        dlg = ExecuteActionDialog(groups, manifest_path=None)
+        try:
+            with patch.object(
+                LockedRowsConfirmDialog,
+                "ask",
+                return_value=LockedRowsConfirmDialog.CANCEL,
+            ) as ask:
+                dlg._on_execute_requested()
+            ask.assert_called_once()
+            _, kwargs = ask.call_args
+            assert kwargs["affected_count"] == 3
+            assert kwargs["locked_paths"] == ["/c.jpg"]
+        finally:
+            dlg.close()
+
 
 # ── _set_decision_by_regex persist-failure swallow ────────────────────────
 


### PR DESCRIPTION
## Summary

- `_ask_lock_confirm` was passing `affected_count=len(locked_paths)` (the locked-only subset) instead of the full action count, so `unlocked_count` was always 0 — triggering the all-locked message and disabling "Apply to Unlocked Only" even when only 1 of N rows was locked.
- Added an optional `affected_count` parameter to `_ask_lock_confirm` (defaults to `len(paths)` so single-row call sites are unaffected).
- Supplied `total_delete_count` in `_on_execute_requested` and `len(matched_paths)` in `_set_decision_by_regex`.
- Regression test pins the exact `affected_count` / `locked_paths` call contract.

[qa-not-needed: pure data-plumbing bug — wrong count passed to an existing dialog. s34/s36 already exercise the lock-confirm-at-execute flow end-to-end; dialog button/text behaviour given the correct count is fully covered at layer 1 by TestExecuteRequestedLockConfirm + TestButtonStates in test_locked_rows_confirm_dialog.py.]

## Test plan

- [ ] `pytest tests/test_execute_action_dialog.py tests/test_locked_rows_confirm_dialog.py` — 89 tests pass
- [ ] Existing s34 / s36 QA scenarios unaffected

Closes #207

🤖 Generated with [Claude Code](https://claude.com/claude-code)