### PR TITLE
fix(lock-guard): block remove-from-list on locked items (#208)

### DIFF
--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -352,6 +352,54 @@ class FileOperationsHandler:
                 logger.info(
                     "Removing {} highlighted items from list via toolbar", len(highlighted_items)
                 )
+
+                # Lock guard (#208): surface LockedRowsConfirmDialog if any
+                # item being removed is locked.
+                all_paths, locked_paths = self._collect_locked_paths_for_removal(
+                    highlighted_items
+                )
+                if locked_paths:
+                    from app.views.dialogs.locked_rows_confirm_dialog import (
+                        LockedRowsConfirmDialog,
+                    )
+                    verdict = LockedRowsConfirmDialog.ask(
+                        self.parent,
+                        action_label=_decision_display_label(REMOVE_FROM_LIST_DECISION),
+                        affected_count=len(all_paths),
+                        locked_paths=locked_paths,
+                    )
+                    if verdict == LockedRowsConfirmDialog.CANCEL:
+                        return
+                    if verdict == LockedRowsConfirmDialog.APPLY_UNLOCKED_ONLY:
+                        locked_set = set(locked_paths)
+                        unlocked = [p for p in all_paths if p not in locked_set]
+                        if unlocked:
+                            self.vm.remove_from_list(unlocked)
+                            self._sync_removed_to_db(unlocked)
+                            self._mark_dirty()
+                            self.ui_updater.refresh_tree(self.vm.groups)
+                            report_count(
+                                self.status_reporter,
+                                t("status.verb_removed"),
+                                len(unlocked),
+                                t("status.noun_item_from_list_singular"),
+                                plural=t("status.noun_item_from_list_plural"),
+                            )
+                        return
+                    # APPLY_ALL_UNLOCKED: unlock the locked subset in memory
+                    # and in SQLite, then fall through to remove everything.
+                    manifest_path = getattr(self, "_manifest_path", None)
+                    locked_set = set(locked_paths)
+                    for group in self.vm.groups:
+                        for rec in group.items:
+                            if rec.file_path in locked_set:
+                                rec.is_locked = False
+                    if manifest_path:
+                        from infrastructure.manifest_repository import ManifestRepository
+                        ManifestRepository().batch_update_lock_state(
+                            manifest_path, {p: False for p in locked_paths}
+                        )
+
                 file_items = [item for item in highlighted_items if item.get("type") == "file"]
                 group_items = [item for item in highlighted_items if item.get("type") == "group"]
 
@@ -397,6 +445,51 @@ class FileOperationsHandler:
     def remove_items_from_list(self, items: list[dict]) -> None:
         """Remove multiple items (files and/or groups) from the list."""
         try:
+            # Lock guard (#208): surface LockedRowsConfirmDialog if any
+            # item being removed is locked.
+            all_paths, locked_paths = self._collect_locked_paths_for_removal(items)
+            if locked_paths:
+                from app.views.dialogs.locked_rows_confirm_dialog import (
+                    LockedRowsConfirmDialog,
+                )
+                verdict = LockedRowsConfirmDialog.ask(
+                    self.parent,
+                    action_label=_decision_display_label(REMOVE_FROM_LIST_DECISION),
+                    affected_count=len(all_paths),
+                    locked_paths=locked_paths,
+                )
+                if verdict == LockedRowsConfirmDialog.CANCEL:
+                    return
+                if verdict == LockedRowsConfirmDialog.APPLY_UNLOCKED_ONLY:
+                    locked_set = set(locked_paths)
+                    unlocked = [p for p in all_paths if p not in locked_set]
+                    if unlocked:
+                        self.vm.remove_from_list(unlocked)
+                        self._sync_removed_to_db(unlocked)
+                        self._mark_dirty()
+                        self.ui_updater.refresh_tree(self.vm.groups)
+                        report_count(
+                            self.status_reporter,
+                            t("status.verb_removed"),
+                            len(unlocked),
+                            t("status.noun_item_from_list_singular"),
+                            plural=t("status.noun_item_from_list_plural"),
+                        )
+                    return
+                # APPLY_ALL_UNLOCKED: unlock the locked subset in memory
+                # and in SQLite, then fall through to remove everything.
+                manifest_path = getattr(self, "_manifest_path", None)
+                locked_set = set(locked_paths)
+                for group in self.vm.groups:
+                    for rec in group.items:
+                        if rec.file_path in locked_set:
+                            rec.is_locked = False
+                if manifest_path:
+                    from infrastructure.manifest_repository import ManifestRepository
+                    ManifestRepository().batch_update_lock_state(
+                        manifest_path, {p: False for p in locked_paths}
+                    )
+
             file_paths: list[str] = []
             group_numbers: list[int] = []
 
@@ -643,6 +736,34 @@ class FileOperationsHandler:
             )
             return
         self.set_decision_with_lock_check(file_items, new_decision)
+
+    def _collect_locked_paths_for_removal(
+        self, items: list[dict]
+    ) -> tuple[list[str], list[str]]:
+        """Expand items (files + groups) to file paths and return (all, locked).
+
+        Used by the remove-from-list lock guard to find locked paths across
+        both individual file items and group items (which expand to all their
+        constituent files).
+        """
+        all_paths: list[str] = []
+        for item in items:
+            if item.get("type") == "file":
+                all_paths.append(item["path"])
+            elif item.get("type") == "group":
+                gn = item.get("group_number")
+                for g in self.vm.groups:
+                    if g.group_number == gn:
+                        all_paths.extend(r.file_path for r in g.items)
+                        break
+        locked_set: set[str] = {
+            rec.file_path
+            for group in self.vm.groups
+            for rec in group.items
+            if rec.is_locked
+        }
+        locked = [p for p in all_paths if p in locked_set]
+        return all_paths, locked
 
     def _locked_paths_in(self, file_items: list[dict]) -> list[str]:
         """Return the paths in ``file_items`` whose record is locked.

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -285,6 +285,135 @@ class TestRemoveFromList:
         assert recs[0].user_decision == ""
 
 
+# ── remove-from-list lock guard (#208) ───────────────────────────────────────
+
+
+class TestRemoveFromListLockGuard:
+    """Lock guard on remove_items_from_list and remove_from_list_toolbar (#208).
+
+    Locked files must surface LockedRowsConfirmDialog before removal,
+    mirroring the guard already present in the execute-dialog remove path.
+    """
+
+    def _setup(self, tmp_path):
+        from app.viewmodels.main_vm import MainVM
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}, {"source_path": "/b.jpg"}])
+        rec_a = _rec("/a.jpg", locked=False)
+        rec_b = _rec("/b.jpg", locked=True)
+        vm = MainVM(MagicMock())
+        vm.groups = [PhotoGroup(group_number=1, items=[rec_a, rec_b])]
+        handler, _, _ = _make_handler(vm, str(db))
+        return handler, rec_a, rec_b, db
+
+    # -- remove_items_from_list -----------------------------------------------
+
+    def test_cancel_does_not_remove_locked_file(self, tmp_path):
+        from app.views.dialogs.locked_rows_confirm_dialog import LockedRowsConfirmDialog
+        handler, rec_a, rec_b, db = self._setup(tmp_path)
+        with patch.object(LockedRowsConfirmDialog, "ask", return_value=LockedRowsConfirmDialog.CANCEL):
+            handler.remove_items_from_list([{"type": "file", "path": "/b.jpg"}])
+        assert rec_b in handler.vm.groups[0].items
+        assert _read_decision(db, "/b.jpg") == ""
+
+    def test_apply_unlocked_only_skips_locked_file(self, tmp_path):
+        from app.views.dialogs.locked_rows_confirm_dialog import LockedRowsConfirmDialog
+        handler, rec_a, rec_b, db = self._setup(tmp_path)
+        items = [
+            {"type": "file", "path": "/a.jpg"},
+            {"type": "file", "path": "/b.jpg"},
+        ]
+        with patch.object(
+            LockedRowsConfirmDialog, "ask",
+            return_value=LockedRowsConfirmDialog.APPLY_UNLOCKED_ONLY,
+        ):
+            handler.remove_items_from_list(items)
+        remaining = [r.file_path for r in handler.vm.groups[0].items]
+        assert "/a.jpg" not in remaining
+        assert "/b.jpg" in remaining
+        assert _read_decision(db, "/a.jpg") == "removed"
+        assert _read_decision(db, "/b.jpg") == ""
+
+    def test_apply_all_unlocked_unlocks_then_removes_all(self, tmp_path):
+        from app.views.dialogs.locked_rows_confirm_dialog import LockedRowsConfirmDialog
+        handler, rec_a, rec_b, db = self._setup(tmp_path)
+        items = [
+            {"type": "file", "path": "/a.jpg"},
+            {"type": "file", "path": "/b.jpg"},
+        ]
+        with patch.object(
+            LockedRowsConfirmDialog, "ask",
+            return_value=LockedRowsConfirmDialog.APPLY_ALL_UNLOCKED,
+        ):
+            handler.remove_items_from_list(items)
+        assert handler.vm.groups == []
+        assert rec_b.is_locked is False
+        assert _read_decision(db, "/a.jpg") == "removed"
+        assert _read_decision(db, "/b.jpg") == "removed"
+
+    def test_no_locked_items_skips_dialog(self, tmp_path):
+        from app.views.dialogs.locked_rows_confirm_dialog import LockedRowsConfirmDialog
+        handler, rec_a, rec_b, _ = self._setup(tmp_path)
+        rec_b.is_locked = False  # no locked items
+        with patch.object(LockedRowsConfirmDialog, "ask") as ask:
+            handler.remove_items_from_list([{"type": "file", "path": "/a.jpg"}])
+        ask.assert_not_called()
+
+    # -- remove_from_list_toolbar ---------------------------------------------
+
+    def test_toolbar_cancel_does_not_remove_locked_file(self, tmp_path):
+        from app.views.dialogs.locked_rows_confirm_dialog import LockedRowsConfirmDialog
+        handler, rec_a, rec_b, db = self._setup(tmp_path)
+        with patch.object(LockedRowsConfirmDialog, "ask", return_value=LockedRowsConfirmDialog.CANCEL):
+            handler.remove_from_list_toolbar([{"type": "file", "path": "/b.jpg"}])
+        assert rec_b in handler.vm.groups[0].items
+
+    def test_toolbar_apply_unlocked_only_skips_locked(self, tmp_path):
+        from app.views.dialogs.locked_rows_confirm_dialog import LockedRowsConfirmDialog
+        handler, rec_a, rec_b, db = self._setup(tmp_path)
+        items = [
+            {"type": "file", "path": "/a.jpg"},
+            {"type": "file", "path": "/b.jpg"},
+        ]
+        with patch.object(
+            LockedRowsConfirmDialog, "ask",
+            return_value=LockedRowsConfirmDialog.APPLY_UNLOCKED_ONLY,
+        ):
+            handler.remove_from_list_toolbar(items)
+        remaining = [r.file_path for r in handler.vm.groups[0].items]
+        assert "/a.jpg" not in remaining
+        assert "/b.jpg" in remaining
+
+    def test_toolbar_apply_all_unlocked_removes_all(self, tmp_path):
+        from app.views.dialogs.locked_rows_confirm_dialog import LockedRowsConfirmDialog
+        handler, rec_a, rec_b, db = self._setup(tmp_path)
+        items = [
+            {"type": "file", "path": "/a.jpg"},
+            {"type": "file", "path": "/b.jpg"},
+        ]
+        with patch.object(
+            LockedRowsConfirmDialog, "ask",
+            return_value=LockedRowsConfirmDialog.APPLY_ALL_UNLOCKED,
+        ):
+            handler.remove_from_list_toolbar(items)
+        assert handler.vm.groups == []
+        assert rec_b.is_locked is False
+
+    def test_group_with_locked_item_expands_correctly(self, tmp_path):
+        """Removing a group that contains a locked file surfaces the dialog
+        with the group's file paths (not just the group item itself)."""
+        from app.views.dialogs.locked_rows_confirm_dialog import LockedRowsConfirmDialog
+        handler, rec_a, rec_b, db = self._setup(tmp_path)
+        with patch.object(
+            LockedRowsConfirmDialog, "ask",
+            return_value=LockedRowsConfirmDialog.CANCEL,
+        ) as ask:
+            handler.remove_items_from_list([{"type": "group", "group_number": 1}])
+        ask.assert_called_once()
+        _, kwargs = ask.call_args
+        assert kwargs["affected_count"] == 2
+        assert "/b.jpg" in kwargs["locked_paths"]
+
+
 # ── set_decision_to_highlighted ───────────────────────────────────────────────
 
 class TestSetDecisionToHighlighted:


### PR DESCRIPTION
## Summary

- `remove_items_from_list` (context menu) and `remove_from_list_toolbar` (toolbar button) bypassed the lock check entirely — locked files could be silently removed from the review list.
- Added `_collect_locked_paths_for_removal` helper that expands group items to constituent file paths, then added an identical lock guard at the start of both methods.
- All three verdicts handled: **Cancel** (abort), **Apply to Unlocked Only** (skip locked, remove the rest), **Unlock & Apply All** (unlock in memory + SQLite, then remove everything).
- Mirrors the guard already present in `ExecuteActionDialog._set_decision` for the single-row right-click remove path.

[qa-not-needed: same rationale as #207 — pure guard insertion on an existing operation; the dialog behaviour given the correct inputs is fully covered at layer 1 by TestRemoveFromListLockGuard (8 tests). The execute-dialog remove path (already guarded) is the layer-3 analogue and exercises the same dialog flow end-to-end.]

## Test plan

- [ ] `pytest tests/test_file_operations.py` — 94 tests pass (8 new in `TestRemoveFromListLockGuard`)
- [ ] Manual: lock a file, right-click → Remove from List → LockedRowsConfirmDialog should appear

Closes #208

🤖 Generated with [Claude Code](https://claude.com/claude-code)