### PR TITLE
fix: save manifest dialog opens with folder picker visible (#230)

### DIFF
--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -16,6 +16,11 @@ from app.views.constants import (
     REMOVE_FROM_LIST_SENTINEL,
     UNLOCK_SENTINEL,
 )
+from app.views.window_state import (
+    QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM,
+    restore_widget_geometry,
+    save_widget_geometry,
+)
 from infrastructure.i18n import t
 
 # Single source of truth for the QFileDialog filter string used wherever
@@ -300,14 +305,29 @@ class FileOperationsHandler:
             )
             return
 
-        save_path, _ = QFileDialog.getSaveFileName(
-            self.parent,
-            t("file_op.save_dialog_title"),
-            manifest_path,
-            MANIFEST_FILE_FILTER,
-        )
-        if not save_path:
+        # #230 — Use a non-native QFileDialog instance with an explicit
+        # minimum size. The native Windows IFileSaveDialog opened with
+        # the folder picker / breadcrumb clipped above the screen top,
+        # and native dialogs ignore Qt-side setMinimumSize. Process-wide
+        # opt-out lives at main.py:99 for CI; this is the production fix.
+        dlg = QFileDialog(self.parent, t("file_op.save_dialog_title"))
+        dlg.setAcceptMode(QFileDialog.AcceptSave)
+        dlg.setFileMode(QFileDialog.AnyFile)
+        dlg.setNameFilter(MANIFEST_FILE_FILTER)
+        dlg.setOption(QFileDialog.DontUseNativeDialog, True)
+        dlg.setMinimumSize(800, 500)
+        dlg.setDirectory(os.path.dirname(manifest_path))
+        dlg.selectFile(os.path.basename(manifest_path))
+
+        restore_widget_geometry(dlg, QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM)
+        try:
+            accepted = dlg.exec() == QFileDialog.Accepted
+        finally:
+            save_widget_geometry(dlg, QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM)
+
+        if not accepted:
             return
+        save_path = dlg.selectedFiles()[0]
 
         try:
             if os.path.normcase(os.path.normpath(save_path)) != os.path.normcase(

--- a/app/views/window_state.py
+++ b/app/views/window_state.py
@@ -34,6 +34,7 @@ QSETTINGS_KEY_COLUMN_HEADER_STATE = "geometry/column_header"
 QSETTINGS_KEY_SCAN_DIALOG_GEOM = "geometry/scan_dialog"
 QSETTINGS_KEY_EXECUTE_ACTION_DIALOG_GEOM = "geometry/execute_action_dialog"
 QSETTINGS_KEY_ACTION_DIALOG_GEOM = "geometry/action_dialog"
+QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM = "geometry/save_manifest_dialog"
 
 
 def qsettings_path() -> Path:

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -554,6 +554,52 @@ class TestGetRecordFieldActionMapping:
 
 # ── save_manifest_decisions ───────────────────────────────────────────────────
 
+class _MockSaveDialog:
+    """Context manager that patches ``QFileDialog`` plus the geometry
+    helpers in the handler module.
+
+    The geometry helpers are stubbed because they otherwise read and
+    write the real ``window_state.ini`` under the repo root — a
+    stale/corrupt blob from a prior session would crash the test, and
+    we don't want unit tests touching shared user state. The handler
+    flow's correctness w.r.t. those calls is covered by the dedicated
+    round-trip test in ``tests/test_window_state.py``.
+
+    ``accept_path=None`` simulates Cancel (Rejected); a string path
+    simulates the user accepting that path.
+    """
+
+    def __init__(self, accept_path):
+        self._accept_path = accept_path
+        self._patches = [
+            patch("app.views.handlers.file_operations.QFileDialog"),
+            patch("app.views.handlers.file_operations.restore_widget_geometry"),
+            patch("app.views.handlers.file_operations.save_widget_geometry"),
+        ]
+
+    def __enter__(self):
+        MockDialog = self._patches[0].__enter__()
+        self._patches[1].__enter__()
+        self._patches[2].__enter__()
+        instance = MockDialog.return_value
+        if self._accept_path is None:
+            instance.exec.return_value = MockDialog.Rejected
+            instance.selectedFiles.return_value = []
+        else:
+            instance.exec.return_value = MockDialog.Accepted
+            instance.selectedFiles.return_value = [self._accept_path]
+        return MockDialog
+
+    def __exit__(self, *exc):
+        for p in reversed(self._patches):
+            p.__exit__(*exc)
+        return False
+
+
+def _mock_save_dialog(accept_path):
+    return _MockSaveDialog(accept_path)
+
+
 class TestSaveManifestDecisions:
     @patch("PySide6.QtWidgets.QMessageBox.information")
     def test_saves_to_same_path_in_place(self, _mock, tmp_path):
@@ -563,7 +609,7 @@ class TestSaveManifestDecisions:
         db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
         handler, _, _ = _make_handler(vm, str(db))
 
-        with patch("PySide6.QtWidgets.QFileDialog.getSaveFileName", return_value=(str(db), "")):
+        with _mock_save_dialog(accept_path=str(db)):
             handler.save_manifest_decisions()
 
         assert _read_decision(db, "/a.jpg") == "keep"
@@ -578,7 +624,7 @@ class TestSaveManifestDecisions:
         new_path = str(tmp_path / "exported.sqlite")
         handler, _, _ = _make_handler(vm, str(db))
 
-        with patch("PySide6.QtWidgets.QFileDialog.getSaveFileName", return_value=(new_path, "")):
+        with _mock_save_dialog(accept_path=new_path):
             handler.save_manifest_decisions()
 
         assert _read_decision(Path(new_path), "/a.jpg") == "delete"
@@ -613,10 +659,7 @@ class TestSaveManifestDecisions:
             new_path = str(tmp_path / "exported.sqlite")
             handler, _, _ = _make_handler(vm, str(db))
 
-            with patch(
-                "PySide6.QtWidgets.QFileDialog.getSaveFileName",
-                return_value=(new_path, ""),
-            ):
+            with _mock_save_dialog(accept_path=new_path):
                 handler.save_manifest_decisions()
 
             assert _read_decision(Path(new_path), "/a.jpg") == "delete"
@@ -631,7 +674,7 @@ class TestSaveManifestDecisions:
         db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
         handler, _, _ = _make_handler(vm, str(db))
 
-        with patch("PySide6.QtWidgets.QFileDialog.getSaveFileName", return_value=("", "")):
+        with _mock_save_dialog(accept_path=None):
             handler.save_manifest_decisions()
 
         assert _read_decision(db, "/a.jpg") == ""
@@ -652,7 +695,7 @@ class TestSaveManifestDecisions:
 
         Drift in this literal at file_operations.py would silently break QA
         scenario s12 (which finds the dialog by exact title) and confuse users
-        who see a renamed title. Asserts the call args of getSaveFileName so
+        who see a renamed title. Asserts the QFileDialog constructor args so
         the title literal can't drift unnoticed (#129 — replacement coverage
         for s12 which cannot run on hosted Windows runners).
         """
@@ -661,17 +704,35 @@ class TestSaveManifestDecisions:
         db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
         handler, _, _ = _make_handler(vm, str(db))
 
-        with patch(
-            "PySide6.QtWidgets.QFileDialog.getSaveFileName",
-            return_value=("", ""),  # cancel; we only care about call args
-        ) as mock_dlg:
+        with _mock_save_dialog(accept_path=None) as MockDialog:
             handler.save_manifest_decisions()
 
-        mock_dlg.assert_called_once()
-        title = mock_dlg.call_args.args[1]
+        MockDialog.assert_called_once()
+        title = MockDialog.call_args.args[1]
         assert title == "Save Manifest Decisions", (
             f"dialog title drift: expected 'Save Manifest Decisions', got {title!r}"
         )
+
+    @patch("PySide6.QtWidgets.QMessageBox.information")
+    def test_dialog_uses_non_native_with_min_size(self, _mock, tmp_path):
+        """#230 regression guard: the save dialog must opt out of the
+        native Windows IFileSaveDialog and apply a minimum size large
+        enough that the folder picker / breadcrumb is visible on first
+        open. Native dialogs ignore setMinimumSize, so dropping either
+        call reproduces the user-visible bug (picker clipped above the
+        screen top).
+        """
+        recs = [_rec("/a.jpg")]
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=recs)])
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
+        handler, _, _ = _make_handler(vm, str(db))
+
+        with _mock_save_dialog(accept_path=None) as MockDialog:
+            handler.save_manifest_decisions()
+
+        instance = MockDialog.return_value
+        instance.setOption.assert_any_call(MockDialog.DontUseNativeDialog, True)
+        instance.setMinimumSize.assert_any_call(800, 500)
 
 
 # ── load → decide → save round-trip ────────────────────────────────────────
@@ -750,10 +811,7 @@ class TestSaveManifestLoadRoundTrip:
         new_path = str(tmp_path / "exported.sqlite")
         vm = SimpleNamespace(groups=groups)
         handler, _, _ = _make_handler(vm, str(src_db))
-        with patch(
-            "PySide6.QtWidgets.QFileDialog.getSaveFileName",
-            return_value=(new_path, ""),
-        ):
+        with _mock_save_dialog(accept_path=new_path):
             handler.save_manifest_decisions()
 
         # Verify the loaded -> decided -> saved chain preserved decisions.
@@ -1323,10 +1381,7 @@ class TestDirtyTracking:
         handler._mark_dirty()
 
         save_path = str(tmp_path / "saved.sqlite")
-        with patch(
-            "PySide6.QtWidgets.QFileDialog.getSaveFileName",
-            return_value=(save_path, ""),
-        ):
+        with _mock_save_dialog(accept_path=save_path):
             handler.save_manifest_decisions()
         assert handler.is_dirty() is False
 

--- a/tests/test_window_state.py
+++ b/tests/test_window_state.py
@@ -333,6 +333,42 @@ class TestExecuteActionDialogDoneSavesGeometry:
         assert blob is not None and len(blob) > 0
 
 
+class TestSaveManifestDialogGeomKey:
+    """#230 — the new ``QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM`` is the
+    wiring between the FileOperationsHandler save flow and the existing
+    save/restore helpers. The handler-level tests verify the call sites,
+    but a misspelled or duplicated key here would silently lose geometry
+    or collide with another dialog's blob. This round-trip pins the key
+    string against accidental drift and confirms the helpers accept it.
+    """
+
+    def test_round_trip_with_save_manifest_key(
+        self, qapp, isolated_qsettings
+    ):
+        from PySide6.QtWidgets import QFileDialog
+        from app.views.window_state import (
+            QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM,
+        )
+
+        dlg_a = QFileDialog()
+        dlg_a.resize(900, 600)
+        dlg_a.move(120, 80)
+        save_widget_geometry(dlg_a, QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM)
+
+        store = window_state_qsettings()
+        blob = store.value(QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM)
+        assert blob is not None and len(blob) > 0
+
+        dlg_b = QFileDialog()
+        dlg_b.resize(400, 300)
+        applied = restore_widget_geometry(
+            dlg_b, QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM
+        )
+        assert applied is True
+        assert dlg_b.size().width() == 900
+        assert dlg_b.size().height() == 600
+
+
 class TestScanDialogDoneSavesGeometry:
     def test_done_saves(self, qapp, isolated_qsettings, tmp_path):
         """ScanDialog needs a JsonSettings instance; tmp_path keeps it

--- a/tests/test_window_state.py
+++ b/tests/test_window_state.py
@@ -350,9 +350,13 @@ class TestSaveManifestDialogGeomKey:
             QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM,
         )
 
+        # Dimensions match the precedent in ``test_round_trip_restores_size``
+        # — small enough to fit on the hosted-CI Windows runners (some
+        # have an 800px-wide virtual screen, so anything >= 900 gets
+        # clamped on restore and the round-trip looks "off by 100px").
         dlg_a = QFileDialog()
-        dlg_a.resize(900, 600)
-        dlg_a.move(120, 80)
+        dlg_a.resize(500, 350)
+        dlg_a.move(100, 100)
         save_widget_geometry(dlg_a, QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM)
 
         store = window_state_qsettings()
@@ -360,13 +364,13 @@ class TestSaveManifestDialogGeomKey:
         assert blob is not None and len(blob) > 0
 
         dlg_b = QFileDialog()
-        dlg_b.resize(400, 300)
+        dlg_b.resize(200, 200)
         applied = restore_widget_geometry(
             dlg_b, QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM
         )
         assert applied is True
-        assert dlg_b.size().width() == 900
-        assert dlg_b.size().height() == 600
+        assert dlg_b.size().width() == 500
+        assert dlg_b.size().height() == 350
 
 
 class TestScanDialogDoneSavesGeometry:


### PR DESCRIPTION
## Summary
- The native Windows `IFileSaveDialog` opened with the folder picker / breadcrumb clipped above the screen top because native dialogs ignore Qt-side `setMinimumSize`. Switched the one Save Manifest Decisions call site to a Qt non-native `QFileDialog` instance with `setMinimumSize(800, 500)`.
- Bundled PR #228's geometry-persistence pattern: new `QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM` key, restore-before / save-after-`exec()`, reusing the existing helpers in `window_state.py`.
- Process-wide opt-out at `main.py:99` (`PHOTO_MANAGER_QT_FILE_DIALOG=1`) is unchanged; this is the local production fix.

## Test plan
- [x] Full suite: `pytest` → 1186 passed, 2 skipped
- [x] Per-file coverage floor: `scripts/check_coverage_per_file.py` → all 48 files ≥ 70%; total 88.37%
- [x] s12 qa scenario: `python -m qa.scenarios._batch s12_save_manifest` → passes (the existing UIA driver auto-detects the Qt `QDialogButtonBox` shape, no scenario change needed)
- [x] New regression guard test: `test_dialog_uses_non_native_with_min_size` pins `DontUseNativeDialog=True` and `setMinimumSize(800, 500)` — dropping either reproduces the bug
- [ ] Manual smoke: launch app, load any manifest, `File → Save Manifest Decisions` → folder picker visible without resizing on first open; geometry persists across sessions

Closes #230

Generated with [Claude Code](https://claude.com/claude-code)