### PR TITLE
fix(qa/s44): read file-row coords from UIA, not 1x-DPI offsets (#229)

### DIFF
--- a/qa/scenarios/s44_execute_highlighted_rows.py
+++ b/qa/scenarios/s44_execute_highlighted_rows.py
@@ -30,6 +30,11 @@ Catches drift in:
   - The complete-group confirm NOT firing when scope is partial (the
     confirm copy claims "EVERY file deleted" which is false when only
     part of the group is in scope).
+
+Click coordinates are read live from UIA ``TreeItem.rectangle()`` rather
+than hard-coded pixel offsets (#229). The previous ``top+83 / top+105``
+anchors were tuned at 1x DPI; at 2x DPI the first click landed on the
+group header and only one file made it into the execute scope.
 """
 from __future__ import annotations
 
@@ -127,18 +132,47 @@ def _regen_fixture() -> list[Path]:
     return paths
 
 
-def _file_row_y(tree_rect, row_index: int) -> int:
-    """Return screen Y for the middle of the Nth (0-based) file row
-    inside the Execute Action dialog's tree.
+def _file_row_centers(tree) -> list[tuple[int, int]]:
+    """Return ``(cx, cy)`` screen-pixel centers of each file row in the
+    dialog tree, in visual order.
 
-    Anchored to s30's empirically-tuned value of ``top + 105`` for the
-    second file row (the 30/25/22-px layout sketch in s30's comment
-    underestimates the real header + group-row height on real DPI).
-    Working back: second file row ≈ top + 105, first file row ≈ 83,
-    Nth file row ≈ 83 + 22*N. The 22 px row pitch is robust across
-    DPI scaling within this DPI range.
+    Reads UIA TreeItem rectangles straight from accessibility, so coords
+    are correct at any DPI (#229: the previous hard-coded ``top+83/+105``
+    anchors were tuned at 1x DPI and missed the file rows at 2x — the
+    first click landed on the group header, so only one file made it
+    into the execute scope).
+
+    The dialog's QTreeView exposes one TreeItem per CELL (column), so
+    each visual row appears as ~``NUM_COLUMNS`` siblings sharing one Y
+    band. We cluster by ``rect.top``, skip the cluster whose leftmost
+    cell carries a "Group N" label (the group header is not a file row),
+    and return the remaining bands' centers.
     """
-    return tree_rect.top + 83 + 22 * row_index
+    by_y: dict[int, list] = {}
+    for it in tree.descendants(control_type="TreeItem"):
+        try:
+            r = it.rectangle()
+        except Exception:
+            continue
+        by_y.setdefault(r.top, []).append(it)
+    rows: list[tuple[int, int]] = []
+    for y_top in sorted(by_y):
+        cells = by_y[y_top]
+        if not cells:
+            continue
+        leftmost = min(cells, key=lambda c: c.rectangle().left)
+        rightmost = max(cells, key=lambda c: c.rectangle().right)
+        leftmost_text = (leftmost.window_text() or "").strip()
+        # Group header row carries "Group N" in its first cell; file rows
+        # carry similarity ("Ref" or "94%") or are blank.
+        if leftmost_text.lower().startswith("group "):
+            continue
+        lr = leftmost.rectangle()
+        rr = rightmost.rectangle()
+        cx = (lr.left + rr.right) // 2
+        cy = (lr.top + lr.bottom) // 2
+        rows.append((cx, cy))
+    return rows
 
 
 def _read_manifest_rows() -> list[tuple[str, str, int]]:
@@ -191,19 +225,25 @@ def main() -> int:
     print("step: locate_dialog_tree")
     tree = exec_dlg.descendants(control_type="Tree")[0]
     tree_rect = tree.rectangle()
-    cx = tree_rect.left + (tree_rect.right - tree_rect.left) // 2
-    row0_y = _file_row_y(tree_rect, 0)
-    row1_y = _file_row_y(tree_rect, 1)
+    file_rows = _file_row_centers(tree)
     print(f"  tree_rect={tree_rect}")
-    print(f"  click_coords_row0=({cx},{row0_y}) row1=({cx},{row1_y})")
+    print(f"  file_row_count_in_tree={len(file_rows)}")
+    if len(file_rows) < 2:
+        print(
+            f"FAIL: dialog tree exposed {len(file_rows)} file row(s) via UIA; "
+            f"need ≥2 to highlight two rows"
+        )
+        return 1
+    (row0_cx, row0_y), (row1_cx, row1_y) = file_rows[0], file_rows[1]
+    print(f"  click_coords_row0=({row0_cx},{row0_y}) row1=({row1_cx},{row1_y})")
 
     print("step: highlight_two_file_rows")
     _uia._focus(exec_dlg)
-    pywinauto.mouse.click(button="left", coords=(cx, row0_y))
+    pywinauto.mouse.click(button="left", coords=(row0_cx, row0_y))
     time.sleep(0.2)
     _uia._key_down(_uia._VK_CONTROL)
     try:
-        pywinauto.mouse.click(button="left", coords=(cx, row1_y))
+        pywinauto.mouse.click(button="left", coords=(row1_cx, row1_y))
     finally:
         _uia._key_up(_uia._VK_CONTROL)
     time.sleep(0.3)

--- a/tests/test_execute_action_dialog.py
+++ b/tests/test_execute_action_dialog.py
@@ -1307,6 +1307,24 @@ class TestExecuteHighlightedRows:
             assert idx.isValid(), f"file row for {p!r} not in tree"
             sel.select(idx, QItemSelectionModel.Select | QItemSelectionModel.Rows)
 
+    @staticmethod
+    def _select_cells_like_real_clicks(dlg, paths: list[str]) -> None:
+        """Mimic the per-cell selection state produced by real mouse
+        clicks under ``ExtendedSelection`` (one cell selected per click,
+        not a whole row). The first click left-selects the COL_NAME cell
+        of the first path; each subsequent path is ctrl-added. This is
+        the scenario that broke #229 — ``_selected_file_paths`` walks
+        ``selectedIndexes()`` and must extract a path from each row even
+        when only one cell of the row is in the selection model.
+        """
+        from PySide6.QtCore import QItemSelectionModel
+        sel = dlg._tree.selectionModel()
+        sel.clear()
+        for p in paths:
+            idx = TestExecuteHighlightedRows._find_file_index(dlg, p)
+            assert idx.isValid(), f"file row for {p!r} not in tree"
+            sel.select(idx, QItemSelectionModel.Select)
+
     # — button label —
 
     def test_button_label_default_when_no_selection(self, qapp):
@@ -1379,6 +1397,61 @@ class TestExecuteHighlightedRows:
         assert deleted == ["/del.jpg"]
         assert "/keep.jpg" not in dlg.executed_paths
         assert "/other_del.jpg" not in deleted
+
+    def test_two_highlighted_paths_in_same_group_both_execute(self, qapp):
+        """#229 regression: ctrl-clicking 2 rows in the same group must
+        result in BOTH files being passed to ``_delete_file``. Uses the
+        single-cell selection state that real mouse clicks produce under
+        ``ExtendedSelection``, which is what surfaces the bug — selecting
+        whole rows via ``Select | Rows`` masks it.
+        """
+        from app.views.dialogs.execute_action_dialog import ExecuteActionDialog
+        groups = [_group(
+            _rec("/del1.jpg", "delete"),
+            _rec("/keep.jpg", "keep"),
+            _rec("/del2.jpg", "delete"),
+        )]
+        dlg = ExecuteActionDialog(groups, manifest_path=None)
+        self._select_cells_like_real_clicks(dlg, ["/del1.jpg", "/del2.jpg"])
+
+        deleted: list[str] = []
+        with patch.object(dlg, "_delete_file", side_effect=deleted.append):
+            dlg._on_execute_requested()
+
+        assert set(deleted) == {"/del1.jpg", "/del2.jpg"}
+        assert "/keep.jpg" not in dlg.executed_paths
+
+    def test_two_highlighted_paths_across_groups_both_execute(self, qapp):
+        """#229 regression: ctrl-clicking one row from each of two groups
+        must delete BOTH. Mirrors the same single-cell selection state as
+        the same-group case but exercises the cross-group path through
+        the execute loop.
+        """
+        from app.views.dialogs.execute_action_dialog import ExecuteActionDialog
+        groups = [
+            _group(
+                _rec("/g1_del.jpg", "delete"),
+                _rec("/g1_keep.jpg", "keep"),
+                number=1,
+            ),
+            _group(
+                _rec("/g2_del.jpg", "delete"),
+                _rec("/g2_keep.jpg", "keep"),
+                number=2,
+            ),
+        ]
+        dlg = ExecuteActionDialog(groups, manifest_path=None)
+        self._select_cells_like_real_clicks(dlg, ["/g1_del.jpg", "/g2_del.jpg"])
+
+        deleted: list[str] = []
+        with patch.object(dlg, "_delete_file", side_effect=deleted.append):
+            dlg._on_execute_requested()
+
+        assert set(deleted) == {"/g1_del.jpg", "/g2_del.jpg"}
+        # The non-highlighted keep rows are out of scope and should not
+        # land in executed_paths either.
+        assert "/g1_keep.jpg" not in dlg.executed_paths
+        assert "/g2_keep.jpg" not in dlg.executed_paths
 
     def test_no_selection_executes_all_decided_rows(self, qapp):
         from PySide6.QtWidgets import QMessageBox as _QMB


### PR DESCRIPTION
## Summary

- Replaces hard-coded ``top+83 / top+105 / +22*N`` Y offsets in
  `qa/scenarios/s44_execute_highlighted_rows.py` with a `_file_row_centers`
  helper that reads dialog-tree TreeItem rectangles via UIA — coords are
  correct at any DPI without manual DPR math.
- Adds two regression tests in `tests/test_execute_action_dialog.py`
  covering the contract that two highlighted file rows route both paths
  through `_on_execute` (same-group and cross-group cases).
- The dialog code (`_selected_file_paths`, the execute loop) is unchanged
  — reproduction with debug prints showed it is correct.

## Root cause

`_selected_file_paths` works as designed. The s44 driver's hard-coded
offsets were tuned at 1x DPI; on a 2x display ``tree.top+83`` lands on
the group header. The dialog correctly filters group-header cells out of
scope, leaving only one file path. The Execute-button label still flipped
to "(highlighted)" because one file row IS in selection, so the failure
masqueraded as a dialog bug. Debug-print trace (now removed):

```
[DEBUG-229] _selected_file_paths: total_idx=22 group_hdr=11 file_cells=11 unique_paths=1
```

11 group-header cells + 11 file-row cells; only 1 unique path → exactly
1 file deleted by ``_on_execute``.

## Test plan

- [x] `python -m qa.scenarios._batch s44_execute_highlighted_rows` — passes (`removed_count=2`).
- [x] `python -m pytest tests/test_execute_action_dialog.py` — 86 passed.
- [x] `python -m pytest` — 1186 passed, 2 skipped, 88% global coverage.
- [x] `python scripts/check_coverage_per_file.py` — all 48 files clear the 70% floor.

Closes #229

🤖 Generated with [Claude Code](https://claude.com/claude-code)