### PR TITLE
Add UI invariants probe layer (#243)

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,7 @@ Read that before adding tests for a new feature. Short version:
 | 1 — Unit + mocks (CI) | Refactoring bugs, parser logic | Real third-party behavior |
 | 2 — Integration (local, on-demand) | Spot-tests for specific boundary bugs already hit (exiftool / send2trash / rawpy edge cases) | GUI behavior; anything you haven't written a spot-test for |
 | 3 — `/qa-explore` (local) | Label drift, dialog regressions, state-transition bugs, boundary happy paths | Anything off the scripted path |
+| Probes — `tests/test_ui_probes.py` + sNN soft-probe blocks (CI) | Cross-cutting invariants: dropdown drift, missing kwargs, label uniqueness, translation passthroughs, menu-gating drift, bridge-pattern holes ([#243](https://github.com/jackal998/photo-manager/issues/243)) | Anything not framed as a structural invariant |
 
 **No test padding.** A test that exists only to clear a coverage gate
 is metric gaming, not engineering — see the testing rules in

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -51,6 +51,28 @@ each with a comment naming the layer that DOES cover them.
   Ref row is at the bottom of its group.
 - *Misses:* Anything not exercised by the scripted scenario path.
 
+**Probes** (`tests/test_ui_probes.py` + sNN soft-probe blocks)
+- Cross-cutting structural invariants that *every* layer above misses
+  by design — added in [#243](https://github.com/jackal998/photo-manager/issues/243).
+- *Catches:* "Did the dialog dropdown drift from the tree columns?",
+  "Did a callsite drop a kwarg that gates a panel?", "Did a translation
+  ship as an English passthrough?", "Are two equivalent menu paths
+  reaching the same destructive surface?", "Is the bridge proxy out
+  of sync with its Protocol?".
+- *Why a separate layer:* scenario drivers replay one canonical path
+  each. Probes inspect a structural relationship — a single probe
+  catches a whole class of drift across many surfaces.
+- *Two flavours:*
+  - Static probes (`tests/test_ui_probes.py`) — AST or YAML
+    inspection, run as pytest in CI. Use `@pytest.mark.xfail(strict=True)`
+    so CI tolerates known-bug probes today and flips red the moment
+    the fix lands without removing the marker.
+  - Live soft-probes (extension blocks in `qa/scenarios/sNN_*.py`) —
+    UIA inspection for runtime state. Use a `print("probe_status: …")`
+    pattern instead of `failures.append` so qa-batch stays green
+    until the bug is fixed; comment block documents the one-line
+    upgrade to a hard failure.
+
 A bug in production likely lives at **a layer not currently asserted**.
 Knowing which layer you're skimping on is more important than the headline
 coverage number.
@@ -327,6 +349,31 @@ Running a shard locally for debugging:
 
 An explicit positional list (`python -m qa.scenarios._batch sNN_xyz …`)
 still works and overrides sharding — handy for targeted iteration.
+
+---
+
+## Probe inventory
+
+`tests/test_ui_probes.py` (static, AST/YAML) + soft probes inside
+scenario drivers. Each row names the invariant, the bug it catches
+today (XFAIL) or its forward-defensive role (PASS), and where the
+soft-probe upgrade path lives if applicable.
+
+| Probe | Invariant | Today | Catches |
+|---|---|---|---|
+| `test_probe_select_dialog_exposes_every_filterable_tree_column` | Every filterable tree column appears in the Select dialog's field dropdown | XFAIL | [#238](https://github.com/jackal998/photo-manager/issues/238) |
+| `test_probe_action_dialog_receives_groups_from_main_window_callsite` | Main-window callsite of `ActionDialog` passes `groups=` so the numeric panel can show | XFAIL | [#237](https://github.com/jackal998/photo-manager/issues/237) |
+| `test_probe_similarity_column_emits_at_most_one_ref_per_group` | At most one row per group renders as "Ref"; siblings fall back to similarity % or sentinel | XFAIL | [#241](https://github.com/jackal998/photo-manager/issues/241) |
+| `test_probe_no_execute_mode_toggle_in_menu` | `menu_controller.py` no longer registers an `execute_mode` action | XFAIL | [#240](https://github.com/jackal998/photo-manager/issues/240) |
+| `test_probe_action_handlers_impl_proxies_every_protocol_method` | Every method on `ActionHandlers` Protocol exists on `ActionHandlersImpl` | PASS | Future #175/#182-class bridge regression |
+| `test_probe_manifest_dependent_menu_actions_are_gated` | Every menu action that requires a loaded manifest is in `MANIFEST_ACTIONS` | XFAIL | [#244](https://github.com/jackal998/photo-manager/issues/244) |
+| `test_probe_zh_tw_translations_are_not_english_passthroughs` | zh_TW values that match en values must contain CJK chars (heuristic; tiny exempt list for product names) | XFAIL | [#245](https://github.com/jackal998/photo-manager/issues/245) |
+| `s49` `step: probe_visual_selection` (soft live) | After scan-complete with auto-select on, the tree's selection model contains the keeper rows | logs `XFAIL_KNOWN_BUG_239` | [#239](https://github.com/jackal998/photo-manager/issues/239) |
+
+When the corresponding bug lands, the static probes flip XFAIL→XPASS-strict
+and the bug-fix PR removes the marker. The soft probe is converted from
+`print(probe_status: …)` to `failures.append(…)` per the comment block in
+the scenario.
 
 ---
 

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -483,6 +483,39 @@ def read_tree_row_order(win: UIAWrapper) -> list[str]:
     return [t for _, t in name_cells]
 
 
+def read_selected_tree_row_basenames(win: UIAWrapper) -> list[str]:
+    """Return basenames of currently-selected file rows in the result tree.
+
+    Counterpart to :func:`read_tree_row_order` for selection state.
+    Walks ``TreeItem`` descendants, filters by basename regex (file rows
+    only — group-header rows aren't selectable file targets), and keeps
+    only those whose UIA SelectionItem pattern reports selected.
+
+    Used by #243-style probes that inspect post-action UI state (e.g.
+    s49 verifying "Auto select after scan" actually highlights the
+    keeper row, not just writes ``action=KEEP`` to the manifest).
+    Returned order matches display order (sorted by row top).
+    """
+    items = win.descendants(control_type="TreeItem")
+    selected: list[tuple[int, str]] = []
+    for it in items:
+        try:
+            txt = (it.window_text() or "").strip()
+            if not txt or not _BASENAME_RE.match(txt):
+                continue
+            if not it.is_selected():
+                continue
+            r = it.rectangle()
+            selected.append((r.top, txt))
+        except Exception:
+            # is_selected() raises on TreeItems without a SelectionItem
+            # pattern (group-header rows on some Qt builds). Skip them
+            # rather than crashing the probe.
+            continue
+    selected.sort(key=lambda pair: pair[0])
+    return [t for _, t in selected]
+
+
 def click_column_header(win: UIAWrapper, header_text: str) -> None:
     """Click the result-tree column header whose label equals ``header_text``.
 

--- a/qa/scenarios/s49_scan_auto_select.py
+++ b/qa/scenarios/s49_scan_auto_select.py
@@ -201,6 +201,38 @@ def main() -> int:
                 f"actions are MOVE / EXACT / REVIEW_DUPLICATE"
             )
 
+    # Probe #239 — auto-select must apply VISUAL selection to the
+    # keeper row, not just write action=KEEP to the manifest. Today
+    # the wiring stops one step short (main_window._load_manifest_from_path
+    # refreshes the tree but never selects KEEP rows). Logged here as
+    # a probe-status line — not a scenario failure — so qa-batch stays
+    # green until #239 lands. When the fix ships, flip the `if` branch
+    # to `failures.append(...)` and remove this guard comment.
+    print("step: probe_visual_selection")
+    try:
+        selected_basenames = _uia.read_selected_tree_row_basenames(win)
+    except Exception as exc:
+        # Helper isn't expected to raise (it swallows per-item errors)
+        # but a top-level catch keeps an unexpected exception from
+        # masking the manifest-side success that's the scenario's real
+        # contract today.
+        print(f"  probe_visual_selection_error: {exc!r}")
+        selected_basenames = []
+    print(f"  selected_basenames={selected_basenames}")
+    if EXPECTED_KEEPER not in selected_basenames:
+        print(
+            f"  probe_status: XFAIL_KNOWN_BUG_239 — "
+            f"after scan-complete + close-and-load, tree selection "
+            f"does not include {EXPECTED_KEEPER!r}; auto-select wrote "
+            f"action=KEEP to the manifest but did not apply visual "
+            f"selection. See https://github.com/jackal998/photo-manager/issues/239"
+        )
+    else:
+        # When this branch fires, the fix has landed — convert the
+        # probe to a hard failure (move into the failures list) and
+        # remove this whole guard block.
+        print("  probe_status: PASS (#239 fixed — promote this probe to a hard assertion)")
+
     if failures:
         for f in failures:
             print(f"FAIL: {f}")

--- a/tests/test_ui_probes.py
+++ b/tests/test_ui_probes.py
@@ -20,9 +20,11 @@ per-file gate. AST inspection sidesteps that entanglement.
 from __future__ import annotations
 
 import ast
+import re
 from pathlib import Path
 
 import pytest
+import yaml
 
 from app.viewmodels.main_vm import PhotoGroup, PhotoRecord
 from app.views import constants
@@ -31,6 +33,10 @@ from app.views.tree_model_builder import build_model
 REPO = Path(__file__).resolve().parents[1]
 DIALOG_HANDLER_PATH = REPO / "app" / "views" / "handlers" / "dialog_handler.py"
 MENU_CONTROLLER_PATH = REPO / "app" / "views" / "components" / "menu_controller.py"
+ACTION_HANDLERS_PATH = REPO / "app" / "views" / "handlers" / "action_handlers.py"
+CONTEXT_MENU_PATH = REPO / "app" / "views" / "handlers" / "context_menu.py"
+EN_YAML = REPO / "translations" / "en.yml"
+ZH_TW_YAML = REPO / "translations" / "zh_TW.yml"
 
 
 # Tree columns that the user expects to filter against in the Select
@@ -200,6 +206,203 @@ def test_probe_action_dialog_receives_groups_from_main_window_callsite():
             "dropdown silently shows the regex panel instead of the "
             ">/</= panel. See #237."
         )
+
+
+def _ast_class_method_names(path: Path, class_name: str) -> set[str]:
+    """Return the set of public method names defined on a class, read
+    from source via AST so the probe doesn't import the module."""
+    tree = ast.parse(path.read_text(encoding="utf-8"))
+    for cls in ast.walk(tree):
+        if isinstance(cls, ast.ClassDef) and cls.name == class_name:
+            return {
+                fn.name for fn in cls.body
+                if isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and not fn.name.startswith("_")
+            }
+    raise AssertionError(
+        f"class {class_name} not found in {path} — file may have been "
+        f"moved or renamed."
+    )
+
+
+def test_probe_action_handlers_impl_proxies_every_protocol_method():
+    """Every method on the ``ActionHandlers`` Protocol (the contract
+    the context menu invokes against) MUST be present on
+    ``ActionHandlersImpl`` (the manual proxy bridge to file_operations).
+
+    Catches: future drift of the bridge-pattern hole that caused #175
+    (forgot ``set_locked_state``) and #182 (forgot
+    ``set_decision_with_lock_check``). Python's Protocol is advisory —
+    a missing method survives until the menu item fires at runtime and
+    the AttributeError gets swallowed by Qt's signal dispatch. This
+    probe is the static enforcement the Protocol can't give us.
+
+    Today: passes (3 manual tests in
+    ``tests/test_context_menu.py::TestActionHandlersImplBridge`` cover
+    a subset; this probe enforces 100% Protocol parity automatically).
+    """
+    protocol_methods = _ast_class_method_names(
+        CONTEXT_MENU_PATH, "ActionHandlers"
+    )
+    impl_methods = _ast_class_method_names(
+        ACTION_HANDLERS_PATH, "ActionHandlersImpl"
+    )
+
+    missing = protocol_methods - impl_methods
+    assert not missing, (
+        f"ActionHandlersImpl is missing proxies for ActionHandlers "
+        f"Protocol methods: {sorted(missing)}. Context-menu items that "
+        f"invoke these will silently no-op via Qt's swallowed "
+        f"AttributeError. Background: feedback_action_handlers_bridge "
+        f"in memory; #175 / #182 are prior instances."
+    )
+
+    # Reverse direction is informative but not a hard error: the impl
+    # can carry helper methods that aren't part of the Protocol surface.
+    # If a stale proxy ever needs to be removed, that's a code-review
+    # concern, not a structural invariant.
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#244 — action_by_regex is not in MANIFEST_ACTIONS, so "
+           "Set Action by Regex stays enabled before any manifest "
+           "loads. Remove this marker when #244 lands.",
+)
+def test_probe_manifest_dependent_menu_actions_are_gated():
+    """Actions that operate on the loaded manifest MUST be in
+    ``MANIFEST_ACTIONS`` so they're disabled before a manifest is open
+    and re-enabled on load.
+
+    Catches: ``action_by_regex`` is registered in menu_controller.py but
+    is NOT in ``MANIFEST_ACTIONS`` and has no ``setEnabled(False)``
+    call — so "Set Action by Regex…" is always clickable, even before
+    any manifest exists. Clicking it on startup tries to filter an
+    empty record set.
+
+    We hardcode the design rule ("Set Action by Regex requires a
+    manifest") here rather than trying to derive it statically — that's
+    the probe's job. Add new gated actions to ``_MANIFEST_DEPENDENT``
+    when the menu grows.
+    """
+    # Read MANIFEST_ACTIONS via AST — same coverage-isolation rationale
+    # as the other static probes.
+    src = MENU_CONTROLLER_PATH.read_text(encoding="utf-8")
+    tree = ast.parse(src)
+    manifest_actions: set[str] = set()
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Assign)
+                and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and node.targets[0].id == "MANIFEST_ACTIONS"
+                and isinstance(node.value, ast.Tuple)):
+            for elt in node.value.elts:
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                    manifest_actions.add(elt.value)
+            break
+
+    # Design-rule: actions that require a loaded manifest to make sense.
+    # Add new entries here when the menu grows. Keep this list aligned
+    # with the user expectation that "no manifest open" = "every
+    # manifest-mutating menu item is greyed out".
+    _MANIFEST_DEPENDENT = {
+        "save_manifest",
+        "execute_action",
+        "remove_from_list",
+        "action_by_regex",
+    }
+
+    missing = _MANIFEST_DEPENDENT - manifest_actions
+    assert not missing, (
+        f"Menu actions need manifest gating but are NOT in "
+        f"MANIFEST_ACTIONS: {sorted(missing)}. These will stay enabled "
+        f"before any manifest loads, so the user can click them and "
+        f"get an empty / undefined-behaviour dispatch. Add the missing "
+        f"entries to MANIFEST_ACTIONS in "
+        f"app/views/components/menu_controller.py."
+    )
+
+
+def _walk_yaml_leaf_strings(
+    d_en, d_zh, prefix: str = ""
+) -> list[tuple[str, str, str]]:
+    """Yield ``(dotted_key, en_value, zh_value)`` for every leaf string
+    where both locales define the same key. Skips missing-from-zh keys
+    (those are caught by the existing ``test_zh_tw_has_every_key_present_in_english``)."""
+    out: list[tuple[str, str, str]] = []
+    if not isinstance(d_en, dict) or not isinstance(d_zh, dict):
+        return out
+    for k, v_en in d_en.items():
+        v_zh = d_zh.get(k)
+        key = f"{prefix}.{k}" if prefix else k
+        if isinstance(v_en, dict):
+            out.extend(_walk_yaml_leaf_strings(v_en, v_zh, key))
+        elif isinstance(v_en, str) and isinstance(v_zh, str):
+            out.append((key, v_en, v_zh))
+    return out
+
+
+# Keys that are intentionally identical in both locales — product /
+# proper-noun strings that are not localized. Keep this list tiny;
+# anything new added here should have an explicit reason in the PR
+# description (e.g. "brand name", "version string format").
+_TRANSLATION_EXEMPT_KEYS: frozenset[str] = frozenset({
+    "main_window.title",  # "Photo Manager" — product name, untranslated by design
+})
+
+_CJK_RE = re.compile(r"[一-鿿]")
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#245 — 9 zh_TW values from #209 (numeric compare panel) "
+           "plus execute_dialog.execute_button_highlighted still ship "
+           "the raw English string. Remove this marker when #245 lands.",
+)
+def test_probe_zh_tw_translations_are_not_english_passthroughs():
+    """Every zh_TW value that differs from the English string visually
+    must actually be in Chinese — not a structurally-present key whose
+    value was copy-pasted from en.yml during a feature PR.
+
+    Catches: the 9 numeric-panel keys from #209 and
+    ``execute_dialog.execute_button_highlighted`` that shipped with
+    English text in zh_TW. The existing
+    ``test_zh_tw_has_every_key_present_in_english`` only checks
+    structural key parity; it cannot catch a key whose value was
+    pasted-as-English.
+
+    Heuristic: zh value equals en value AND contains no CJK characters
+    AND has at least one Latin letter AND is at least 3 chars long.
+    The exempt list (``_TRANSLATION_EXEMPT_KEYS``) carries product /
+    proper-noun strings that are legitimately the same in both
+    locales.
+    """
+    en = yaml.safe_load(EN_YAML.read_text(encoding="utf-8"))
+    zh = yaml.safe_load(ZH_TW_YAML.read_text(encoding="utf-8"))
+
+    untranslated: list[tuple[str, str]] = []
+    for key, v_en, v_zh in _walk_yaml_leaf_strings(en, zh):
+        if key in _TRANSLATION_EXEMPT_KEYS:
+            continue
+        if v_zh != v_en:
+            continue  # different value — translated (even if poorly)
+        if _CJK_RE.search(v_zh):
+            continue  # contains Chinese — translated (just happens to match en in some part)
+        if not re.search(r"[A-Za-z]", v_zh):
+            continue  # no alphabetic content (numbers, punctuation only)
+        if len(v_zh.strip()) < 3:
+            continue  # too short to be a meaningful phrase
+        untranslated.append((key, v_zh))
+
+    assert not untranslated, (
+        f"zh_TW values appear to be untranslated English passthroughs "
+        f"({len(untranslated)} keys):\n  " +
+        "\n  ".join(f"{k!r}: {v!r}" for k, v in untranslated) +
+        "\n\nEither translate the values in translations/zh_TW.yml, or "
+        "if the string is legitimately identical (product name, etc.), "
+        "add the key to _TRANSLATION_EXEMPT_KEYS in this file with a "
+        "one-line reason."
+    )
 
 
 @pytest.mark.xfail(

--- a/tests/test_ui_probes.py
+++ b/tests/test_ui_probes.py
@@ -1,0 +1,227 @@
+"""UI invariants — static probes for cross-cutting UI consistency.
+
+Per [#243](https://github.com/jackal998/photo-manager/issues/243): the
+qa-explore scenario batch is excellent at *replay* of canonical paths
+but architecturally can't catch certain bug classes — field-vs-column
+drift, label uniqueness violations, dropped callsite parameters. This
+file is the complementary *probe* layer that runs in CI on every PR.
+
+Each probe targets a structural invariant that, if violated, has bitten
+us at least once. The current state of each invariant when the probe
+was added is recorded in a comment next to the test so a failing CI run
+points the maintainer at the right open issue.
+
+Implementation note: probes #237 and #238 inspect ``dialog_handler.py``
+via ``ast.parse(file.read_text())`` instead of importing it. Importing
+the module would force coverage measurement (#185 lists this file as
+out-of-scope for layer-1 — it's a thin Qt wrapper) and would trip the
+per-file gate. AST inspection sidesteps that entanglement.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from app.viewmodels.main_vm import PhotoGroup, PhotoRecord
+from app.views import constants
+from app.views.tree_model_builder import build_model
+
+REPO = Path(__file__).resolve().parents[1]
+DIALOG_HANDLER_PATH = REPO / "app" / "views" / "handlers" / "dialog_handler.py"
+MENU_CONTROLLER_PATH = REPO / "app" / "views" / "components" / "menu_controller.py"
+
+
+# Tree columns that the user expects to filter against in the Select
+# dialog. The Group column (index 0) is the row-grouping mechanism
+# itself, not a filterable per-row value — exclude it. Similarity (the
+# within-group label "Ref" / "100%" / "85%") IS filterable: it's how a
+# user picks "all near-duplicates with > 90% similarity".
+_FILTERABLE_COLUMNS: dict[int, str] = {
+    constants.COL_ACTION:        "Action",
+    constants.COL_SCORE:         "Score",
+    constants.COL_LOCK:          "Lock",
+    constants.COL_NAME:          "File Name",
+    constants.COL_FOLDER:        "Folder",
+    constants.COL_SIZE_BYTES:    "Size (Bytes)",
+    constants.COL_GROUP_COUNT:   "Group Count",
+    constants.COL_CREATION_DATE: "Creation Date",
+    constants.COL_SHOT_DATE:     "Shot Date",
+    constants.COL_RESOLUTION:    "Resolution",
+}
+
+
+def _show_action_dialog_ast() -> ast.FunctionDef:
+    """Return the AST node for ``DialogHandler.show_action_dialog``.
+
+    Read as text + ast.parse so we don't import dialog_handler.py — see
+    module docstring for the coverage-gate rationale.
+    """
+    tree = ast.parse(DIALOG_HANDLER_PATH.read_text(encoding="utf-8"))
+    for cls in ast.walk(tree):
+        if isinstance(cls, ast.ClassDef) and cls.name == "DialogHandler":
+            for fn in cls.body:
+                if (isinstance(fn, ast.FunctionDef)
+                        and fn.name == "show_action_dialog"):
+                    return fn
+    raise AssertionError(
+        "DialogHandler.show_action_dialog not found in "
+        f"{DIALOG_HANDLER_PATH} — file may have been moved or renamed."
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#238 — Score and Resolution not yet in dialog dropdown. "
+           "Remove this marker when #238 lands.",
+)
+def test_probe_select_dialog_exposes_every_filterable_tree_column():
+    """Every filterable tree column must appear in the Select dialog's
+    field dropdown.
+
+    Catches: #238 (Score, Resolution missing from dialog despite being
+    visible as tree columns).
+    """
+    fn = _show_action_dialog_ast()
+    # The fields list is a literal in show_action_dialog: locate the
+    # `fields = [...]` assignment and read its string constants.
+    declared: set[str] = set()
+    for node in ast.walk(fn):
+        if (isinstance(node, ast.Assign)
+                and len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and node.targets[0].id == "fields"
+                and isinstance(node.value, ast.List)):
+            for elt in node.value.elts:
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                    declared.add(elt.value)
+            break
+
+    missing = set(_FILTERABLE_COLUMNS.values()) - declared
+    assert not missing, (
+        f"Select dialog's field dropdown is missing tree columns: "
+        f"{sorted(missing)}. Every column visible in the tree must be "
+        f"filterable from the Select dialog. See #238."
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#241 — multiple Ref labels render in groups with multiple "
+           "MOVE-action rows (e.g. Live Photo HEIC + MOV passenger). "
+           "Remove this marker when #241 lands.",
+)
+def test_probe_similarity_column_emits_at_most_one_ref_per_group(qapp):
+    """Within a single duplicate group, only one row should render as
+    the reference / primary ("Ref"); the rest must show 100% (exact
+    duplicate), a similarity percentage (near-duplicate), or a neutral
+    sentinel.
+
+    Catches: #241 (multiple MOVE rows in a group all render "Ref" —
+    Live Photo HEIC + MOV passenger, etc.).
+    """
+    from infrastructure.i18n import t
+
+    # Synthetic group: two MOVE-action records, the canonical shape that
+    # triggers #241 (Live Photo HEIC primary + MOV passenger both
+    # classified MOVE by the scanner).
+    base_kwargs = dict(
+        group_number=1, is_mark=False, is_locked=False,
+        capture_date=None, modified_date=None,
+    )
+    rec_heic = PhotoRecord(
+        file_path="/fake/IMG_0001.HEIC", folder_path="/fake",
+        action="MOVE", score=0.87, file_size_bytes=1_000_000, **base_kwargs,
+    )
+    rec_mov = PhotoRecord(
+        file_path="/fake/IMG_0001.MOV", folder_path="/fake",
+        # Passengers carry no score per scanner/scoring.py
+        action="MOVE", score=None, file_size_bytes=2_000_000, **base_kwargs,
+    )
+    group = PhotoGroup(group_number=1, items=[rec_heic, rec_mov])
+
+    model, _proxy = build_model([group])
+
+    ref_label = t("tree.similarity_ref")
+    ref_count = 0
+    for parent_row in range(model.rowCount()):
+        parent = model.item(parent_row, constants.COL_GROUP)
+        for child_row in range(parent.rowCount()):
+            sim_cell = parent.child(child_row, constants.COL_GROUP)
+            if sim_cell is not None and sim_cell.text() == ref_label:
+                ref_count += 1
+
+    assert ref_count <= 1, (
+        f"Group rendered {ref_count} '{ref_label}' labels — at most 1 "
+        f"per group. Additional Ref-tier rows should fall back to a "
+        f"similarity percentage or neutral sentinel. See #241."
+    )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#237 — main-window callsite drops `groups=`, so the "
+           "numeric compare panel never appears when picking Size etc. "
+           "Remove this marker when #237 lands.",
+)
+def test_probe_action_dialog_receives_groups_from_main_window_callsite():
+    """When the main window opens the Select dialog via right-click,
+    the ``groups=`` parameter MUST be threaded through — otherwise the
+    numeric-condition panel (>, <, =, Top-N) silently stays hidden even
+    when the user picks a numeric field.
+
+    Catches: #237. We inspect dialog_handler.py's AST rather than
+    invoking the function so the probe doesn't pull dialog_handler.py
+    into coverage measurement.
+    """
+    fn = _show_action_dialog_ast()
+    # Find the `ActionDialog(...)` call inside show_action_dialog.
+    action_dialog_calls: list[ast.Call] = []
+    for node in ast.walk(fn):
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "ActionDialog"):
+            action_dialog_calls.append(node)
+
+    assert action_dialog_calls, (
+        "No ActionDialog(...) call found inside "
+        "DialogHandler.show_action_dialog — file may have been "
+        "refactored. Update the probe to match."
+    )
+
+    for call in action_dialog_calls:
+        kwarg_names = {kw.arg for kw in call.keywords if kw.arg}
+        assert "groups" in kwarg_names, (
+            "DialogHandler.show_action_dialog calls ActionDialog "
+            "without `groups=`. The numeric-condition panel is gated "
+            "on a non-empty `self._groups`, so without this argument "
+            "picking Size / Score / Group Count / Similarity from the "
+            "dropdown silently shows the regex panel instead of the "
+            ">/</= panel. See #237."
+        )
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="#240 — Execute Mode toggle (Option-B prototype for #165) "
+           "has not yet been removed. Remove this marker when #240 lands.",
+)
+def test_probe_no_execute_mode_toggle_in_menu():
+    """The Execute Mode toggle (Ctrl+E) was added in d8bd1dc as an
+    Option-B prototype for #165. The decision was made to remove it and
+    keep the legacy Execute Action dialog as the sole destructive path
+    (see #240). This probe enforces the absence so the toggle can't
+    silently come back.
+
+    Catches: #240 (Option-B prototype still registered in
+    menu_controller.py).
+    """
+    src = MENU_CONTROLLER_PATH.read_text(encoding="utf-8")
+    assert '"execute_mode"' not in src, (
+        "menu_controller.py still registers an 'execute_mode' action. "
+        "The Execute Mode toggle was decided to be removed in favor of "
+        "the legacy Execute Action dialog (see #240). All references "
+        "to 'execute_mode' should be deleted along with the supporting "
+        "code in main_window.py and execute_mode_helpers.py."
+    )


### PR DESCRIPTION
## Summary

Implements the complementary probe layer proposed in #243 — automated checks for cross-cutting UI invariants that the existing qa-explore scenario batch is architecturally unable to catch (dropdown drift, label uniqueness, dropped callsite parameters, bridge-pattern holes, translation drift, menu-gating drift).

Each of the 5 UX issues that slipped past qa-explore in a single 5-minute manual session is now caught by an automated probe. Two additional bugs (#244, #245) surfaced during the research round and are caught by the new probes too.

### Probes added (8 total)

| # | Probe | Catches | Today |
|---|---|---|---|
| 1 | Select dialog field/column diff (AST) | #238 | XFAIL |
| 2 | Select dialog passes `groups=` (AST) | #237 | XFAIL |
| 3 | s49 auto-select visual selection (live, soft) | #239 | logs `XFAIL_KNOWN_BUG_239` |
| 4 | Execute Mode toggle absence (text) | #240 | XFAIL |
| 5 | One Ref per group (build_model) | #241 | XFAIL |
| 6 | ActionHandlers Protocol↔Impl parity (AST) | future #175/#182-class regression | PASS |
| 7 | Manifest-dependent actions gated (AST) | #244 (new) | XFAIL |
| 8 | zh_TW values not English passthroughs (YAML) | #245 (new) | XFAIL |

Static probes use `@pytest.mark.xfail(strict=True)` so CI stays green today and flips red the moment any bug is fixed without the marker being removed — the standard known-bug regression-test pattern.

The s49 live probe uses a soft-fail pattern (logs `probe_status`, doesn't fail the scenario) because qa-batch has no xfail concept. Comment block documents the one-line upgrade (`print(...)` → `failures.append(...)`) for when #239 lands.

### Design choices

- **AST / text inspection over `inspect.getsource`** for probes that read source files. Importing `dialog_handler.py` from a test would pull it into coverage measurement (the file is invisible on Linux CI where no Qt-dependent test reaches it), tripping the per-file 70% gate. File-text inspection avoids that entanglement entirely.
- **Heuristic translation probe** (zh == en && no CJK && alphabetic && ≥3 chars) with a tiny exempt list (`main_window.title = "Photo Manager"`) for product/proper-noun strings.
- **Forward-defensive probe #6**: the bridge is clean today — but #175 and #182 (and the prior round of manual `TestActionHandlersImplBridge` tests covering only 3/5 proxies) prove the pattern is recurrent. Static probe gives 100% Protocol parity for free.

### Files changed

- `tests/test_ui_probes.py` — new, 7 static probes, ~410 LOC
- `qa/scenarios/_uia.py` — `read_selected_tree_row_basenames` helper (+30 LOC)
- `qa/scenarios/s49_scan_auto_select.py` — #239 soft-probe block (+25 LOC)
- `docs/testing.md` — probes section + per-probe inventory table
- `README.md` — probes row added to the testing-layers summary

### Verification

- `pytest tests/` — full suite green (1 pass + 6 xfail in `test_ui_probes.py`, all other tests unchanged)
- `scripts/check_coverage_per_file.py` — 50 files clear 70% gate
- 87.77% global coverage (above 80% floor)

## Test plan

- [x] Static probes detect their target bugs today (each xfailed with a citation)
- [x] Static probes pass cleanly when their bug is fixed (verified by removing the bug condition manually in scratch, not committed)
- [x] Full test suite green
- [x] Per-file 70% gate green
- [x] s49 syntax-parses and helper imports cleanly (end-to-end qa-batch run deferred to maintainer; see comment block)
- [ ] (after merge) qa-batch run picks up the s49 extension on next workflow trigger
- [ ] (when #237/#238/#239/#240/#241/#244/#245 land) corresponding probe flips XPASS-strict → marker removed in the bug-fix PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)