### PR TITLE
ci(qa-batch): fail when a soft probe is ready to be promoted

### DIFF
--- a/.github/workflows/qa-batch.yml
+++ b/.github/workflows/qa-batch.yml
@@ -125,6 +125,33 @@ jobs:
           # `$LASTEXITCODE` from the python invocation is what matters.
           exit $LASTEXITCODE
 
+      # Probe-layer promotion detector (#243 follow-up). Soft probes
+      # embedded inside scenarios print `probe_status: XFAIL_KNOWN_BUG_N`
+      # while the target bug exists, and `probe_status: PASS …` once
+      # the bug is fixed. The scenario itself still passes either way
+      # (soft-fail by design so qa-batch stays green during known-bug
+      # windows). This step closes the loop: when the bug is fixed
+      # and the probe starts emitting PASS, fail the job so the bug-fix
+      # PR is forced to either (a) promote the probe to a hard
+      # `failures.append(...)` in the scenario, or (b) delete the soft
+      # probe block entirely. Mirrors the role @pytest.mark.xfail(strict=True)
+      # plays for the static probes in tests/test_ui_probes.py.
+      - name: Detect probes ready for promotion
+        if: always()
+        shell: pwsh
+        run: |
+          if (-not (Test-Path qa-batch.log)) { exit 0 }
+          $passes = Select-String -Path qa-batch.log -Pattern 'probe_status:\s*PASS'
+          if ($passes) {
+            Write-Host '::error::A soft probe is now passing — its target bug appears to be fixed.'
+            Write-Host '::error::Promote it to a hard assertion (failures.append) in the scenario, or delete the probe block.'
+            Write-Host '::error::See docs/testing.md "Probes" section and the comment block in the affected scenario.'
+            Write-Host ''
+            Write-Host 'Matching log lines:'
+            $passes | ForEach-Object { Write-Host "  $($_.Line)" }
+            exit 1
+          }
+
       # Always emit a per-scenario rc summary to the job page so triage from
       # the PR is one click. Runs even on failure so we see WHICH scenarios
       # failed without digging through the full log.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -373,7 +373,12 @@ soft-probe upgrade path lives if applicable.
 When the corresponding bug lands, the static probes flip XFAIL→XPASS-strict
 and the bug-fix PR removes the marker. The soft probe is converted from
 `print(probe_status: …)` to `failures.append(…)` per the comment block in
-the scenario.
+the scenario; the **"Detect probes ready for promotion"** step in
+[`.github/workflows/qa-batch.yml`](../.github/workflows/qa-batch.yml) greps
+`qa-batch.log` for `probe_status: PASS` and fails the job if any are
+found — same forcing-function as `xfail(strict=True)` for the static
+probes, so a bug-fix PR cannot merge while leaving a soft probe in its
+print-only state.
 
 ---
 


### PR DESCRIPTION
## Summary

Closes the one CI gap left by #246 (UI probe layer).

Soft probes embedded inside qa-batch scenarios — today: the `step: probe_visual_selection` block in `qa/scenarios/s49_scan_auto_select.py` for #239 — print `probe_status: …` into `qa-batch.log` but never fail the scenario. That's by design: it keeps qa-batch green during known-bug windows. But it also means **when the bug is fixed, nobody knows to upgrade the probe** unless they read the log by hand.

New step in `.github/workflows/qa-batch.yml`: grep `qa-batch.log` for `probe_status: PASS` and fail the job if any are found.

After this lands, a bug-fix PR for #239 (or any future soft-probe-tracked bug) must either:
- promote the probe to a hard `failures.append(...)` in the scenario, or
- delete the soft probe block entirely

— or qa-batch fails and the PR can't merge. Same forcing-function `@pytest.mark.xfail(strict=True)` plays for the static probes in `tests/test_ui_probes.py`.

### Verified

- Regex `probe_status:\s*PASS` matches `probe_status: PASS …` lines, does NOT match `probe_status: XFAIL_KNOWN_BUG_…` lines (confirmed locally with the exact log shape emitted by s49).
- Only two `probe_status` references exist in the repo today — both inside the s49 soft probe block — so no false-positive sites.

## Files changed

- `.github/workflows/qa-batch.yml` (+27 LOC — one new step)
- `docs/testing.md` (+6 LOC — Probes section now points at the step)

## Test plan

- [x] Locally verified regex behaviour against the exact print() strings in s49
- [x] Locally verified `grep -rn "probe_status"` only matches the s49 soft probe
- [ ] (after merge) qa-batch CI runs on a PR — confirm the step exits 0 today (no probes passing yet)
- [ ] (when #239 lands) qa-batch CI runs on the fix PR — step fails until the soft probe is promoted in the same PR
- [ ] (when #239 lands) maintainer promotes \`print(probe_status: ...)\` → \`failures.append(...)\` per the comment block in s49

🤖 Generated with [Claude Code](https://claude.com/claude-code)