### PR TITLE
fix(scan): visually select KEEP rows after auto-select scan (#239)

### DIFF
--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -26,7 +26,7 @@ from app.views.components.status_reporter_impl import StatusReporterImpl
 
 # Import extracted components
 from app.views.components.tree_controller import TreeController
-from app.views.constants import COL_CREATION_DATE, COL_FOLDER, COL_GROUP, COL_NAME, COL_SHOT_DATE, COL_SIZE_BYTES
+from app.views.constants import COL_CREATION_DATE, COL_FOLDER, COL_GROUP, COL_NAME, COL_SHOT_DATE, COL_SIZE_BYTES, PATH_ROLE
 from app.views.handlers.action_handlers import ActionHandlersImpl
 from app.views.handlers.context_menu import ContextMenuHandler
 from app.views.handlers.dialog_handler import DialogHandler
@@ -420,7 +420,7 @@ class MainWindow(QMainWindow):
         from app.views.dialogs.scan_dialog import ScanDialog
         dlg = ScanDialog(
             settings=self._settings,
-            on_scan_complete=self._load_manifest_from_path,
+            on_scan_complete=self._load_manifest_after_scan,
             parent=self,
             should_proceed=self._confirm_no_pending_decisions,
         )
@@ -505,6 +505,65 @@ class MainWindow(QMainWindow):
             )
         except Exception as exc:
             QMessageBox.critical(self, t("main_window.load_error_title"), str(exc))
+
+    def _load_manifest_after_scan(self, manifest_path: str) -> None:
+        """Load the manifest produced by a scan and apply tree selection
+        to any rows the worker pre-decided as keepers (#239).
+
+        Distinct from :meth:`_load_manifest_from_path` (the Open-Manifest
+        path) so re-opening an existing manifest that happens to carry
+        ``action="KEEP"`` rows doesn't clobber whatever selection the
+        user had in mind. The scan-complete path is the only place the
+        user has explicitly asked auto-select to choose for them.
+        """
+        self._load_manifest_from_path(manifest_path)
+        keeper_paths = {
+            getattr(rec, "file_path", "")
+            for group in self._vm.groups
+            for rec in getattr(group, "items", [])
+            if getattr(rec, "action", "") == "KEEP"
+        }
+        keeper_paths.discard("")
+        if keeper_paths:
+            self._select_rows_by_paths(keeper_paths)
+
+    def _select_rows_by_paths(self, target_paths: set[str]) -> None:
+        """Apply tree selection to every row whose PATH_ROLE is in
+        ``target_paths``. Scrolls to the first match so the user sees
+        the selection state, not just the count in the status bar.
+        Used by :meth:`_load_manifest_after_scan` for the auto-select
+        post-scan highlight (#239). Generalises :meth:`_reselect_by_path`
+        from single- to multi-target selection.
+        """
+        from PySide6.QtCore import QItemSelectionModel
+
+        if not target_paths:
+            return
+        model = self.tree.model()
+        if model is None:
+            return
+        sel_model = self.tree.selectionModel()
+        if sel_model is None:
+            return
+
+        sel_model.clearSelection()
+        first_idx = None
+        # Top-level rows are groups; their children are files. Same
+        # traversal shape as _reselect_by_path.
+        for group_row in range(model.rowCount()):
+            group_idx = model.index(group_row, COL_GROUP)
+            for child_row in range(model.rowCount(group_idx)):
+                name_idx = model.index(child_row, COL_NAME, group_idx)
+                path = model.data(name_idx, PATH_ROLE)
+                if path in target_paths:
+                    sel_model.select(
+                        name_idx,
+                        QItemSelectionModel.Select | QItemSelectionModel.Rows,
+                    )
+                    if first_idx is None:
+                        first_idx = name_idx
+        if first_idx is not None:
+            self.tree.scrollTo(first_idx)
 
     def on_open_manifest(self) -> None:
         """Handle Open Manifest action."""

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -106,7 +106,7 @@ calls out what would be uncaught even with a green CI.
 | `core/models.py` | 100% | dataclasses |
 | `core/services/sort_service.py` | 100% | pure logic |
 | `core/services/interfaces.py` | 100% | dataclasses + protocols |
-| `core/services/auto_select.py` | 100% | pure helper for #212. Picks the top-scored row per duplicate group; consumed by `scan_worker._run_pipeline` when the dialog's "Auto select after scan" checkbox is on. Tie-break + None-handling mirror `select_paths_top_n` (`app/views/dialogs/select_dialog.py`) so manual and auto runs converge on the same keeper. Layer 3: s49. |
+| `core/services/auto_select.py` | 100% | pure helper for #212. Picks the top-scored row per duplicate group; consumed by `scan_worker._run_pipeline` when the dialog's "Auto select after scan" checkbox is on. Tie-break + None-handling mirror `select_paths_top_n` (`app/views/dialogs/select_dialog.py`) so manual and auto runs converge on the same keeper. Layer 3: s49 covers the full pipeline including #239's visual-selection step — `MainWindow._load_manifest_after_scan` walks `vm.groups` for `action="KEEP"` and applies the tree selection. |
 
 ### `infrastructure/`
 
@@ -368,7 +368,7 @@ soft-probe upgrade path lives if applicable.
 | `test_probe_action_handlers_impl_proxies_every_protocol_method` | Every method on `ActionHandlers` Protocol exists on `ActionHandlersImpl` | PASS | Future #175/#182-class bridge regression |
 | `test_probe_manifest_dependent_menu_actions_are_gated` | Every menu action that requires a loaded manifest is in `MANIFEST_ACTIONS` | XFAIL | [#244](https://github.com/jackal998/photo-manager/issues/244) |
 | `test_probe_zh_tw_translations_are_not_english_passthroughs` | zh_TW values that match en values must contain CJK chars (heuristic; tiny exempt list for product names) | XFAIL | [#245](https://github.com/jackal998/photo-manager/issues/245) |
-| `s49` `step: probe_visual_selection` (soft live) | After scan-complete with auto-select on, the tree's selection model contains the keeper rows | logs `XFAIL_KNOWN_BUG_239` | [#239](https://github.com/jackal998/photo-manager/issues/239) |
+| `s49` `step: verify_visual_selection_of_keeper` (hard live) | After scan-complete with auto-select on, the tree's selection model contains the keeper rows | PASS | Forward-defensive against [#239](https://github.com/jackal998/photo-manager/issues/239) recurring |
 
 When the corresponding bug lands, the static probes flip XFAIL→XPASS-strict
 and the bug-fix PR removes the marker. The soft probe is converted from

--- a/qa/scenarios/s49_scan_auto_select.py
+++ b/qa/scenarios/s49_scan_auto_select.py
@@ -201,37 +201,38 @@ def main() -> int:
                 f"actions are MOVE / EXACT / REVIEW_DUPLICATE"
             )
 
-    # Probe #239 — auto-select must apply VISUAL selection to the
-    # keeper row, not just write action=KEEP to the manifest. Today
-    # the wiring stops one step short (main_window._load_manifest_from_path
-    # refreshes the tree but never selects KEEP rows). Logged here as
-    # a probe-status line — not a scenario failure — so qa-batch stays
-    # green until #239 lands. When the fix ships, flip the `if` branch
-    # to `failures.append(...)` and remove this guard comment.
-    print("step: probe_visual_selection")
+    # #239 — auto-select must apply VISUAL selection to the keeper row,
+    # not just write action=KEEP to the manifest. The earlier soft-probe
+    # incarnation (logging probe_status: XFAIL_KNOWN_BUG_239) was
+    # promoted to a hard assertion when #239 fixed
+    # main_window._load_manifest_after_scan to walk vm.groups for
+    # action="KEEP" rows and apply the tree selection after refresh.
+    print("step: verify_visual_selection_of_keeper")
     try:
         selected_basenames = _uia.read_selected_tree_row_basenames(win)
     except Exception as exc:
         # Helper isn't expected to raise (it swallows per-item errors)
-        # but a top-level catch keeps an unexpected exception from
-        # masking the manifest-side success that's the scenario's real
-        # contract today.
-        print(f"  probe_visual_selection_error: {exc!r}")
+        # but a top-level catch turns an unexpected exception into a
+        # diagnostic FAIL instead of masking it as "selection empty".
+        failures.append(
+            f"reading selected tree rows raised {exc!r} — probe can't "
+            f"verify #239 visual-selection state"
+        )
         selected_basenames = []
     print(f"  selected_basenames={selected_basenames}")
-    if EXPECTED_KEEPER not in selected_basenames:
-        print(
-            f"  probe_status: XFAIL_KNOWN_BUG_239 — "
-            f"after scan-complete + close-and-load, tree selection "
-            f"does not include {EXPECTED_KEEPER!r}; auto-select wrote "
-            f"action=KEEP to the manifest but did not apply visual "
-            f"selection. See https://github.com/jackal998/photo-manager/issues/239"
+    if selected_basenames and EXPECTED_KEEPER not in selected_basenames:
+        failures.append(
+            f"tree selection after scan-complete is {selected_basenames!r}; "
+            f"expected to include the auto-select keeper "
+            f"{EXPECTED_KEEPER!r}. action=KEEP rows must be visually "
+            f"selected — see #239."
         )
-    else:
-        # When this branch fires, the fix has landed — convert the
-        # probe to a hard failure (move into the failures list) and
-        # remove this whole guard block.
-        print("  probe_status: PASS (#239 fixed — promote this probe to a hard assertion)")
+    elif not selected_basenames:
+        failures.append(
+            f"tree selection is empty after scan-complete with "
+            f"auto-select ON. Expected {EXPECTED_KEEPER!r} to be "
+            f"highlighted — see #239."
+        )
 
     if failures:
         for f in failures:


### PR DESCRIPTION
## Summary

Closes #239. Auto-select promoted from "writes \`action=KEEP\` to the manifest" → "writes AND highlights the keeper in the tree."

### The bug

The "Auto select after scan" checkbox (#212) wired through to the worker, which writes \`action=KEEP\` to the top-scored row of each duplicate group. But \`MainWindow._load_manifest_from_path\` refreshed the tree without applying any visual selection, so users who enabled the checkbox saw nothing change in the GUI. The manifest was correct; the user-visible state wasn't.

### Source fix

Split the scan-complete path away from the Open-Manifest path so re-opening an existing manifest with stale KEEP rows doesn't clobber whatever selection the user had in mind:

\`\`\`python
def _load_manifest_after_scan(self, manifest_path: str) -> None:
    self._load_manifest_from_path(manifest_path)
    keeper_paths = {
        rec.file_path
        for group in self._vm.groups
        for rec in getattr(group, "items", [])
        if getattr(rec, "action", "") == "KEEP"
    }
    if keeper_paths:
        self._select_rows_by_paths(keeper_paths)
\`\`\`

\`_select_rows_by_paths\` generalises the existing \`_reselect_by_path\` (single path) to a set. Same model-walk shape (top-level group rows → children); each match contributes a \`Select | Rows\` selection so the whole row highlights, not just the file-name cell. First match is the scrollTo target so the user sees the highlight immediately on long manifests.

\`on_scan_sources\` now wires \`on_scan_complete=self._load_manifest_after_scan\` instead of binding directly to \`_load_manifest_from_path\`.

### Probe promotion

s49's soft probe (added in #246 as \`step: probe_visual_selection\` emitting \`print(probe_status: …)\`) becomes a hard \`failures.append(…)\` assertion. Step renamed \`verify_visual_selection_of_keeper\` to match its post-fix role.

The qa-batch CI step "Detect probes ready for promotion" (#247) was the forcing-function for this PR — once the source fix lands, s49 starts emitting \`probe_status: PASS\` into qa-batch.log, the grep step fails the job, and the bug-fix PR cannot merge without also promoting the probe. Did both in one commit.

### Docs

\`docs/testing.md\`:
- Probe inventory row for #239 moves from \`logs XFAIL_KNOWN_BUG_239\` → PASS
- \`core/services/auto_select.py\` cell now mentions the visual-selection step as part of s49's full-pipeline coverage

## Verified locally

\`\`\`
$ .venv/Scripts/python.exe -m qa.scenarios._batch s49_scan_auto_select
...
step: verify_visual_selection_of_keeper
  selected_basenames=['neardup_00_q95.jpg']
scenario: s49_scan_auto_select DONE
[OK] s49_scan_auto_select
\`\`\`

Plus:

- \`pytest tests/\` — **1205 passed + 2 skipped + 1 xfailed** (the lone remaining xfail is #245 zh_TW translations)
- \`scripts/check_coverage_per_file.py\` — 49 tracked files clear the 70% gate
- Global coverage **88.15%**

## Test plan

- [x] s49 scenario passes locally end-to-end
- [x] Full pytest suite green
- [x] Per-file gate green
- [ ] (manual) Scan a fixture with auto-select on → confirm the top-scored row of each group is highlighted in the tree on scan-complete; scroll position shows the first keeper
- [ ] (manual) Open an existing manifest that happens to carry KEEP rows → confirm \`_load_manifest_from_path\` (not the new \`_after_scan\`) is the entry point and no selection is applied (selection only fires on the scan-complete path)
- [ ] (CI) qa-batch — s49 passes with the new hard assertion; "Detect probes ready for promotion" step exits 0 (no \`probe_status: PASS\` lines left in the log)

## Bug-fix arc state after merge

7 of 7 bug-shaped items from the original arc closed. #245 zh_TW translations is the only remaining xfail in \`test_ui_probes.py\` — that one needs translation copy, not engineering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)