### PR TITLE
feat(execute): preview pane in Execute Action dialog (#165)

### DIFF
--- a/app/views/dialogs/execute_action_dialog.py
+++ b/app/views/dialogs/execute_action_dialog.py
@@ -13,6 +13,7 @@ from PySide6.QtWidgets import (
     QLabel,
     QMenu,
     QPushButton,
+    QSplitter,
     QTreeView,
     QVBoxLayout,
 )
@@ -29,10 +30,14 @@ from app.views.constants import (
     UNLOCK_SENTINEL,
     settable_decisions,
 )
+from app.views.preview_pane import PreviewPane
 from app.views.tree_model_builder import build_model
 from app.views.window_state import (
     QSETTINGS_KEY_EXECUTE_ACTION_DIALOG_GEOM,
+    QSETTINGS_KEY_EXECUTE_ACTION_DIALOG_SPLITTER_STATE,
+    restore_splitter_state,
     restore_widget_geometry,
+    save_splitter_state,
     save_widget_geometry,
 )
 from infrastructure.i18n import t
@@ -56,6 +61,7 @@ class ExecuteActionDialog(QDialog):
         manifest_path: str | None,
         parent=None,
         settings: object | None = None,
+        task_runner: object | None = None,
     ) -> None:
         super().__init__(parent)
         # settings is optional so existing tests / callers that don't
@@ -64,6 +70,14 @@ class ExecuteActionDialog(QDialog):
         # recent-patterns survive across runs even when reached via
         # the Execute Action route.
         self._settings = settings
+        # task_runner is optional so unit tests that don't need a real
+        # image-loading pipeline can omit it. When absent, the dialog
+        # falls back to the pre-#165 single-column layout — no preview
+        # pane, no splitter. When present, the tree is wrapped in a
+        # horizontal splitter alongside the PreviewPane.
+        self._task_runner = task_runner
+        self._preview: PreviewPane | None = None
+        self._splitter: QSplitter | None = None
         self.setWindowTitle(t("execute_dialog.title"))
         self.setMinimumSize(900, 560)
         # #139 — QDialog.exec() sets WA_ShowModal but leaves windowModality
@@ -93,6 +107,15 @@ class ExecuteActionDialog(QDialog):
         # ``restore_widget_geometry`` falls back to that default when a
         # previously-saved rect would land on a disconnected monitor.
         restore_widget_geometry(self, QSETTINGS_KEY_EXECUTE_ACTION_DIALOG_GEOM)
+        # #165 — splitter sizes round-trip independently of dialog
+        # geometry (saveState vs saveGeometry are separate Qt blobs).
+        # Only attempt restore when the preview-enabled layout actually
+        # built a splitter; the runner=None branch has no splitter.
+        if self._splitter is not None:
+            restore_splitter_state(
+                self._splitter,
+                QSETTINGS_KEY_EXECUTE_ACTION_DIALOG_SPLITTER_STATE,
+            )
 
     # ------------------------------------------------------------------ helpers
 
@@ -144,7 +167,24 @@ class ExecuteActionDialog(QDialog):
         # Matches the main result tree (tree_controller.py:45).
         self._tree.setSelectionMode(QAbstractItemView.ExtendedSelection)
         self._rebuild_tree_model()
-        layout.addWidget(self._tree)
+        # #165 — when a task_runner was threaded through the constructor,
+        # wrap the tree in a horizontal splitter alongside an embedded
+        # PreviewPane so the user can see what each file looks like
+        # before confirming destructive action. Without a runner (the
+        # original test/legacy path) keep the single-column layout
+        # exactly as it was — no splitter, no preview.
+        if self._task_runner is not None:
+            self._preview = PreviewPane(self, self._task_runner)
+            self._splitter = QSplitter(Qt.Horizontal, self)
+            self._splitter.addWidget(self._tree)
+            self._splitter.addWidget(self._preview)
+            # Tree wider than preview by default; the persisted splitter
+            # state takes over once the user resizes the divider once.
+            self._splitter.setStretchFactor(0, 3)
+            self._splitter.setStretchFactor(1, 2)
+            layout.addWidget(self._splitter)
+        else:
+            layout.addWidget(self._tree)
 
         # Warning banner for complete-group deletions
         self._warning_banner = QFrame()
@@ -265,14 +305,33 @@ class ExecuteActionDialog(QDialog):
         ``execute_button_highlighted`` so the user sees that Execute is
         scoped to the highlight. Empty selection reverts to the default
         ``execute_button`` label.
+
+        #165 — also drives the embedded preview pane: exactly one file
+        row selected → show_single, anything else → clear. Multi-select
+        intentionally clears rather than showing the first row, so the
+        user isn't misled into thinking the preview reflects "the"
+        selection.
         """
         btn = self._btn_box.button(QDialogButtonBox.Ok)
         if btn is None:
             return
-        if self._selected_file_paths():
+        selected = self._selected_file_paths()
+        if selected:
             btn.setText(t("execute_dialog.execute_button_highlighted"))
         else:
             btn.setText(t("execute_dialog.execute_button"))
+        if self._preview is not None:
+            if len(selected) == 1:
+                path = next(iter(selected))
+                self._preview.show_single(
+                    path,
+                    {
+                        "name": os.path.basename(path),
+                        "folder": os.path.dirname(path),
+                    },
+                )
+            else:
+                self._preview.clear()
 
     def _on_jump_to_group(self, href: str) -> None:
         """Scroll the dialog tree to the group identified by ``href``.
@@ -959,6 +1018,15 @@ class ExecuteActionDialog(QDialog):
 
         ``done()`` funnels ``accept()``, ``reject()`` and the X-button
         path so this one hook catches every dismissal.
+
+        #165 — when the preview-enabled layout built a splitter, save
+        its state on the same close path so divider position survives
+        across opens.
         """
         save_widget_geometry(self, QSETTINGS_KEY_EXECUTE_ACTION_DIALOG_GEOM)
+        if self._splitter is not None:
+            save_splitter_state(
+                self._splitter,
+                QSETTINGS_KEY_EXECUTE_ACTION_DIALOG_SPLITTER_STATE,
+            )
         super().done(result)

--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -196,6 +196,7 @@ class FileOperationsHandler:
         status_reporter: StatusReporter,
         checked_paths_provider: object | None = None,
         highlighted_items_provider: object | None = None,
+        task_runner: object | None = None,
     ) -> None:
         self.vm = vm
         self.settings = settings
@@ -204,6 +205,11 @@ class FileOperationsHandler:
         self.status_reporter = status_reporter
         self.checked_paths_provider = checked_paths_provider
         self.highlighted_items_provider = highlighted_items_provider
+        # #165 — forwarded into ExecuteActionDialog so its embedded
+        # PreviewPane can request thumbnails via the same runner the
+        # main window uses. Optional for handler-level unit tests that
+        # never reach the dialog.
+        self.task_runner = task_runner
         # Dirty since last load / save / execute. Decisions auto-persist
         # to SQLite, so leaving the app without an explicit Save isn't
         # a data-loss risk; the dirty flag is purely a UX cue for the
@@ -882,6 +888,7 @@ class FileOperationsHandler:
         dlg = ExecuteActionDialog(
             self.vm.groups, manifest_path, self.parent,
             settings=self.settings,
+            task_runner=self.task_runner,
         )
         accepted = dlg.exec() == QDialog.Accepted
         # When the user removed rows via the immediate single-row

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -198,6 +198,12 @@ class MainWindow(QMainWindow):
         self.status_reporter = StatusReporterImpl(self)
         self.ui_updater = UIUpdaterImpl(self)
 
+        # #165 — runner needs to exist before the file operations
+        # handler so the handler can forward it to ExecuteActionDialog's
+        # embedded PreviewPane. The PreviewPane in the main window
+        # (built later in _setup_ui) reuses this same runner instance.
+        self._runner = ImageTaskRunner(service=self._img, receiver=self)
+
         # Initialize file operations handler
         self.file_operations = FileOperationsHandler(
             vm=self._vm,
@@ -207,6 +213,7 @@ class MainWindow(QMainWindow):
             status_reporter=self.status_reporter,
             checked_paths_provider=None,
             highlighted_items_provider=self.tree_controller,
+            task_runner=self._runner,
         )
 
         # Tree data provider for dialog handler
@@ -275,8 +282,9 @@ class MainWindow(QMainWindow):
 
         right_widget, right_layout = self.layout_manager.create_preview_section()
 
-        # Create image task runner and preview pane
-        self._runner = ImageTaskRunner(service=self._img, receiver=self)
+        # Preview pane consumes the runner created in _setup_components
+        # (#165 — runner lifecycle moved up so FileOperationsHandler
+        # can forward it to ExecuteActionDialog's embedded preview).
         self._preview = PreviewPane(right_widget, self._runner, thumb_size=self._thumb_size)
         right_layout.addWidget(self._preview)
 

--- a/app/views/window_state.py
+++ b/app/views/window_state.py
@@ -18,7 +18,7 @@ import os
 from pathlib import Path
 
 from PySide6.QtCore import QRect, QSettings
-from PySide6.QtWidgets import QApplication, QWidget
+from PySide6.QtWidgets import QApplication, QSplitter, QWidget
 
 # Stable QSettings keys for every persistable window-/dialog-geometry
 # blob. Changing any of these silently invalidates the round-trip
@@ -33,6 +33,13 @@ QSETTINGS_KEY_MAIN_SPLITTER_STATE = "geometry/main_splitter"
 QSETTINGS_KEY_COLUMN_HEADER_STATE = "geometry/column_header"
 QSETTINGS_KEY_SCAN_DIALOG_GEOM = "geometry/scan_dialog"
 QSETTINGS_KEY_EXECUTE_ACTION_DIALOG_GEOM = "geometry/execute_action_dialog"
+# Splitter sizes for the in-dialog tree-vs-preview split (#165). Stored
+# separately from the dialog frame geometry because Qt's saveState blob
+# for a QSplitter and saveGeometry blob for a QWidget are independent;
+# round-tripping each via its own helper keeps the contract obvious.
+QSETTINGS_KEY_EXECUTE_ACTION_DIALOG_SPLITTER_STATE = (
+    "geometry/execute_action_dialog_splitter"
+)
 QSETTINGS_KEY_ACTION_DIALOG_GEOM = "geometry/action_dialog"
 QSETTINGS_KEY_SAVE_MANIFEST_DIALOG_GEOM = "geometry/save_manifest_dialog"
 
@@ -124,6 +131,35 @@ def save_widget_geometry(widget: QWidget, key: str) -> None:
     try:
         store = window_state_qsettings()
         store.setValue(key, widget.saveGeometry())
+        store.sync()
+    except Exception:
+        pass
+
+
+def restore_splitter_state(splitter: QSplitter, key: str) -> bool:
+    """Restore ``splitter.saveState()`` bytes saved under ``key``.
+
+    Returns ``True`` when a saved blob existed and was applied,
+    ``False`` when there was no blob or the blob was rejected. Unlike
+    geometry restore there's no off-screen guard — splitter state is a
+    list of pane sizes, not a screen rect.
+    """
+    store = window_state_qsettings()
+    blob = store.value(key)
+    if not blob:
+        return False
+    return bool(splitter.restoreState(blob))
+
+
+def save_splitter_state(splitter: QSplitter, key: str) -> None:
+    """Persist ``splitter.saveState()`` under ``key``.
+
+    Mirrors :func:`save_widget_geometry`: swallow OS-level QSettings
+    failures so a write error never aborts the dialog's close path.
+    """
+    try:
+        store = window_state_qsettings()
+        store.setValue(key, splitter.saveState())
         store.sync()
     except Exception:
         pass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,18 @@ omit = [
   "run_all_linters.py",               # dev tooling shell, not user-facing
   "infrastructure/image_service.py",  # requires running QApplication for decode; covered by qa-explore preview pane (s05)
   "infrastructure/logging.py",        # module-level loguru sink setup; no executable surface beyond import
+  # The four files below are the qa-explore territory of the preview
+  # stack: Qt-widget rendering + QThreadPool dispatch + Qt MediaPlayer
+  # coordination. They are loaded into the layer-1 coverage report the
+  # moment any unit test instantiates ExecuteActionDialog with a
+  # task_runner (#165) — which exercises only constructor + show_single
+  # + clear, well below the 70% per-file floor. Layer-3 covers the
+  # real surface (rendering, fit-on-width, video lifecycle). The
+  # layer-1 cascade is noise (see feedback_test_import_cascade.md).
+  "app/views/preview_pane.py",                       # Qt rendering, image fit + video player wiring; covered by qa-explore s05 (huge preview) + s11 (video live)
+  "app/views/image_tasks.py",                        # QThreadPool dispatch + signal plumbing; covered by qa-explore s05 + s44 (highlighted-rows preview)
+  "app/views/widgets/group_media_controller.py",     # group video play/pause coordinator; covered by qa-explore s11
+  "app/views/widgets/video_player.py",               # QMediaPlayer + QVideoWidget wrapper; covered by qa-explore s11
 ]
 
 [tool.coverage.report]

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -191,6 +191,12 @@ ALL_SCENARIOS = [
     # destructive — just probes that the widgets surface after picking
     # a numeric field, then closes the dialog without applying.
     "s50_select_numeric_panel_from_main_window",
+    # s51 (#165) — Execute Action dialog now embeds a PreviewPane via a
+    # horizontal splitter. Non-destructive: opens the dialog with one
+    # row marked 'delete', clicks the row, asserts that the dialog
+    # contains both a tree and a preview pane visible to UIA, then
+    # cancels without executing.
+    "s51_execute_dialog_preview",
 ]
 
 

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -189,6 +189,12 @@ SCENARIO_SOURCES: dict[str, list[str] | None] = {
     # manifest so the menu item is enabled and ``records_provider``
     # has groups to pass to ActionDialog. Non-destructive.
     "s50_select_numeric_panel_from_main_window": ["qa/sandbox/near-duplicates"],
+    # s51 (#165) — Execute Action dialog now embeds a PreviewPane. Same
+    # near-duplicates fixture as s30/s34/s44: 5 JPEGs in one group is
+    # plenty for opening the dialog, selecting a row, and asserting the
+    # preview surface mounted. Non-destructive — cancels without
+    # executing.
+    "s51_execute_dialog_preview": ["qa/sandbox/near-duplicates"],
 }
 
 

--- a/qa/scenarios/s51_execute_dialog_preview.py
+++ b/qa/scenarios/s51_execute_dialog_preview.py
@@ -1,0 +1,242 @@
+"""Scenario 51 — Execute Action dialog embeds a PreviewPane (#165).
+
+Required source: qa/sandbox/near-duplicates (5 files, basenames
+neardup_NN_qXX.jpg).
+
+The Option-A landing for #165 wraps the Execute Action dialog's review
+tree in a horizontal QSplitter alongside an embedded ``PreviewPane`` so
+users can see what each row looks like before confirming a destructive
+operation. Selection-change wiring + ``show_single`` / ``clear`` calls
+are pinned at layer 1 in
+``tests/test_execute_action_dialog.py::TestExecuteDialogPreviewPane``
+where MagicMock runners satisfy the contract; this scenario is the
+layer-3 confirmation that in a real running app:
+
+  * threading ``task_runner`` from MainWindow → FileOperationsHandler
+    → ExecuteActionDialog actually reaches the dialog,
+  * the preview-enabled branch of ``_build_ui`` actually fires (not
+    silently skipped by a None runner from a refactor regression), and
+  * the dialog's UIA tree exposes the preview pane so a user with a
+    screen reader can perceive it.
+
+Non-destructive — opens the dialog with one row marked 'delete' so the
+Execute button enables and the dialog passes its has-decisions gate,
+then dismisses via Close without clicking Execute.
+
+Sister to s30 / s33 / s34 (Execute Action dialog drivers); same
+fixture, same regex partition machinery.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+from qa.scenarios import _uia
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO / "qa" / "run-manifest.sqlite"
+FIXTURE_NAME_GLOB = "neardup_"
+
+# Mark every row 'delete' so the dialog tree has rows the user can click
+# and the Execute button enables. The actual Execute click never fires
+# in this scenario (we close via Cancel/Close before that).
+DELETE_REGEX = r"neardup_"
+FIELD = "File Name"
+
+# Preview header label text. Lives at ``preview.header`` in translations/en.yml.
+# A drift here (rename in the YAML) would surface as a clear FAIL line —
+# preferable to a silent miss because the marker IS the only thing the
+# scenario can grip onto without inspecting Qt internals.
+PREVIEW_HEADER_TEXT = "Preview"
+
+
+def _read_decisions() -> dict[str, str]:
+    if not MANIFEST_PATH.exists():
+        raise RuntimeError(f"manifest not found at {MANIFEST_PATH}")
+    conn = sqlite3.connect(str(MANIFEST_PATH))
+    try:
+        rows = conn.execute(
+            "SELECT source_path, user_decision FROM migration_manifest "
+            "WHERE source_path LIKE ?",
+            (f"%{FIXTURE_NAME_GLOB}%",),
+        ).fetchall()
+    finally:
+        conn.close()
+    return {Path(p).name: (d or "") for p, d in rows}
+
+
+def _find_preview_header(exec_dlg) -> object | None:
+    """Return the PreviewPane's header QLabel wrapper, or None.
+
+    The header is the only Text/Static descendant whose window text is
+    exactly the preview header constant. Matching by exact equality
+    (not substring) avoids accidentally grabbing a status-bar or
+    summary label that happened to contain the word "Preview".
+    """
+    for ct in ("Text", "Static"):
+        for d in exec_dlg.descendants(control_type=ct):
+            try:
+                txt = (d.window_text() or "").strip()
+            except Exception:
+                continue
+            if txt == PREVIEW_HEADER_TEXT:
+                return d
+    return None
+
+
+def _find_splitter(exec_dlg) -> object | None:
+    """Return the first QSplitter descendant of ``exec_dlg``, or None.
+
+    Pre-#165 the dialog had a flat QVBoxLayout with no splitter; the
+    presence of any QSplitter under the Execute Action dialog is a
+    strong positive signal that the preview-enabled layout actually
+    fired. Matches by class_name='QSplitter' so a wrapper-widget
+    insertion around the splitter doesn't hide it.
+    """
+    for ct in ("Pane", "Group", "Custom"):
+        for d in exec_dlg.descendants(control_type=ct):
+            try:
+                cls = (d.element_info.class_name or "")
+            except Exception:
+                cls = ""
+            if cls == "QSplitter":
+                return d
+    return None
+
+
+def main() -> int:
+    print("scenario: s51_execute_dialog_preview")
+    app, win = _uia.connect_main()
+    pid = win.process_id()
+    print(f"connected: pid={pid} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, _ = _uia.open_scan_dialog(win)
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+    _, win = _uia.connect_main()
+
+    print("step: snapshot_initial")
+    initial = _read_decisions()
+    if not initial:
+        print("FAIL: no fixture rows found in manifest after scan")
+        return 1
+    print(f"  rows={len(initial)}")
+
+    print(f"step: bulk_delete_via_regex regex={DELETE_REGEX!r}")
+    _uia.mark_all_via_regex_standalone(
+        win, field=FIELD, regex=DELETE_REGEX, action_label="delete"
+    )
+    after = _read_decisions()
+    not_deleted = [n for n, d in after.items() if d != "delete"]
+    if not_deleted:
+        print(
+            f"FAIL: bulk delete did not cover every row; missed {not_deleted}"
+        )
+        return 1
+    print(f"  all {len(after)} rows now have user_decision='delete'")
+
+    print("step: open_execute_action_dialog")
+    exec_dlg, _ = _uia.open_execute_action_dialog(win)
+
+    # ── Assert the splitter mounted. Without preview-enabled wiring,
+    # ExecuteActionDialog._build_ui falls back to a flat layout and no
+    # QSplitter would appear among the descendants. ─────────────────────
+    print("step: locate_splitter")
+    splitter = _find_splitter(exec_dlg)
+    if splitter is None:
+        print(
+            "FAIL: no QSplitter descendant in ExecuteActionDialog — "
+            "preview-enabled layout did not fire (task_runner=None?)"
+        )
+        return 1
+    print(f"  splitter_found class={splitter.element_info.class_name!r}")
+
+    # ── Assert the PreviewPane's header label is present in the dialog's
+    # UIA tree. This is what a screen reader would announce when the
+    # user tabs into the preview region. ─────────────────────────────────
+    print("step: locate_preview_header")
+    header = _find_preview_header(exec_dlg)
+    if header is None:
+        print(
+            "FAIL: PreviewPane header label "
+            f"(text={PREVIEW_HEADER_TEXT!r}) not found among dialog "
+            "descendants — preview pane was not mounted"
+        )
+        return 1
+    try:
+        rect = header.rectangle()
+        print(f"  preview_header_rect={rect}")
+    except Exception as exc:
+        print(f"  (could not read header rect: {exc})")
+
+    # ── Click the first file row in the dialog tree to drive
+    # ``_on_selection_changed`` → ``preview.show_single``. We don't try
+    # to assert the rendered image (Qt fills the QLabel pixmap async via
+    # the runner pool); the layer-1 tests already pin that show_single
+    # is called with the right arguments. Here we just verify nothing
+    # crashes between selection and preview update. ─────────────────────
+    print("step: click_first_file_row")
+    file_rows = [
+        d for d in exec_dlg.descendants(control_type="TreeItem")
+    ]
+    if not file_rows:
+        print("FAIL: no TreeItem descendants in Execute Action dialog")
+        return 1
+    # The first descendant TreeItem is the group header; the second is
+    # the first file row. Some Qt versions surface only file rows as
+    # TreeItem and put group headers under "DataItem"; if so, fall
+    # through to whatever the first clickable row is.
+    target_row = file_rows[1] if len(file_rows) > 1 else file_rows[0]
+    print(f"  target_row_text={target_row.window_text()!r}")
+    try:
+        target_row.click_input()
+    except Exception as exc:
+        print(f"FAIL: clicking tree row raised: {exc!r}")
+        return 1
+    # Give the preview pipeline a beat to dispatch the show_single call.
+    # No assertion on rendered pixmap — just confirm the app didn't
+    # crash between click and the next UIA call.
+    time.sleep(0.3)
+
+    # Re-locate the dialog and header — if the click crashed the
+    # window, this would raise. Successful re-locate is the assertion.
+    print("step: post_click_uia_still_responsive")
+    header_after = _find_preview_header(exec_dlg)
+    if header_after is None:
+        print(
+            "FAIL: preview header disappeared after row click — "
+            "dialog likely crashed or detached"
+        )
+        return 1
+
+    print("step: close_execute_action_dialog")
+    close_btn = _uia._find_dialog_button(exec_dlg, "Close")
+    close_btn.click_input()
+    time.sleep(0.3)
+
+    # ── Manifest must still hold the decisions we set — Close does NOT
+    # execute. A regression where Close accidentally fired Execute
+    # would zero out the deleted_paths and may even hit the recycle
+    # bin; pinning the post-Close decision state guards against that.
+    post_close = _read_decisions()
+    if post_close != after:
+        print(
+            "FAIL: manifest decisions changed after Close (should be "
+            f"a no-op); pre={after} post={post_close}"
+        )
+        return 1
+
+    print("scenario: s51_execute_dialog_preview DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_execute_action_dialog.py
+++ b/tests/test_execute_action_dialog.py
@@ -1583,3 +1583,171 @@ class TestExecuteHighlightedRows:
                 dlg._on_execute_requested()
 
         q.assert_called_once()
+
+
+# ── #165 — embedded PreviewPane wiring ─────────────────────────────────────
+
+class TestExecuteDialogPreviewPane:
+    """#165 — when a ``task_runner`` is threaded through the dialog
+    constructor, the tree is wrapped in a horizontal splitter alongside
+    an embedded ``PreviewPane`` and selection changes drive the preview.
+    With no runner (existing default), the dialog must keep the original
+    single-column layout untouched — every pre-#165 caller still works.
+    """
+
+    @staticmethod
+    def _mock_runner():
+        """Return a MagicMock that satisfies ``PreviewPane``'s contract.
+
+        ``PreviewPane.show_single`` may call ``request_single_preview``
+        on the runner; a plain MagicMock will return a Mock for that
+        method call without raising. We don't actually load any images
+        in unit tests — the assertion target is the dialog's wiring,
+        not the runner's behaviour."""
+        from unittest.mock import MagicMock
+        return MagicMock()
+
+    @staticmethod
+    def _find_file_index(dlg, path: str):
+        # Mirrors the helper in TestExecuteHighlightedRows so this
+        # class can stand alone if reordered.
+        from PySide6.QtCore import QModelIndex
+        from app.views.constants import COL_NAME, PATH_ROLE
+        model = dlg._tree.model()
+        if model is None:
+            return QModelIndex()
+        for grow in range(model.rowCount()):
+            gidx = model.index(grow, 0)
+            for frow in range(model.rowCount(gidx)):
+                fidx = model.index(frow, COL_NAME, gidx)
+                if fidx.data(PATH_ROLE) == path:
+                    return fidx
+        return QModelIndex()
+
+    @classmethod
+    def _select(cls, dlg, paths: list[str]) -> None:
+        from PySide6.QtCore import QItemSelectionModel
+        sel = dlg._tree.selectionModel()
+        sel.clear()
+        for p in paths:
+            idx = cls._find_file_index(dlg, p)
+            assert idx.isValid(), f"file row for {p!r} not in tree"
+            sel.select(idx, QItemSelectionModel.Select | QItemSelectionModel.Rows)
+
+    def test_ctor_with_runner_builds_preview_and_splitter(self, qapp):
+        """Threading a runner through the constructor must materialise
+        the preview pane + splitter. The pre-#165 single-column layout
+        only checks for the tree; this catches a regression where the
+        runner was accepted but ignored."""
+        from PySide6.QtWidgets import QSplitter
+        from app.views.dialogs.execute_action_dialog import ExecuteActionDialog
+        from app.views.preview_pane import PreviewPane
+
+        groups = [_group(_rec("/a.jpg", "delete"))]
+        dlg = ExecuteActionDialog(
+            groups, manifest_path=None, task_runner=self._mock_runner()
+        )
+        assert isinstance(dlg._preview, PreviewPane)
+        assert isinstance(dlg._splitter, QSplitter)
+        # Tree must be inside the splitter, not in the root layout, or
+        # the user's resize won't actually change anything.
+        assert dlg._splitter.indexOf(dlg._tree) >= 0
+        assert dlg._splitter.indexOf(dlg._preview) >= 0
+
+    def test_ctor_without_runner_keeps_single_column_layout(self, qapp):
+        """Existing callers that don't pass a runner must still get the
+        pre-#165 layout — no preview, no splitter. Catches the breaking-
+        change-by-default regression that would silently surface a half-
+        built preview pane to callers that have no runner to give it."""
+        from app.views.dialogs.execute_action_dialog import ExecuteActionDialog
+        groups = [_group(_rec("/a.jpg", "delete"))]
+        dlg = ExecuteActionDialog(groups, manifest_path=None)
+        assert dlg._preview is None
+        assert dlg._splitter is None
+
+    def test_selecting_single_row_calls_show_single_with_path_and_info(self, qapp):
+        """The selection-change handler must call ``preview.show_single``
+        with the row's file path and an info dict that at minimum
+        carries ``name`` and ``folder`` derived from the path. Catches
+        the silent miswiring where the signal connects but the preview
+        never updates because the wrong index is read."""
+        import os
+        from unittest.mock import patch
+        from app.views.dialogs.execute_action_dialog import ExecuteActionDialog
+
+        path = "/some/folder/a.jpg"
+        groups = [_group(_rec(path, "delete"))]
+        dlg = ExecuteActionDialog(
+            groups, manifest_path=None, task_runner=self._mock_runner()
+        )
+        with patch.object(dlg._preview, "show_single") as show_single:
+            self._select(dlg, [path])
+        assert show_single.called
+        call_path, call_info = show_single.call_args[0]
+        assert call_path == path
+        assert call_info["name"] == os.path.basename(path)
+        assert call_info["folder"] == os.path.dirname(path)
+
+    def test_selecting_zero_or_multi_rows_clears_preview(self, qapp):
+        """Multi-select would be ambiguous ("which file?"), and empty
+        selection should leave nothing showing. Both must call
+        ``preview.clear()`` rather than leaving stale state."""
+        from unittest.mock import patch
+        from app.views.dialogs.execute_action_dialog import ExecuteActionDialog
+
+        groups = [_group(_rec("/a.jpg", "delete"), _rec("/b.jpg", "delete"))]
+        dlg = ExecuteActionDialog(
+            groups, manifest_path=None, task_runner=self._mock_runner()
+        )
+        # Multi-select → clear (not "first row wins").
+        with patch.object(dlg._preview, "clear") as clear_multi:
+            self._select(dlg, ["/a.jpg", "/b.jpg"])
+        assert clear_multi.called
+        # Empty selection → clear.
+        with patch.object(dlg._preview, "clear") as clear_empty:
+            dlg._tree.selectionModel().clear()
+        assert clear_empty.called
+
+    def test_splitter_state_persists_across_dialog_instances(
+        self, qapp, monkeypatch, tmp_path
+    ):
+        """Open dlg, resize the splitter, close, reopen → divider
+        position must round-trip. The off-screen-guard helpers don't
+        apply to splitter state (no screen rect), so this confirms the
+        save/restore wiring on its own — separate from the dialog's
+        geometry persistence covered in test_window_state.py."""
+        # Isolate QSettings to a tmp INI so the test never touches the
+        # real window_state.ini. Mirrors the isolated_qsettings fixture
+        # in tests/test_window_state.py (anchored at repo root because
+        # PHOTO_MANAGER_HOME is resolved relative to it).
+        from app.views.dialogs.execute_action_dialog import ExecuteActionDialog
+        from app.views.window_state import qsettings_path
+        monkeypatch.setenv("PHOTO_MANAGER_HOME", str(tmp_path.name))
+        repo_root = qsettings_path().parent
+        repo_root.mkdir(parents=True, exist_ok=True)
+        ini = qsettings_path()
+        if ini.exists():
+            ini.unlink()
+
+        groups = [_group(_rec("/a.jpg", "delete"))]
+
+        runner = self._mock_runner()
+        dlg_a = ExecuteActionDialog(
+            groups, manifest_path=None, task_runner=runner
+        )
+        # Force a specific divider position then close → triggers save.
+        dlg_a._splitter.setSizes([700, 300])
+        sizes_a = dlg_a._splitter.sizes()
+        dlg_a.done(0)
+
+        dlg_b = ExecuteActionDialog(
+            groups, manifest_path=None, task_runner=runner
+        )
+        sizes_b = dlg_b._splitter.sizes()
+        # Qt may pixel-adjust by 1 for borders; compare with tolerance.
+        assert len(sizes_a) == len(sizes_b) == 2
+        for a, b in zip(sizes_a, sizes_b):
+            assert abs(a - b) <= 2, f"splitter sizes drifted: {sizes_a} → {sizes_b}"
+
+        if ini.exists():
+            ini.unlink()

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -1276,6 +1276,40 @@ class TestEntryPointGuards:
         info.assert_called_once()
         assert "No manifest open" in info.call_args[0][2]
 
+    def test_execute_action_threads_task_runner_to_dialog(self):
+        """#165 — the handler must forward its ``task_runner`` to
+        ``ExecuteActionDialog`` so the dialog's embedded PreviewPane can
+        render previews. Silent drop here would surface as a no-op
+        preview pane in production with no error to trace it back."""
+        from app.views.handlers.file_operations import FileOperationsHandler
+
+        runner = MagicMock(name="image_task_runner")
+        vm = SimpleNamespace(
+            groups=[],
+            remove_deleted_and_prune=MagicMock(),
+            remove_from_list=MagicMock(),
+        )
+        handler = FileOperationsHandler(
+            vm=vm, settings=MagicMock(), parent_widget=MagicMock(),
+            ui_updater=MagicMock(), status_reporter=MagicMock(),
+            task_runner=runner,
+        )
+        handler._manifest_path = "/tmp/fake.sqlite"
+
+        # Patch the class symbol that file_operations imports lazily
+        # inside execute_action. The dialog instance is mocked so we
+        # don't drive into Qt — we're checking the construction kwargs.
+        with patch(
+            "app.views.dialogs.execute_action_dialog.ExecuteActionDialog"
+        ) as DlgCls:
+            DlgCls.return_value.exec.return_value = 0
+            DlgCls.return_value.removed_from_list_paths = []
+            DlgCls.return_value.deleted_paths = []
+            DlgCls.return_value.executed_paths = []
+            handler.execute_action()
+
+        assert DlgCls.call_args.kwargs["task_runner"] is runner
+
 
 # ── Item 2 — dirty-tracking flag + silent save ─────────────────────────────
 


### PR DESCRIPTION
## Summary

- Embeds the existing `PreviewPane` into `ExecuteActionDialog` via a horizontal `QSplitter` so users can see what each file looks like before confirming destructive ops. Same `PreviewPane` class as the main window — no DRY duplication.
- `task_runner` kwarg on the dialog is optional (default `None`): existing callers and tests fall back to the pre-#165 single-column layout unchanged. New tests cover the runner-present branch explicitly.
- Splitter divider position persists across opens via new `save_splitter_state` / `restore_splitter_state` helpers in `window_state.py` (Qt `saveState` bytes are distinct from `saveGeometry`, so they need their own key).
- Threading: `ImageTaskRunner` is now constructed in `MainWindow._setup_components` (moved from `_setup_ui`) so `FileOperationsHandler` can forward it through to the dialog. The main-window `PreviewPane` reuses the same runner instance — no second runner is created.

## Out of scope (deliberately deferred)

- Issue #68 (failure-bucket split) — same dialog, separate PR per the planning notes on #165.
- `info` dict passed to `show_single` is minimal (`name` + `folder`); size / creation / shot can come later if the preview feels thin.

## Coverage notes

Four GUI-heavy files (`preview_pane.py`, `image_tasks.py`, `group_media_controller.py`, `video_player.py`) now get pulled into the layer-1 coverage report by the new tests that instantiate a real `PreviewPane`. They've been added to `[tool.coverage.run] omit` in `pyproject.toml` with qa-explore coverage pointers — same pattern as the existing `image_service.py` entry, and consistent with the `feedback_test_import_cascade` guidance to keep test-cascade noise out of the layer-1 floor.

## Test plan

- [x] `pytest` full suite: 1212 passed, 2 skipped, 88.35 % global coverage
- [x] `scripts/check_coverage_per_file.py`: all 49 tracked files clear the 70 % per-file floor
- [x] `pytest tests/test_execute_action_dialog.py::TestExecuteDialogPreviewPane`: 5 new layer-1 tests cover constructor wiring (with + without runner), selection → `show_single` with path + info dict, multi/empty select → `clear`, splitter round-trip across instances
- [x] `pytest tests/test_file_operations.py`: extended `TestEntryPointGuards` to assert `task_runner` is forwarded to the dialog
- [x] Layer-3 scenario `s51_execute_dialog_preview`: confirms `QSplitter` mounts in the live dialog, the preview header is reachable via UIA, row-click doesn't crash, Close is non-destructive
- [ ] Manual smoke: launch app, scan, set decisions, open Execute Action, click rows, confirm preview updates and divider survives reopen

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)