### PR TITLE
docs(features): backfill full app behaviour + README audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,13 @@ window) showing all groups for final review.
 All decision changes are batch-persisted to SQLite in a single transaction
 immediately before execution.
 
+For the full Execute Action feature surface — lock-confirm dialog,
+preview pane, dialog geometry persistence, all-delete jump-to banner,
+scope-to-highlighted-rows — and for every other user-visible flow in
+the app, see [`docs/features.md`](docs/features.md). This Step 1-4
+walkthrough is the onboarding path; `docs/features.md` is the
+canonical catalogue.
+
 ---
 
 ## Classification rules

--- a/docs/features.md
+++ b/docs/features.md
@@ -8,10 +8,12 @@ This file is the answer to "is this behaviour documented?" and
 "what's the expected UX for X?". It complements — does not replace —
 the happy-path walkthrough in [`README.md` § Usage — GUI](../README.md#usage--gui).
 
-**This is PR A — schema validation against the Execute Action cluster.**
-PR B will backfill the rest of the app (scan, review, save/load,
-preview, i18n). PR C will harden `docs_guard` to enforce updates here
-whenever user-visible behaviour changes.
+The full backfill ships in two stages: [PR #263](https://github.com/jackal998/photo-manager/pull/263)
+seeded the Execute Action cluster; this PR completes the inventory
+(scan, review, save/load, preview, i18n). A follow-up PR will harden
+`docs_guard` to require an update here whenever user-visible
+behaviour changes — see [#262](https://github.com/jackal998/photo-manager/issues/262)
+for the chore plan.
 
 ---
 
@@ -19,6 +21,12 @@ whenever user-visible behaviour changes.
 
 | Feature | Area |
 |---|---|
+| [Bulk regex — remove from list (deferred decision)](#bulk-regex--remove-from-list-deferred-decision) | Bulk operations |
+| [Context menu — Lock / Unlock](#context-menu--lock--unlock) | Context menu |
+| [Context menu — Open Folder](#context-menu--open-folder) | Context menu |
+| [Context menu — Set Action (per-file)](#context-menu--set-action-per-file) | Context menu |
+| [Empty area context menu](#empty-area-context-menu) | Context menu |
+| [Empty-state action buttons](#empty-state-action-buttons) | Main window |
 | [Execute Action — base flow](#execute-action--base-flow) | Execute Action |
 | [Execute Action — complete-group delete confirm](#execute-action--complete-group-delete-confirm) | Execute Action |
 | [Execute Action — complete-group warning banner with jump-to](#execute-action--complete-group-warning-banner-with-jump-to) | Execute Action |
@@ -26,6 +34,95 @@ whenever user-visible behaviour changes.
 | [Execute Action — lock-confirm dialog](#execute-action--lock-confirm-dialog) | Execute Action |
 | [Execute Action — preview pane](#execute-action--preview-pane) | Execute Action |
 | [Execute Action — scope to highlighted rows](#execute-action--scope-to-highlighted-rows) | Execute Action |
+| [Exit dirty-flag prompt](#exit-dirty-flag-prompt) | Main window |
+| [Keep-worthiness scoring](#keep-worthiness-scoring) | Review |
+| [Language switch](#language-switch) | i18n |
+| [List menu — Remove from List](#list-menu--remove-from-list) | Menus |
+| [Log menu](#log-menu) | Menus |
+| [Main window — column order/width persistence](#main-window--column-orderwidth-persistence) | Main window |
+| [Main window — geometry + splitter persistence](#main-window--geometry--splitter-persistence) | Main window |
+| [Main window — keyboard navigation](#main-window--keyboard-navigation) | Main window |
+| [Main window — results tree double-click](#main-window--results-tree-double-click) | Main window |
+| [Main window — sort persistence within session](#main-window--sort-persistence-within-session) | Main window |
+| [Main window — status bar baseline](#main-window--status-bar-baseline) | Main window |
+| [Open Manifest — base flow](#open-manifest--base-flow) | File operations |
+| [Save Manifest Decisions — base flow](#save-manifest-decisions--base-flow) | File operations |
+| [Scan dialog — auto-select after scan](#scan-dialog--auto-select-after-scan) | Scan |
+| [Scan dialog — collapse Advanced Settings](#scan-dialog--collapse-advanced-settings) | Scan |
+| [Scan dialog — folder list (no priority arrows)](#scan-dialog--folder-list-no-priority-arrows) | Scan |
+| [Scan dialog — multi-source scan](#scan-dialog--multi-source-scan) | Scan |
+| [Scan flow — rescan confirm](#scan-flow--rescan-confirm) | Scan |
+| [Scan flow — visual selection of KEEP rows after scan](#scan-flow--visual-selection-of-keep-rows-after-scan) | Scan |
+| [Set Action dialog — Beginner / Regex mode toggle](#set-action-dialog--beginner--regex-mode-toggle) | Set Action dialog |
+| [Set Action dialog — live preview + validation](#set-action-dialog--live-preview--validation) | Set Action dialog |
+| [Set Action dialog — numeric comparison panel](#set-action-dialog--numeric-comparison-panel) | Set Action dialog |
+| [Set Action dialog — Score / Lock / Resolution fields](#set-action-dialog--score--lock--resolution-fields) | Set Action dialog |
+
+---
+
+### Bulk regex — remove from list (deferred decision)
+
+- **Entry point:** Set Action dialog's action dropdown — `settable_decisions(include_remove=True)` at [app/views/constants.py:97](../app/views/constants.py#L97).
+- **Trigger:** In the Set Action dialog (opened from main window menu or right-click), pick "remove from list" as the action and Apply.
+- **Behaviour:** Matched rows get `user_decision='remove_from_list'` set (a third decision value alongside `delete` and `keep`), displayed in the Action column via a localised label. Files are not moved or deleted — rows are reviewed in Execute Action like delete/keep decisions and the actual removal (flag as removed in the manifest, drop from the view) happens at execute time. Single-row right-click in the Execute Action dialog stays IMMEDIATE with its own confirm — that path is set + execute on one click, which is intentionally distinct from the bulk deferred path.
+- **Conditions / variants:** The `remove from list` entry appears in the dropdown only when `include_remove=True` is passed (currently the regex dialog and the Execute Action dialog's right-click submenu). The main-window right-click submenu omits it because it already has a top-level **List > Remove from List** item.
+- **Related:** [PR #158](https://github.com/jackal998/photo-manager/pull/158); QA scenario [`qa/scenarios/s29_remove_from_list_by_regex.py`](../qa/scenarios/s29_remove_from_list_by_regex.py); related multi-select flow [`qa/scenarios/s20_multi_remove_from_list.py`](../qa/scenarios/s20_multi_remove_from_list.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Context menu — Lock / Unlock
+
+- **Entry point:** Right-click submenu on file rows in the main result tree — `app/views/handlers/context_menu.py`. Also surfaces in the Execute Action dialog's right-click menu and as Lock/Unlock sentinels in the regex dialog action dropdown (`include_lock=True`).
+- **Trigger:** User right-clicks a file row (single or multi-select) and picks **Lock** or **Unlock**.
+- **Behaviour:** Flips the orthogonal `is_locked` flag on each selected row's manifest record. Locked rows display the 🔒 prefix in the Lock column and freeze their `user_decision` against bulk-regex changes and against execute-time deletion (the lock-confirm dialog gates any attempted change — see [Execute Action — lock-confirm dialog](#execute-action--lock-confirm-dialog)).
+- **Conditions / variants:** Lock and Unlock are always idempotent — they never surface the lock-confirm dialog themselves. They are the escape valve for the freeze semantic.
+- **Related:** [PR #175](https://github.com/jackal998/photo-manager/pull/175) (closes [#164](https://github.com/jackal998/photo-manager/issues/164)); QA scenario [`qa/scenarios/s35_lock_via_context_menu.py`](../qa/scenarios/s35_lock_via_context_menu.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Context menu — Open Folder
+
+- **Entry point:** Right-click submenu on file rows in the main result tree — shared `app/views/handlers/file_opener.py` (extracted from `context_menu.py` in [PR #198](https://github.com/jackal998/photo-manager/pull/198)).
+- **Trigger:** User right-clicks a file row and picks **Open Folder**.
+- **Behaviour:** Opens the file's containing directory in the OS file manager with the file pre-selected (on Windows, `explorer /select,<path>`; on other platforms, falls back to `QDesktopServices.openUrl` on the parent directory).
+- **Conditions / variants:** The same OS-aware impl is reused by the file-row double-click handler (see [Main window — results tree double-click](#main-window--results-tree-double-click)) — one canonical Open Folder cascade rather than two divergent copies.
+- **Related:** Originally part of the [PR #19](https://github.com/jackal998/photo-manager/pull/19) context-menu redesign; extracted into a shared helper in [PR #198](https://github.com/jackal998/photo-manager/pull/198). QA scenario [`qa/scenarios/s19_context_menu_open_folder.py`](../qa/scenarios/s19_context_menu_open_folder.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Context menu — Set Action (per-file)
+
+- **Entry point:** Right-click submenu on file rows in the main result tree — [app/views/handlers/context_menu.py](../app/views/handlers/context_menu.py).
+- **Trigger:** User right-clicks a file row (single or multi-select) and picks **Set Action > delete / keep / remove from list**.
+- **Behaviour:** Sets `user_decision` on each selected row to the chosen value. Multi-select applies the same decision to every selected row in one batch. For multi-select with locked rows in the set, the lock-confirm dialog gates the write (see [Execute Action — lock-confirm dialog](#execute-action--lock-confirm-dialog)).
+- **Conditions / variants:** Single-row right-click also offers **Set Action by Field/Regex…** (multi-select got that entry too in [PR #162](https://github.com/jackal998/photo-manager/pull/162) — parity with single-select). The "remove from list" entry behaves differently per context: from the main-window submenu it's the same deferred decision as the bulk path; from the Execute Action dialog's single-row right-click it's IMMEDIATE (set + execute on one click).
+- **Related:** Foundation in [PR #19](https://github.com/jackal998/photo-manager/pull/19); QA scenario [`qa/scenarios/s15_context_menu.py`](../qa/scenarios/s15_context_menu.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Empty area context menu
+
+- **Entry point:** Right-click on the empty area of the main result tree (below the loaded rows).
+- **Trigger:** User right-clicks a non-row area of the tree.
+- **Behaviour:** Surfaces a context menu with global tree-actions (rather than the per-row Set Action menu). Distinct from the per-row menu so the user always gets the relevant actions for what they actually clicked.
+- **Conditions / variants:** Available regardless of whether any rows are selected.
+- **Related:** QA scenario [`qa/scenarios/s25_empty_area_context_menu.py`](../qa/scenarios/s25_empty_area_context_menu.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Empty-state action buttons
+
+- **Entry point:** Two `QPushButton` primary actions next to the first-run hint label in the main window — [app/views/components/empty_state.py](../app/views/components/empty_state.py).
+- **Trigger:** Pre-manifest state — visible on every launch where no manifest has been loaded yet.
+- **Behaviour:** **Scan Sources…** opens the Scan dialog (same end-state as **File > Scan Sources…**); **Open Manifest…** opens the native Open Manifest file picker (same end-state as **File > Open Manifest…**). Button labels are pulled from the same translation keys as the matching menu items, so they stay in sync across locales.
+- **Conditions / variants:** The whole label-plus-buttons widget hides atomically once `refresh_tree` sees a loaded manifest. Preserves the pre-#137 contract that the empty state vanishes the moment data lands.
+- **Related:** [PR #197](https://github.com/jackal998/photo-manager/pull/197) (closes [#137](https://github.com/jackal998/photo-manager/issues/137)); QA scenario [`qa/scenarios/s41_empty_state_action_buttons.py`](../qa/scenarios/s41_empty_state_action_buttons.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
 
 ---
 
@@ -102,6 +199,259 @@ whenever user-visible behaviour changes.
 - **Behaviour:** Execute button label tracks the selection — `Execute` ↔ `Execute Action (highlighted)` — and clicking it processes ONLY the highlighted rows' decisions. Empty selection preserves the pre-#211 "execute every decided row" semantics. Lock guard narrows with scope: locked rows OUTSIDE the highlight don't fire `LockedRowsConfirmDialog`; locked rows INSIDE the highlight still do (scope narrows, never skips).
 - **Conditions / variants:** Complete-group "ALL files will be deleted" confirm only fires when the highlighted scope fully covers a group's delete-decision rows. Partial selections suppress that confirm so the "EVERY file deleted" copy stays accurate. The selection listener must be re-wired on every `_rebuild_tree_model` because `QTreeView.setModel` installs a fresh `QItemSelectionModel`.
 - **Related:** [PR #219](https://github.com/jackal998/photo-manager/pull/219) (closes [#211](https://github.com/jackal998/photo-manager/issues/211)); QA scenario [`qa/scenarios/s44_execute_highlighted_rows.py`](../qa/scenarios/s44_execute_highlighted_rows.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Exit dirty-flag prompt
+
+- **Entry point:** `MainWindow.closeEvent` reads `FileOperationsHandler._is_dirty`.
+- **Trigger:** User closes the app (X button, Alt+F4, File > Exit) after making decision changes that haven't been explicitly saved via Save Manifest Decisions.
+- **Behaviour:** A 3-button `QMessageBox` appears — **Save & leave** silently saves to the loaded manifest path then exits; **Leave** exits without an additional save; **Back** stays in the app (the default, so accidental Esc/Enter keeps the user in place). Decisions auto-persist to the loaded manifest as soon as they're set, so **Leave** never loses data — the prompt is purely about offering an explicit save (e.g. before a Save-As to another path).
+- **Conditions / variants:** Dirty flag flips on `set_decision`, `remove_items_from_list`, and `remove_from_list_toolbar`. It clears on manifest load, save, silent save, and successful execute — so a fresh manifest with no changes never triggers the prompt.
+- **Related:** [PR #158](https://github.com/jackal998/photo-manager/pull/158); QA scenario [`qa/scenarios/s28_exit_dirty_prompt.py`](../qa/scenarios/s28_exit_dirty_prompt.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Keep-worthiness scoring
+
+- **Entry point:** Score column (COL_SCORE at index 2) in the main result tree — [app/views/constants.py:22](../app/views/constants.py#L22). Within-group rows sort by score descending so the best copy lands at the top of every group.
+- **Trigger:** Every scanned file gets a score automatically — no user action needed. The score lands in the manifest at scan time. Re-scoring without re-scanning is available via `ManifestRepository.rescore(weights)`.
+- **Behaviour:** Composite score in `[0.0, 1.0]` measuring how "keep-worthy" each file is, computed as a pure function of file attributes (no user-intent signals). Two-tier algorithm: tier 1 absolute penalties (format, `xmpMM:DerivedFrom`); tier 2 weighted composite of eight continuous signals (resolution, EXIF completeness, date provenance, filename, GPS, path, Live Photo, file size). Live Photo MOV passengers get `score = NULL` and are skipped by ranking — they inherit the paired HEIC's decision.
+- **Conditions / variants:** The previous "Apply best-copy decisions to this group" right-click action was removed in [PR #224](https://github.com/jackal998/photo-manager/pull/224) (closes [#210](https://github.com/jackal998/photo-manager/issues/210)) because it was superseded by the regex dialog's "top 1 by score within group" numeric condition (see [Set Action dialog — numeric comparison panel](#set-action-dialog--numeric-comparison-panel)). Auto-select after scan (see [Scan dialog — auto-select after scan](#scan-dialog--auto-select-after-scan)) is the third surface that consumes scoring.
+- **Related:** Cluster originated in [#187](https://github.com/jackal998/photo-manager/issues/187): [PR #199](https://github.com/jackal998/photo-manager/pull/199), [#200](https://github.com/jackal998/photo-manager/pull/200), [#202](https://github.com/jackal998/photo-manager/pull/202), [#203](https://github.com/jackal998/photo-manager/pull/203), [#204](https://github.com/jackal998/photo-manager/pull/204), [#205](https://github.com/jackal998/photo-manager/pull/205), [#206](https://github.com/jackal998/photo-manager/pull/206); QA scenario [`qa/scenarios/s42_scoring.py`](../qa/scenarios/s42_scoring.py). Algorithm details in [README.md § Keep-worthiness scoring](../README.md#keep-worthiness-scoring-187).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Language switch
+
+- **Entry point:** Main window menu → **View > Language** submenu — built by `menu_controller.py` via `QActionGroup(exclusive=True)`.
+- **Trigger:** User picks a locale from the Language submenu.
+- **Behaviour:** A Yes/No confirm prompt appears. On Yes the `MainWindow` rebuilds in place via the same factory used at startup — no app restart needed. State preserved best-effort: window geometry, splitter sizes, selected row's path. The chosen locale persists to `settings.json` under `ui.locale`.
+- **Conditions / variants:** Available locales are discovered from `translations/<code>.yml` files. Each new YAML file appearing alongside `en.yml` shows up automatically in the picker on the next launch (no enum to update). Adding a new locale: copy `en.yml` → `<code>.yml`, translate values, restart once. Picking the already-active locale is a no-op (no confirm fires).
+- **Related:** [PR #157](https://github.com/jackal998/photo-manager/pull/157); QA scenario [`qa/scenarios/s22_language_switch.py`](../qa/scenarios/s22_language_switch.py); translator workflow in [`docs/i18n.md`](i18n.md).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### List menu — Remove from List
+
+- **Entry point:** Main window menu → **List > Remove from List** — handler at `MainWindow._remove_from_list_toolbar`.
+- **Trigger:** User selects one or more rows in the main tree and picks **List > Remove from List**.
+- **Behaviour:** Drops the selected rows from the in-memory view and queues them for removal from the manifest on save. Flips the dirty flag (see [Exit dirty-flag prompt](#exit-dirty-flag-prompt)). This is the immediate "drop from view" path — distinct from the bulk regex deferred decision (see [Bulk regex — remove from list (deferred decision)](#bulk-regex--remove-from-list-deferred-decision)).
+- **Conditions / variants:** Works with single or multi-select. Lock-aware via the standard `set_decision_with_lock_check` route (locked rows trigger the lock-confirm dialog).
+- **Related:** Originally [PR #158](https://github.com/jackal998/photo-manager/pull/158); QA scenarios [`qa/scenarios/s20_multi_remove_from_list.py`](../qa/scenarios/s20_multi_remove_from_list.py), [`qa/scenarios/s21_list_menu_remove.py`](../qa/scenarios/s21_list_menu_remove.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Log menu
+
+- **Entry point:** Main window menu → **Log** — labels in [translations/en.yml:36-41](../translations/en.yml#L36).
+- **Trigger:** User picks one of: **Open Latest Log**, **Open Latest Delete Log**, **Open Log Directory**, **Open Delete Log Directory**.
+- **Behaviour:** Opens the corresponding log file or directory in the OS default application / file manager. "Latest log" resolves to the most recently rotated `loguru` log file; "delete log" resolves to the audit CSV that `delete_service` writes on every Execute Action run.
+- **Conditions / variants:** Log directory path comes from `infrastructure/logging.py` configuration. If no log file has been written yet (first run before any logging fires) the "Open Latest" entries open the directory instead.
+- **Related:** QA scenario [`qa/scenarios/s18_log_menu.py`](../qa/scenarios/s18_log_menu.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Main window — column order/width persistence
+
+- **Entry point:** Tree header drag/resize signals in `MainWindow`, persisting to `QSettings` via the helpers in [app/views/window_state.py](../app/views/window_state.py).
+- **Trigger:** User drags a column header to reorder or resizes a column boundary.
+- **Behaviour:** Saves the new column order and widths on every drag/resize signal — not only at `closeEvent` — so the layout survives force-quits and OS-level kills, not just clean exits. Re-applies on launch.
+- **Conditions / variants:** Persisted alongside main-window geometry under `PHOTO_MANAGER_HOME` (when set) so QA scenarios and dev runs stay isolated from any installed-app state.
+- **Related:** [PR #227](https://github.com/jackal998/photo-manager/pull/227) (closes [#214](https://github.com/jackal998/photo-manager/issues/214)); QA scenario [`qa/scenarios/s47_column_layout_persist.py`](../qa/scenarios/s47_column_layout_persist.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Main window — geometry + splitter persistence
+
+- **Entry point:** `MainWindow.closeEvent` saves geometry; the matching restore runs in `__init__`. Shared helpers in [app/views/window_state.py](../app/views/window_state.py).
+- **Trigger:** Window position, size, maximize state, and splitter ratio round-trip on every clean exit and restore on the next launch.
+- **Behaviour:** Geometry stored under QSettings key `geometry/main_window` (`saveGeometry()` bytes); splitter state under `geometry/main_splitter` (`saveState()` bytes). Stored under `PHOTO_MANAGER_HOME` when set; otherwise under repo root in `window_state.ini`. The splitter also enforces a 200 px floor on each pane and disables collapse, so the preview pane can no longer be squeezed to invisibility ([#136](https://github.com/jackal998/photo-manager/issues/136)).
+- **Conditions / variants:** Position tolerance on round-trip is ~50–60 px on Win10 due to DWM's invisible-frame extension and high-DPI rcNormalPosition rounding — the contract is "reopens where it was," not pixel-perfect. Off-screen guard (rect <25% visible on any connected screen) falls back to widget defaults.
+- **Related:** [PR #191](https://github.com/jackal998/photo-manager/pull/191) (closes [#141](https://github.com/jackal998/photo-manager/issues/141), [#136](https://github.com/jackal998/photo-manager/issues/136)); QA scenario [`qa/scenarios/s39_window_geometry_persist.py`](../qa/scenarios/s39_window_geometry_persist.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Main window — keyboard navigation
+
+- **Entry point:** Main result tree's built-in `QTreeView` keyboard handling, augmented in [tree_controller.py](../app/views/handlers/tree_controller.py).
+- **Trigger:** User presses arrow keys / Home / End / Page Up / Page Down with the tree focused.
+- **Behaviour:** Navigate rows with arrow keys; expand/collapse groups with Left/Right at group-header rows. Selected row is preserved across model rebuilds (e.g. after a decision change) so keyboard-driven review doesn't lose place.
+- **Conditions / variants:** Multi-select works with Shift+arrow and Ctrl+click as in the standard Qt tree behaviour. The selection model is preserved across `setModel` calls so the highlighted row survives a tree refresh.
+- **Related:** QA scenario [`qa/scenarios/s26_keyboard_navigation.py`](../qa/scenarios/s26_keyboard_navigation.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Main window — results tree double-click
+
+- **Entry point:** `TreeController` double-click dispatcher — [tree_controller.py](../app/views/handlers/tree_controller.py) (dispatcher added in [PR #198](https://github.com/jackal998/photo-manager/pull/198)).
+- **Trigger:** User double-clicks a row in the main result tree.
+- **Behaviour:** **File row** → opens the file in the OS default viewer (`QDesktopServices.openUrl`). **Group header row** → toggles expand/collapse for that group. Qt's built-in `setExpandsOnDoubleClick` is disabled so the toggle path doesn't race the default expansion behaviour.
+- **Conditions / variants:** The OS-spawn branch for files is layer-1 covered only — spawning a real viewer has no deterministic close-trigger across image apps. The Open Folder cascade is shared with the context menu via [app/views/handlers/file_opener.py](../app/views/handlers/file_opener.py).
+- **Related:** [PR #198](https://github.com/jackal998/photo-manager/pull/198) (closes [#143](https://github.com/jackal998/photo-manager/issues/143)); QA scenario [`qa/scenarios/s40_results_tree_double_click.py`](../qa/scenarios/s40_results_tree_double_click.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Main window — sort persistence within session
+
+- **Entry point:** Header-click handler — `MainWindow._on_header_clicked` ([app/views/main_window.py:806](../app/views/main_window.py#L806)) stashes `(logical_index, order)` on the `TreeController`. `TreeController.refresh_model` ([tree_controller.py:225](../app/views/handlers/tree_controller.py#L225)) replays the stashed state on every model rebuild.
+- **Trigger:** User clicks a column header to change sort field/direction.
+- **Behaviour:** Within the session, the chosen sort survives every model rebuild — a File → Open Manifest, a decision change, an execute run — without reverting to defaults. Within-group rows always sort by score descending first (the keep-worthiness ranking), with the user's column sort layered on top.
+- **Conditions / variants:** The across-launch surface (writing the sort state to `window_state.ini` so a fresh process restores it) is **not** implemented today — sort resets on app restart. Tracked separately from the within-session persistence.
+- **Related:** [#121](https://github.com/jackal998/photo-manager/issues/121); QA scenario [`qa/scenarios/s45_sort_persistence.py`](../qa/scenarios/s45_sort_persistence.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Main window — status bar baseline
+
+- **Entry point:** Persistent `QLabel` attached to `QStatusBar` via `addWidget` in `MainWindow`.
+- **Trigger:** Always present — never expires. Temporary action toasts (`showMessage(text, timeout)`) layer on top.
+- **Behaviour:** The baseline label always shows a resting message ("Ready" on startup, "Loaded manifest: <parts>" after a load). Qt's hide-during-temp / show-after-clear semantics fall back to the label so the bar never goes blank after a transient message expires or after a menu hover clears the bar.
+- **Conditions / variants:** Pre-#138, startup `status_ready` was shown via `showMessage(text, 3000)` and the bar went blank after 3s. Pre-#140, opening any menu cleared the load-summary text permanently because Qt's `QAction` hover path calls `statusBar().showMessage(action.statusTip())` even when the tip is empty. The baseline label fixes both.
+- **Related:** [#138](https://github.com/jackal998/photo-manager/issues/138), [#140](https://github.com/jackal998/photo-manager/issues/140); QA scenario [`qa/scenarios/s37_status_bar_baseline.py`](../qa/scenarios/s37_status_bar_baseline.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Open Manifest — base flow
+
+- **Entry point:** Main window menu → **File > Open Manifest…** ([translations/en.yml:26](../translations/en.yml#L26)). Also reachable from the empty-state primary button (see [Empty-state action buttons](#empty-state-action-buttons)).
+- **Trigger:** User picks **File > Open Manifest…** or clicks the empty-state **Open Manifest…** button.
+- **Behaviour:** Opens the native file picker filtered to `*.sqlite`. On accept, loads the chosen manifest via `ManifestLoadWorker` (a background `QThread` so the UI stays responsive), then refreshes the tree. Status bar updates to "Loaded manifest: <name>".
+- **Conditions / variants:** When the currently loaded manifest has unsaved decisions, a "Discard pending decisions?" confirm fires before the new manifest replaces it. Old manifests without the cached columns (`file_size_bytes`, `shot_date`, `creation_date`, `mtime`) auto-migrate and fall back to per-row filesystem reads transparently — re-scan once for the load-time speed benefit.
+- **Related:** Foundation in [PR #12](https://github.com/jackal998/photo-manager/pull/12); QA scenario [`qa/scenarios/s16_open_manifest.py`](../qa/scenarios/s16_open_manifest.py); stale-path handling exercised in [`qa/scenarios/s24_stale_manifest_paths.py`](../qa/scenarios/s24_stale_manifest_paths.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Save Manifest Decisions — base flow
+
+- **Entry point:** Main window menu → **File > Save Manifest Decisions…** ([translations/en.yml:27](../translations/en.yml#L27)).
+- **Trigger:** User picks **File > Save Manifest Decisions…**.
+- **Behaviour:** Opens a file picker. Choosing the same path saves in-place; choosing a new path exports a copy. Decisions are written to the chosen file, and subsequent saves default to that location. Clears the dirty flag on success (see [Exit dirty-flag prompt](#exit-dirty-flag-prompt)).
+- **Conditions / variants:** Decisions also auto-persist to the loaded manifest as soon as they're set — Save Manifest Decisions is the explicit "save to a different path" / "snapshot" affordance, not the only persistence path. A silent variant (`save_manifest_decisions_silent`) writes to the loaded manifest path with no picker — used by the exit prompt's **Save & leave** branch.
+- **Related:** Dirty-flag plumbing in [PR #158](https://github.com/jackal998/photo-manager/pull/158); QA scenario [`qa/scenarios/s12_save_manifest.py`](../qa/scenarios/s12_save_manifest.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Scan dialog — auto-select after scan
+
+- **Entry point:** "Auto select after scan" checkbox under Advanced Settings in [app/views/dialogs/scan_dialog.py](../app/views/dialogs/scan_dialog.py).
+- **Trigger:** User expands **Advanced settings** in the Scan dialog and ticks **Auto select after scan**. Setting persists across sessions via `ui.scan_dialog.auto_select_enabled` (defaults `False`).
+- **Behaviour:** When enabled, the scan worker promotes the top-scored row in each duplicate group to `action="KEEP"` before writing the manifest. The manifest loads with keepers already chosen and the user does not have to open the Selection dialog manually. Other duplicates retain their classifier action (`MOVE` / `EXACT` / `REVIEW_DUPLICATE`) so deletions still require explicit user confirmation through the review workflow. Auto-select picks keepers, never deleters.
+- **Conditions / variants:** Default is off — pre-#212 behaviour is preserved for users who don't opt in. Ranking semantics match the regex dialog's "Top 1 by score" rule (see [Set Action dialog — numeric comparison panel](#set-action-dialog--numeric-comparison-panel)): `score=None` rows excluded, ties break by `source_path` ascending — so manual and auto runs converge on the same keeper. Pairs with the post-scan visual-selection feature (see [Scan flow — visual selection of KEEP rows after scan](#scan-flow--visual-selection-of-keep-rows-after-scan)).
+- **Related:** [PR #232](https://github.com/jackal998/photo-manager/pull/232) (closes [#212](https://github.com/jackal998/photo-manager/issues/212)); QA scenario [`qa/scenarios/s49_scan_auto_select.py`](../qa/scenarios/s49_scan_auto_select.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Scan dialog — collapse Advanced Settings
+
+- **Entry point:** **Advanced settings** collapsible panel in the Scan dialog — [app/views/dialogs/scan_dialog.py](../app/views/dialogs/scan_dialog.py).
+- **Trigger:** User clicks the **Advanced settings** disclosure to expand or collapse the panel.
+- **Behaviour:** Tech-detail settings (similarity threshold, mean-color threshold, grouping parameters, auto-select toggle) live under a single collapsible panel rather than cluttering the main scan UI. New users see only the source list and the **Start Scan** button by default; power users expand to tune.
+- **Conditions / variants:** Expanded/collapsed state is not persisted today — opens collapsed every time.
+- **Related:** [PR #179](https://github.com/jackal998/photo-manager/pull/179) collapsed grouping parameters; [#163](https://github.com/jackal998/photo-manager/issues/163) drove the original consolidation.
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Scan dialog — folder list (no priority arrows)
+
+- **Entry point:** Source list widget in the Scan dialog (`_SourceListWidget`) — [app/views/dialogs/scan_dialog.py](../app/views/dialogs/scan_dialog.py).
+- **Trigger:** Always — applies to every interaction with the source list.
+- **Behaviour:** Clean 3-column list (path / Recursive checkbox / × remove). Display is sorted alphabetically by path (case-insensitive). The underlying entries list stays insertion-ordered so the duplicate-path check and the scanner's source-priority inference (top of scan = highest priority) still work.
+- **Conditions / variants:** Replaces the pre-#213 5-column table that had ↑/↓ priority arrows. Per-row callbacks receive the entries-index (not the display row) so clicking row 0 after the alphabetical sort still targets the alphabetically-first entry. ⚠ The README's Step 1 wording still mentions the removed arrows — tracked in [#264](https://github.com/jackal998/photo-manager/issues/264).
+- **Related:** [PR #223](https://github.com/jackal998/photo-manager/pull/223) (closes [#213](https://github.com/jackal998/photo-manager/issues/213)); QA scenario [`qa/scenarios/s17_scan_dialog_widgets.py`](../qa/scenarios/s17_scan_dialog_widgets.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Scan dialog — multi-source scan
+
+- **Entry point:** Source list widget in the Scan dialog plus the **+ Add Selected Folder** button — [app/views/dialogs/scan_dialog.py](../app/views/dialogs/scan_dialog.py).
+- **Trigger:** User browses the embedded folder tree, double-clicks a folder or clicks **+ Add Selected Folder** to add it to the source list. Repeats for unlimited folders. Toggles **Recursive** per source as needed.
+- **Behaviour:** Walks every source folder, hashes every file, and writes one consolidated `migration_manifest.sqlite` covering the whole set. Recursive sources walk subdirectories; non-recursive scan only the immediate folder. Layout is two-column (folder tree on the left, source list also on the left below it — see [PR #160](https://github.com/jackal998/photo-manager/pull/160)).
+- **Conditions / variants:** Source paths persist to `settings.json` (`sources.list`) between sessions. The Scan dialog accepts invalid / missing paths but surfaces a validation toast on Start Scan ([`qa/scenarios/s38_scan_dialog_invalid_path.py`](../qa/scenarios/s38_scan_dialog_invalid_path.py)).
+- **Related:** [PR #17](https://github.com/jackal998/photo-manager/pull/17) (dynamic multi-source scan); [PR #160](https://github.com/jackal998/photo-manager/pull/160) (two-column layout); QA scenarios [`qa/scenarios/s10_multi_source.py`](../qa/scenarios/s10_multi_source.py), [`qa/scenarios/s17_scan_dialog_widgets.py`](../qa/scenarios/s17_scan_dialog_widgets.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Scan flow — rescan confirm
+
+- **Entry point:** Confirm dialog fired before a re-scan replaces the currently loaded manifest.
+- **Trigger:** User starts a scan while a manifest with pending decisions is already loaded.
+- **Behaviour:** A confirm dialog asks the user to acknowledge that re-scanning will replace the loaded manifest. If the scan output path matches the loaded manifest path, those decisions will be permanently lost on disk; otherwise the previous manifest is preserved on disk but no longer visible in this window.
+- **Conditions / variants:** Cancel keeps the loaded manifest intact and aborts the scan. Confirm proceeds with the scan.
+- **Related:** QA scenario [`qa/scenarios/s27_rescan_confirm.py`](../qa/scenarios/s27_rescan_confirm.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Scan flow — visual selection of KEEP rows after scan
+
+- **Entry point:** Post-scan tree-selection hook in `MainWindow` after the manifest loads via **Close & Load**.
+- **Trigger:** Scan with auto-select enabled finishes and the user clicks **Close & Load**.
+- **Behaviour:** The rows that auto-select marked `KEEP` are visually highlighted in the result tree so the user can see at a glance which keepers the scorer picked — eliminating the "what just happened?" moment after a silent auto-select.
+- **Conditions / variants:** Only fires when auto-select after scan is enabled (see [Scan dialog — auto-select after scan](#scan-dialog--auto-select-after-scan)). Without auto-select, no rows are pre-marked, so nothing to highlight.
+- **Related:** [PR #255](https://github.com/jackal998/photo-manager/pull/255) (fix for [#239](https://github.com/jackal998/photo-manager/issues/239)).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Set Action dialog — Beginner / Regex mode toggle
+
+- **Entry point:** Radio toggle at the top of the Set Action dialog — [app/views/dialogs/select_dialog.py](../app/views/dialogs/select_dialog.py).
+- **Trigger:** User opens **Action > Set Action by Field/Regex…** (or right-clicks a row → **Set Action by Field/Regex…**). Beginner is the default for new users.
+- **Behaviour:** **Beginner** mode replaces the regex line edit with "Find rows where it [contains | starts with | ends with | exactly matches] [text]". The dialog synthesises the regex internally (via `re.escape` so the user's plain text stays literal — no need to know that `()/.` are special). **Regex** mode exposes the raw pattern input plus a cheatsheet chip row (`.*`, `\d`, `\w`, `^`, `$`, `\.`, `[abc]`) for power users. Recent patterns dropdown (capped at 10, deduped, persisted under `ui.action_dialog.recent_patterns`) is reachable from a `Recent ▾` button next to the regex input; picking from Recent always lands the user in Regex mode (the stored values are raw regex, not Beginner tuples).
+- **Conditions / variants:** Mode persists in `settings.json` under `ui.action_dialog.mode` so power users who flip to Regex once stay there. The match counter sits in a dedicated row visible in both modes — toggling mode never hides the live count, which is the primary feedback for both inputs. Match-span highlighting in the preview emboldens the matched substring in each row regardless of mode.
+- **Related:** [PR #167](https://github.com/jackal998/photo-manager/pull/167) (Phase B — Beginner mode, cheatsheet, recent patterns, match highlight); [PR #168](https://github.com/jackal998/photo-manager/pull/168) (Phase C — Simple rename + 3-col cheatsheet); QA scenario [`qa/scenarios/s31_simple_mode_regex.py`](../qa/scenarios/s31_simple_mode_regex.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Set Action dialog — live preview + validation
+
+- **Entry point:** Right-side `QListWidget` + match counter + validation icon in the Set Action dialog — [app/views/dialogs/select_dialog.py](../app/views/dialogs/select_dialog.py). Match closure built by `build_match_fn` in [app/views/handlers/file_operations.py](../app/views/handlers/file_operations.py).
+- **Trigger:** User types in the Beginner-mode text input or Regex-mode pattern input. Debounced 150 ms after the last keystroke.
+- **Behaviour:** Preview shows up to 50 matched filenames with a "…and N more" footer; match counter shows "N of M match". Live validation surfaces a green ✓ / red ✗ icon and a friendly error label ("Invalid regex: unmatched ')' at position 7") the moment `re.compile` fails — no more silent failure on Apply. The closure short-circuits on invalid regex so the dialog never iterates the record set with a broken pattern. The same `build_match_fn` closure is shared by both Apply and preview so what you see is byte-for-byte what `set_decision_by_regex` will match.
+- **Conditions / variants:** Right-click parity — the Execute Action dialog's tree context menu and the main window's multi-selection right-click both offer **Set Action by Field/Regex…**, opening the same dialog with the same live preview.
+- **Related:** [PR #162](https://github.com/jackal998/photo-manager/pull/162) (Phase A — live preview, validation, right-click parity); QA scenarios [`qa/scenarios/s14_action_by_regex.py`](../qa/scenarios/s14_action_by_regex.py), [`qa/scenarios/s30_execute_dialog_regex_right_click.py`](../qa/scenarios/s30_execute_dialog_regex_right_click.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Set Action dialog — numeric comparison panel
+
+- **Entry point:** Numeric panel that replaces the regex input when a numeric-capable field is chosen — [app/views/dialogs/select_dialog.py](../app/views/dialogs/select_dialog.py).
+- **Trigger:** User opens the Set Action dialog **from the Execute Action dialog** and picks one of the numeric-capable fields: Size (Bytes), Group Count, Similarity, Score, Creation Date, Shot Date. The main-window standalone route doesn't pass `groups`, so the numeric panel never surfaces there — existing regex/simple behaviour is unchanged for the main-window entry.
+- **Behaviour:** Two modes — **Threshold comparison** (`>`, `>=`, `<`, `<=`, `==`, `!=`) against a typed value (date fields accept ISO `YYYY-MM-DD`); **Top N / Bottom N within group** ranked by the selected field with stable `file_path` tiebreak so the same configuration always selects the same rows. Both modes ride through the existing `setActionRequested(field, pattern, decision)` signal as encoded pseudo-patterns (`__cmp__:OP:VALUE`, `__top_n__:N:asc|desc`).
+- **Conditions / variants:** The "top 1 by score within group" configuration is the supported way to apply best-copy to a group — the standalone right-click "Apply best-copy decisions to this group" action was removed in [PR #224](https://github.com/jackal998/photo-manager/pull/224).
+- **Related:** [PR #221](https://github.com/jackal998/photo-manager/pull/221) (closes [#209](https://github.com/jackal998/photo-manager/issues/209)); QA scenarios [`qa/scenarios/s43_numeric_condition.py`](../qa/scenarios/s43_numeric_condition.py), [`qa/scenarios/s50_select_numeric_panel_from_main_window.py`](../qa/scenarios/s50_select_numeric_panel_from_main_window.py).
+- **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Set Action dialog — Score / Lock / Resolution fields
+
+- **Entry point:** Field dropdown in the Set Action dialog — [app/views/dialogs/select_dialog.py](../app/views/dialogs/select_dialog.py); field metadata in [app/views/constants.py](../app/views/constants.py).
+- **Trigger:** User opens the Set Action dialog and expands the field combo.
+- **Behaviour:** Score, Lock, and Resolution each appear as fields the user can match against. Score auto-opens the numeric comparison panel (it's in `_NUMERIC_FIELDS`). Lock is matched as a stringified flag ("Locked" / ""). Resolution is matched as `WIDTH×HEIGHT` (e.g. `^1920×1080$`) to mirror the tree's Resolution column rendering exactly.
+- **Conditions / variants:** All three labels go through `t()` so they translate correctly. Without this addition, picking Score from the combo would have rendered untranslated; Lock would have been picker-visible but raw-English; Resolution wasn't there at all.
+- **Related:** [PR #250](https://github.com/jackal998/photo-manager/pull/250) (closes [#238](https://github.com/jackal998/photo-manager/issues/238)); QA scenario [`qa/scenarios/s50_select_numeric_panel_from_main_window.py`](../qa/scenarios/s50_select_numeric_panel_from_main_window.py).
 - **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
 
 ---


### PR DESCRIPTION
## Summary

Extends `docs/features.md` from the seven-feature Execute Action seed ([PR #263](https://github.com/jackal998/photo-manager/pull/263)) to **36 features** covering the rest of the app. Every `qa/scenarios/sNN_*.py` driver is now referenced from at least one feature entry. `README.md § Step 4` gains a pointer to `docs/features.md` as the canonical catalogue; the Step 1-4 walkthrough remains the onboarding path.

## New feature entries (29 added on top of the PR A seed)

### Bulk operations
- Bulk regex — remove from list (deferred decision)

### Context menu
- Context menu — Lock / Unlock
- Context menu — Open Folder
- Context menu — Set Action (per-file)
- Empty area context menu

### Main window
- Empty-state action buttons (#137, #197)
- Exit dirty-flag prompt (#158)
- Main window — column order/width persistence (#214, #227)
- Main window — geometry + splitter persistence (#136, #141, #191)
- Main window — keyboard navigation
- Main window — results tree double-click (#143, #198)
- Main window — sort persistence within session (#121)
- Main window — status bar baseline (#138, #140)

### File operations
- Open Manifest — base flow
- Save Manifest Decisions — base flow (#158)

### Scan
- Scan dialog — auto-select after scan (#212, #232)
- Scan dialog — collapse Advanced Settings (#163, #179)
- Scan dialog — folder list (no priority arrows) (#213, #223)
- Scan dialog — multi-source scan (#17, #160)
- Scan flow — rescan confirm
- Scan flow — visual selection of KEEP rows after scan (#239, #255)

### Set Action dialog
- Set Action dialog — Beginner / Regex mode toggle (#167, #168)
- Set Action dialog — live preview + validation (#162)
- Set Action dialog — numeric comparison panel (#209, #221)
- Set Action dialog — Score / Lock / Resolution fields (#238, #250)

### Review
- Keep-worthiness scoring (#187 cluster)

### Menus
- List menu — Remove from List
- Log menu

### i18n
- Language switch (#157)

## README audit — three deltas filed as separate follow-up issues

Per the brief, the README audit's deliverable is the issue filings + a "verified current" line on each features.md entry; behaviour fixes ship in separate PRs. The "Set Action dialog — folder list" entry already cross-references [#264](https://github.com/jackal998/photo-manager/issues/264) in its Conditions/variants line.

- [#264](https://github.com/jackal998/photo-manager/issues/264) — README Step 1 mentions ↑/↓ priority arrows removed in [#223](https://github.com/jackal998/photo-manager/pull/223).
- [#265](https://github.com/jackal998/photo-manager/issues/265) — README Step 2 misses Score column, misses double-click behaviour, mentions stale "Set Action to Activated Files" menu path.
- [#266](https://github.com/jackal998/photo-manager/issues/266) — README Step 4 "Click Execute to carry out all decisions" inaccurate post-[#219](https://github.com/jackal998/photo-manager/pull/219).

## Acceptance for PR B

- [x] ≥25 features in `docs/features.md` (36 now)
- [x] Every `qa/scenarios/sNN_*.py` is referenced from at least one feature entry
- [x] README audit deltas filed as `[QA-friction]` follow-up issues
- [x] No README claims stealth-fixed — Step 4 only gains a pointer line; the inaccurate "Click Execute" wording is left for [#266](https://github.com/jackal998/photo-manager/issues/266)
- [x] Doc-only PR — no source files touched, no tests to run
- [x] `docs_guard` doesn't fire — only docs touched

## Follow-up — PR C

Next: `feat(hooks): docs_guard catches behavioural changes; update-docs skill row`. The hook will gain a behavioural-modify trigger for `app/views/{dialogs,handlers}/` and require `docs/features.md` specifically (rather than any doc touch) when the trigger is behavioural. Skill row + `CLAUDE.md` one-liner + layer-1 hook test land in the same PR.

Refs [#262](https://github.com/jackal998/photo-manager/issues/262)

🤖 Generated with [Claude Code](https://claude.com/claude-code)