### PR TITLE
feat(hooks): docs_guard catches behavioural changes; update-docs skill row

### DIFF
--- a/.claude/skills/update-docs/SKILL.md
+++ b/.claude/skills/update-docs/SKILL.md
@@ -1,0 +1,118 @@
+---
+name: update-docs
+description: Use after implementing any fix or new feature in photo-manager to keep documentation in sync. Checks README.md and pyproject.toml against what actually changed. Applies only surgical edits to affected sections.
+origin: local
+---
+
+# Update Docs After Each Fix / Feature
+
+Activate this skill after implementing any non-trivial change to photo-manager so that documentation stays in sync with the code.
+
+## When to activate
+
+- After adding, renaming, or deleting a source file
+- After adding a test file
+- After changing the SQLite schema (new columns, renamed columns)
+- After adding or removing a service, interface, or module
+- After changing menu actions or UI flow
+- After bumping the Python version
+- After adding or removing a `settings.json` key
+- After deprecating or deleting code
+- After **any change that shifts what each test layer covers**:
+  - Adding or removing an entry in `[tool.coverage.run] omit`
+  - Adding a `tests/integration/` test (layer 2 spot-add — record it
+    in `docs/testing.md` per-module table; layer 2 is on-demand, not
+    a maintained suite, so each addition is an event worth noting)
+  - Adding or modifying a `qa/scenarios/sNN_*.py` driver (layer 3)
+  - A module's layer-1 coverage changes by ≥5pp (e.g. lifted from 73 → 90)
+
+---
+
+## Docs map for `photo-manager`
+
+| File | What it tracks | Sections / spots to check |
+|------|---------------|--------------------------|
+| `README.md` | Project structure tree, test list, test count, "Run tests" section | `## Project structure` block; `tests/` subtree; `# NNN tests` comment; layer-summary table in "Run tests" |
+| `docs/features.md` | Canonical feature inventory — entry points, triggers, conditions, related PRs/issues/scenarios | Per-feature sections; the alphabetical index table at the top |
+| `pyproject.toml` | Python version for Black / Ruff / Pylint; coverage `omit` list (each entry needs a justification + cross-layer pointer) | `target-version = ["py3XX"]`, `target-version = "py3XX"`, `py-version = "3.XX"`; `[tool.coverage.run] omit = [...]` comments |
+| `docs/testing.md` | The 3-layer model + per-module residual-risk table — canonical answer to "what's covered, what's not, what's the risk" | Per-module rows under each section (`scanner/`, `core/`, `infrastructure/`, `app/`); "Open work" list at the end |
+| `CLAUDE.md` | Hard testing rules (no padding, 3 layers, 70% per-file floor, 3-trigger rule for new features) | "Testing ground rules" section — only update if the policy itself changes |
+
+---
+
+## Checklist
+
+Work through every item below. Check only the items relevant to your change.
+
+### Files changed?
+- [ ] Added a `.py` file → add it to `README.md` project structure tree at the right indentation level
+- [ ] Added a test file `tests/test_*.py` → add it to `README.md` test list; bump the `# 270+ tests` count
+- [ ] Removed or deprecated a file → mark `[deprecated]` in `README.md`; do **not** delete the entry
+- [ ] Renamed a file → update `README.md`
+
+### Schema changed?
+- [ ] Added column(s) to `migration_manifest` → update `README.md` manifest schema table (§ "Scanner features" / manifest schema)
+- [ ] Updated `_MIGRATIONS` list → verify migration note in `README.md` is still accurate
+
+### Service / interface changed?
+- [ ] Added or removed an infrastructure class → update `README.md` infrastructure tree
+
+### UI / menu changed?
+- [ ] Changed a dialog → update `README.md` dialogs tree
+
+### User-visible behaviour changed?
+- [ ] Button label change, conditional dialog, action scope change,
+      new keyboard shortcut, new menu item, post-action state change,
+      new condition affecting a flow → add or update the corresponding
+      section in `docs/features.md` (the canonical feature inventory).
+      Touch `README.md § Usage — GUI § Step N` only if the change is
+      part of the documented Step-1-4 happy path; otherwise the
+      `docs/features.md` entry is sufficient. Enforced by
+      `scripts/hooks/docs_guard.py` at `gh pr create` time — see the
+      [`docs/features.md`](../../../docs/features.md) "How to update
+      this file" section.
+
+### Settings changed?
+- [ ] Added a new `settings.json` key → add it to `README.md` Configuration section
+- [ ] Removed a key → remove or annotate it in `README.md`
+
+### Python version bumped?
+- [ ] `pyproject.toml` — update `target-version` (Black + Ruff) and `py-version` (Pylint)
+
+### Background worker / major flow changed?
+- [ ] New `QThread` worker → add to `README.md` workers/ subtree
+
+---
+
+## How to apply
+
+1. Read the changed source file(s) to understand exactly what changed.
+2. For each checked item above, read the relevant doc section.
+3. Apply **surgical edits** — replace only the stale sentence/row/bullet; do not rewrite entire sections.
+4. After all edits, run `python -m pytest tests/ -q --tb=short` to confirm no regressions.
+   If coverage drops below the configured `fail_under` threshold in `pyproject.toml`,
+   add tests for the new code before committing.
+5. Commit the doc changes alongside the code change (or as an immediate follow-up commit on the same branch).
+
+---
+
+## Example edit patterns
+
+**New file added** (`app/views/dialogs/export_dialog.py`):
+```
+# In README.md project structure, find the dialogs/ block and add:
+│   │   │   ├── export_dialog.py            # Export decisions to CSV
+```
+
+**New settings key** (`"preview_max_side": 1024`):
+```
+# In README.md Configuration section, add the key to the example JSON block.
+```
+
+**Deprecated a file** (`app/views/dialogs/legacy_dialog.py`):
+```
+# In README.md project structure, change:
+│   │   │   └── legacy_dialog.py
+# to:
+│   │   │   └── legacy_dialog.py            # [deprecated — legacy stub]
+```

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -156,6 +156,13 @@ the per-module table in [`docs/testing.md`](docs/testing.md). The doc
 is the canonical answer to "what's covered, what's not, what's the
 residual risk" — keep it honest.
 
+The canonical feature inventory lives at [`docs/features.md`](docs/features.md).
+Update it whenever user-visible behaviour changes (button label,
+conditional dialog, action scope, new shortcut/menu, post-action
+state change, new gating condition) — see the `update-docs` skill's
+"User-visible behaviour changed?" row. Enforced at PR-creation time
+by [`scripts/hooks/docs_guard.py`](scripts/hooks/docs_guard.py).
+
 ## Setup (one-time, per machine)
 
 `.claude/settings.json` is gitignored because it contains a machine-specific

--- a/scripts/hooks/docs_guard.py
+++ b/scripts/hooks/docs_guard.py
@@ -76,6 +76,19 @@ _DOC_FILE_PATTERNS = (
     re.compile(r"^translations/README\.md$"),
 )
 
+# Behavioural-modify trigger (#262): MODIFIED files under
+# app/views/{dialogs,handlers}/ shift user-visible behaviour by
+# definition — these are the dialog bodies and action handlers a
+# user reaches. When the diff is non-trivial, require
+# docs/features.md specifically rather than letting any doc touch
+# satisfy the gate. Trivial edits (typo, single-line comment) stay
+# under the diff-size / signature-change threshold and don't fire.
+_DOC_BEHAVIOURAL_MODIFY_PATTERN = re.compile(
+    r"^app/views/(dialogs|handlers)/[^/]+\.py$"
+)
+_BEHAVIOURAL_FEATURES_DOC = "docs/features.md"
+_BEHAVIOURAL_TRIGGER_DIFF_THRESHOLD = 10
+
 _BYPASS_PATTERN = re.compile(r"\[docs-not-needed:[^\]]*\]")
 
 
@@ -119,14 +132,57 @@ def _new_files() -> set[str]:
     return added
 
 
+def _behavioural_modify_qualifies(path: str) -> bool:
+    """Decide whether a modify to ``path`` warrants firing the
+    behavioural docs gate.
+
+    Qualifies when EITHER the diff is at least
+    :data:`_BEHAVIOURAL_TRIGGER_DIFF_THRESHOLD` added + deleted lines
+    OR a function signature line appears in the diff (heuristic: a
+    ``def`` or ``async def`` line on the + / - side of ``git diff
+    -U0``). Trivial edits (a single-line copy tweak, a comment fix)
+    fall under both bars and don't fire the gate.
+
+    Used to keep this trigger from blocking on edits that genuinely
+    don't shift user-visible behaviour.
+    """
+    try:
+        numstat_out = subprocess.check_output(
+            ["git", "diff", "--numstat", "origin/master...HEAD", "--", path],
+            text=True, stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+    total = 0
+    for line in numstat_out.splitlines():
+        # numstat: "added\tdeleted\tpath"; binary files print "-".
+        parts = line.split("\t")
+        if len(parts) >= 2 and parts[0].isdigit() and parts[1].isdigit():
+            total += int(parts[0]) + int(parts[1])
+    if total >= _BEHAVIOURAL_TRIGGER_DIFF_THRESHOLD:
+        return True
+    try:
+        diff_out = subprocess.check_output(
+            ["git", "diff", "-U0", "origin/master...HEAD", "--", path],
+            text=True, stderr=subprocess.DEVNULL,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return False
+    return bool(re.search(r"^[+-]\s*(async\s+)?def\s", diff_out, re.MULTILINE))
+
+
 def _doc_relevant(changed: list[str], added: set[str]) -> list[tuple[str, str]]:
     """Return ``[(path, suggested_doc), …]`` for changes that need docs.
 
     NEW files under doc-relevant directories always trigger. MODIFIED
-    files only trigger for a narrow subset where the modification
-    typically shifts public-facing structure (qa scenarios — name /
-    coverage table; tests — count + tree; manifest_repository —
-    migration list).
+    files trigger for:
+      * qa scenarios — name / coverage table updates;
+      * ``infrastructure/manifest_repository.py`` — migration list;
+      * files under ``app/views/{dialogs,handlers}/`` that pass
+        :func:`_behavioural_modify_qualifies` — these shift
+        user-visible behaviour and require
+        :data:`_BEHAVIOURAL_FEATURES_DOC` specifically (enforced in
+        :func:`main`).
     """
     out: list[tuple[str, str]] = []
     for f in changed:
@@ -143,6 +199,15 @@ def _doc_relevant(changed: list[str], added: set[str]) -> list[tuple[str, str]]:
                 break
             if f == "infrastructure/manifest_repository.py":
                 out.append((f, "README.md schema table (if _MIGRATIONS changed)"))
+                break
+            # Behavioural-modify trigger (#262).
+            if (
+                _DOC_BEHAVIOURAL_MODIFY_PATTERN.match(f)
+                and _behavioural_modify_qualifies(f)
+            ):
+                out.append(
+                    (f, f"{_BEHAVIOURAL_FEATURES_DOC} (user-visible behaviour)")
+                )
                 break
     return out
 
@@ -176,11 +241,45 @@ def main() -> int:
         return 0
 
     docs = _docs_touched(changed)
+
+    # Behavioural-modify triggers (#262) are strict: they require
+    # docs/features.md specifically, not just any doc touch. New files
+    # keep the legacy coarse semantic ("did you think about docs at
+    # all"). The bypass token below still works for both.
+    behavioural = [
+        f for f, _ in relevant
+        if _DOC_BEHAVIOURAL_MODIFY_PATTERN.match(f) and f not in added
+    ]
+    if behavioural and _BEHAVIOURAL_FEATURES_DOC not in docs:
+        msg_lines = [
+            "docs guard fired — blocking `gh pr create`.",
+            "",
+            f"  user-visible behaviour change without a {_BEHAVIOURAL_FEATURES_DOC} update:",
+        ]
+        for f in behavioural:
+            msg_lines.append(f"    {f}")
+        msg_lines += [
+            "",
+            "  Behavioural changes under app/views/{dialogs,handlers}/",
+            f"  must update {_BEHAVIOURAL_FEATURES_DOC} so the canonical",
+            "  feature inventory stays in sync.",
+            "",
+            "  To unblock:",
+            f"    a) Add or update the corresponding section in {_BEHAVIOURAL_FEATURES_DOC}.",
+            "    b) Include `[docs-not-needed: <reason>]` in the gh pr create",
+            "       command (title or body) when the change is genuinely not",
+            "       user-visible (e.g. an internal refactor that preserves",
+            "       behaviour byte-for-byte).",
+        ]
+        sys.stderr.write("\n".join(msg_lines) + "\n")
+        return 2
+
     if docs:
         # At least one doc file was touched — accept the PR; we're
         # checking "did you think about docs at all," not "did you
         # update the exactly-correct line." The qa-scenario-guard
-        # applies the same coarse rule.
+        # applies the same coarse rule. (Behavioural-modify changes
+        # take the strict path above.)
         return 0
 
     msg_lines = [

--- a/tests/test_docs_guard.py
+++ b/tests/test_docs_guard.py
@@ -32,17 +32,27 @@ def _run(
     command: str,
     changed: list[str],
     added: list[str] | None = None,
+    behavioural_qualifies: bool = False,
 ) -> int:
     """Invoke ``main()`` with synthetic stdin + mocked diff helpers.
 
     ``added`` defaults to the same list as ``changed`` so tests can
     pass new files without restating them. To test the "modified
     existing file" branch, pass ``added=[]`` explicitly.
+
+    ``behavioural_qualifies`` controls the return value of the
+    ``_behavioural_modify_qualifies`` helper for every path queried
+    in this run. Defaults to ``False`` so legacy tests that don't
+    care about the #262 behavioural-modify gate stay below the
+    threshold by default.
     """
     mod = _load_hook()
     monkeypatch.setattr(mod, "_changed_files", lambda: list(changed))
     monkeypatch.setattr(
         mod, "_new_files", lambda: set(changed if added is None else added)
+    )
+    monkeypatch.setattr(
+        mod, "_behavioural_modify_qualifies", lambda path: behavioural_qualifies
     )
     payload = json.dumps({"tool_name": "Bash", "tool_input": {"command": command}})
     monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
@@ -236,3 +246,143 @@ class TestStdinRobustness:
         payload = json.dumps({"tool_name": "Read", "tool_input": {}})
         monkeypatch.setattr(sys, "stdin", io.StringIO(payload))
         assert mod.main() == 0
+
+
+# ── behavioural-modify trigger + strict-accept (#262) ─────────────────────
+
+
+class TestBehaviouralModifyTrigger:
+    """The #262 hardening: MODIFIED files under
+    app/views/{dialogs,handlers}/ trigger the docs gate when the diff
+    is non-trivial, AND they require docs/features.md specifically
+    rather than just any doc touch. New files keep the legacy
+    any-doc-touch semantic. Bypass token still works."""
+
+    def test_below_threshold_modify_does_not_trigger(self, monkeypatch):
+        """A trivial edit (< 10 lines, no signature change) doesn't
+        fire the behavioural gate even on a dialog/handler file. This
+        is what keeps the gate from blocking typo fixes."""
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'fix: copy tweak'",
+            changed=["app/views/dialogs/execute_action_dialog.py"],
+            added=[],
+            behavioural_qualifies=False,
+        )
+        assert rc == 0
+
+    def test_above_threshold_modify_without_features_blocks(self, monkeypatch, capsys):
+        """The core enforcement — a non-trivial dialog edit must touch
+        docs/features.md or the PR is blocked."""
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'feat: scope execute to highlighted'",
+            changed=["app/views/dialogs/execute_action_dialog.py"],
+            added=[],
+            behavioural_qualifies=True,
+        )
+        assert rc == 2
+        err = capsys.readouterr().err
+        assert "docs/features.md" in err
+        assert "execute_action_dialog.py" in err
+
+    def test_above_threshold_modify_with_features_passes(self, monkeypatch):
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'feat: scope execute to highlighted'",
+            changed=[
+                "app/views/dialogs/execute_action_dialog.py",
+                "docs/features.md",
+            ],
+            added=[],
+            behavioural_qualifies=True,
+        )
+        assert rc == 0
+
+    def test_handler_above_threshold_blocks_same_as_dialog(self, monkeypatch):
+        """Handlers (file_operations.py, context_menu.py, etc.) ride
+        the same gate as dialogs — both are user-visible behaviour."""
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'feat: new context menu entry'",
+            changed=["app/views/handlers/context_menu.py"],
+            added=[],
+            behavioural_qualifies=True,
+        )
+        assert rc == 2
+
+    def test_above_threshold_with_only_testing_doc_blocks(self, monkeypatch):
+        """docs/testing.md is not enough for a behavioural change —
+        features.md is the canonical user-visible-behaviour doc."""
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'feat'",
+            changed=[
+                "app/views/dialogs/execute_action_dialog.py",
+                "docs/testing.md",
+            ],
+            added=[],
+            behavioural_qualifies=True,
+        )
+        assert rc == 2
+
+    def test_above_threshold_with_only_readme_blocks(self, monkeypatch):
+        """README.md alone is not enough for a behavioural change."""
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'feat'",
+            changed=[
+                "app/views/dialogs/execute_action_dialog.py",
+                "README.md",
+            ],
+            added=[],
+            behavioural_qualifies=True,
+        )
+        assert rc == 2
+
+    def test_new_dialog_with_testing_doc_passes(self, monkeypatch):
+        """NEW files keep the legacy 'any doc touch is enough'
+        semantic — they're typically introducing new structure that
+        the docs map rows already cover."""
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'feat: new dialog'",
+            changed=[
+                "app/views/dialogs/new_dialog.py",
+                "docs/testing.md",
+            ],
+            added=["app/views/dialogs/new_dialog.py"],
+            behavioural_qualifies=False,
+        )
+        assert rc == 0
+
+    def test_bypass_token_works_for_behavioural(self, monkeypatch):
+        """The bypass escape valve still works for behavioural-modify
+        triggers — needed for genuine internal refactors that
+        preserve behaviour byte-for-byte."""
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'refactor [docs-not-needed: pure refactor, no UX change]'",
+            changed=["app/views/dialogs/execute_action_dialog.py"],
+            added=[],
+            behavioural_qualifies=True,
+        )
+        assert rc == 0
+
+    def test_above_threshold_workers_dir_not_in_behavioural_scope(self, monkeypatch):
+        """Only dialogs/ and handlers/ are in the behavioural scope —
+        workers/, components/, widgets/, layout/, viewmodels/ stay
+        on the legacy any-doc-touch rule because they're internal
+        plumbing (background QThreads, layout helpers, viewmodels)
+        that don't independently shift user-facing UX."""
+        # A modified worker file with no docs at all — should NOT
+        # trigger because workers are not in the behavioural pattern
+        # and not in the existing MODIFIED-trigger set.
+        rc = _run(
+            monkeypatch,
+            "gh pr create --title 'fix: worker thread cleanup'",
+            changed=["app/views/workers/scan_worker.py"],
+            added=[],
+            behavioural_qualifies=True,  # would have qualified if scope included workers
+        )
+        assert rc == 0


### PR DESCRIPTION
## Summary

Hardens `docs_guard` so behavioural PRs can no longer bypass the documentation gate by either (a) modifying an existing dialog or handler without docs, or (b) touching `docs/testing.md` instead of `docs/features.md`. This is the third and final PR in the [#262](https://github.com/jackal998/photo-manager/issues/262) chore — [PR #263](https://github.com/jackal998/photo-manager/pull/263) seeded `docs/features.md`, [PR #267](https://github.com/jackal998/photo-manager/pull/267) backfilled it to 36 features, and this PR wires up enforcement.

## Why this exists

Three behavioural PRs ([#219](https://github.com/jackal998/photo-manager/pull/219), [#181](https://github.com/jackal998/photo-manager/pull/181), [#183](https://github.com/jackal998/photo-manager/pull/183)) shipped without `docs_guard` firing because the hook had two gaps:

1. **Narrow on MODIFY** — at [`docs_guard.py:122-147`](scripts/hooks/docs_guard.py#L122) only NEW files in `app/views/{dialogs,handlers,...}/` triggered. Modifications were silent.
2. **Coarse on ACCEPT** — at [`docs_guard.py:150-151`](scripts/hooks/docs_guard.py#L150) ANY doc touch satisfied the gate. `docs/testing.md` was as good as a user-facing doc.

This PR closes both gaps.

## Hook changes — `scripts/hooks/docs_guard.py`

- New `_behavioural_modify_qualifies(path)` helper: runs `git diff --numstat origin/master...HEAD -- <path>` to count added+deleted lines, plus `git diff -U0` to detect `def` / `async def` signature changes. Qualifies if EITHER the diff is ≥10 lines OR a signature line appears. Trivial typo/comment edits stay under both bars.
- `_doc_relevant` adds a new MODIFY branch for `app/views/(dialogs|handlers)/[^/]+\.py$` when `qualifies` returns True. Other directories (`workers`, `components`, `widgets`, `layout`, `viewmodels`) stay on the legacy "NEW files only" semantic — those are internal plumbing.
- `main()` splits accept into two paths:
  - **Behavioural-modify triggers** require `docs/features.md` specifically. Touching only `docs/testing.md` or `README.md` does NOT satisfy. Block message names the specific doc.
  - **Other relevant changes** (NEW files, qa-scenario changes, `manifest_repository.py`) keep the legacy any-doc-touch semantic.
  - The `[docs-not-needed: <reason>]` bypass token still works for both.

## Skill row — `.claude/skills/update-docs/SKILL.md`

- New "User-visible behaviour changed?" checklist row pointing at `docs/features.md` (label change, conditional dialog, scope change, new shortcut/menu, post-action state, new gating condition).
- Docs-map table gains a row for `docs/features.md`.
- **Note on commit**: `.claude/skills/` is gitignored for PII reasons (`/.gitignore:101-108`). The file was force-added with user confirmation — content is pure workflow documentation, no paths/hosts/credentials. Future updates to this file will need `git add -f` until the project sets up a `.claude/skills/.example/` pattern (mentioned in the gitignore comment as the project-shareable convention).

## CLAUDE.md

One-liner under "Documentation duty" naming `docs/features.md` as the canonical feature inventory and pointing at the new skill row + enforcing hook.

## Test coverage — `tests/test_docs_guard.py`

New `TestBehaviouralModifyTrigger` class (8 cases). `_run` helper gains a `behavioural_qualifies` parameter (default `False`) that monkeypatches the qualifies helper so tests don't hit subprocess:

- `test_below_threshold_modify_does_not_trigger` — trivial edits pass (the typo-fix case)
- `test_above_threshold_modify_without_features_blocks` — core enforcement, exit 2 + stderr names `docs/features.md`
- `test_above_threshold_modify_with_features_passes` — happy path
- `test_handler_above_threshold_blocks_same_as_dialog` — handlers ride the same gate
- `test_above_threshold_with_only_testing_doc_blocks` — strict-accept: `docs/testing.md` alone not enough
- `test_above_threshold_with_only_readme_blocks` — strict-accept: `README.md` alone not enough
- `test_new_dialog_with_testing_doc_passes` — NEW files keep legacy semantic
- `test_bypass_token_works_for_behavioural` — escape valve still works
- `test_above_threshold_workers_dir_not_in_behavioural_scope` — `workers/` is out of behavioural scope (internal plumbing)

## Manual smoke test (run before push)

Created throwaway `_smoke-docs-guard` branch off this commit, appended 15 fake `# fake-N` lines to `app/views/dialogs/execute_action_dialog.py`, committed, and ran the hook against a synthetic `gh pr create` payload:

```
$ printf '{"tool_name":"Bash","tool_input":{"command":"gh pr create --title smoke --body x"}}' \
    | python scripts/hooks/docs_guard.py
docs guard fired — blocking `gh pr create`.

  user-visible behaviour change without a docs/features.md update:
    app/views/dialogs/execute_action_dialog.py
  ...
exit=2
```

Touched `docs/features.md`, re-ran — `exit=0`. Branch deleted.

## Test plan

- [x] `pytest tests/test_docs_guard.py -v` — 30 passed (22 existing + 8 new)
- [x] `pytest` full suite — 1221 passed, 2 skipped, 88.35% coverage
- [x] `scripts/check_coverage_per_file.py` — all 49 tracked files clear the 70% per-file floor
- [x] Manual smoke test — see above
- [x] PR C itself doesn't trigger the new gate (`scripts/hooks/` not in any relevant pattern; `tests/test_docs_guard.py` modify isn't in the existing MODIFIED trigger set; `CLAUDE.md` + `SKILL.md` are doc-only)

## What lands together

| File | Change |
|---|---|
| `scripts/hooks/docs_guard.py` | Behavioural-modify trigger + strict-accept rule (+109/-5) |
| `tests/test_docs_guard.py` | `TestBehaviouralModifyTrigger` (8 cases) + `_run` helper extension (+150/-0) |
| `.claude/skills/update-docs/SKILL.md` | New checklist row + docs-map row (force-added) |
| `CLAUDE.md` | One-liner under "Documentation duty" |

Closes [#262](https://github.com/jackal998/photo-manager/issues/262)

🤖 Generated with [Claude Code](https://claude.com/claude-code)