### PR TITLE
docs(readme): audit fixes for Step 1 / 2 / 4 (#264, #265, #266)

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ The tree shows all files loaded from the manifest.
 |--------|---------|
 | **Similarity** | Scanner-assigned match type: `exact` / `similar` / *(empty for unmatched)* |
 | **Action** | Your decision: `delete` / `keep` / *(empty = undecided)* |
+| **Score** | Keep-worthiness ranking in `[0.0, 1.0]` (#187). Within-group rows sort by this descending — best copy at the top. Empty for Live Photo MOV passengers. |
 | **Lock** | 🔒 if the row is locked against bulk operations (#182), empty otherwise. Sortable; searchable via the regex dialog as `Locked` / `""`. |
 | **File Name** | File name |
 | **Folder** | Containing directory |
@@ -170,9 +171,9 @@ The tree shows all files loaded from the manifest.
 
 - *Per file*: right-click a file → **Set Action → delete** / **keep** /
   **remove from list**.
-- *By highlight*: click or multi-select rows in the tree, then
-  **Action › Set Action to Activated Files › delete** (or **keep** /
-  **remove from list**).
+- *Multiple files*: select rows (Ctrl/Shift-click), then right-click
+  any of them → **Set Action** opens the same submenu and applies the
+  chosen decision to every selected row.
 - *In bulk*: **Action › Set Action by Field/Regex…** — pick a column,
   describe what to match, choose an action (`delete`, `keep`, or
   `remove from list`). The dialog defaults to **Simple** mode (pick
@@ -183,6 +184,9 @@ The tree shows all files loaded from the manifest.
   rows are flagged and dropped on save, no files are moved or deleted.
   Right-clicking a row in the main tree (single or multi-select) and
   in the Execute Action dialog also opens the same dialog.
+
+**Navigating:** double-click a file row to open it in the OS default
+viewer (#143); double-click a group header to toggle expand / collapse.
 
 If you close the app with unsaved decisions a prompt appears with
 **Save & leave** / **Leave** / **Back**, so you don't lose work

--- a/README.md
+++ b/README.md
@@ -131,7 +131,9 @@ The PySide6 desktop app is the primary interface. Launch it with `run.bat`.
 
 1. Browse the embedded folder tree to find source directories.
    - Double-click or press **+ Add Selected Folder** to add a folder to the list.
-   - Use **↑ / ↓** buttons to reorder sources (top row = highest dedup priority).
+   - The source list is displayed alphabetically by path. Scan order
+     (and therefore dedup priority for exact duplicates) is inferred
+     from the underlying insertion order, not the displayed row order.
    - Tick or untick the **Recursive** checkbox per source — recursive scans all
      subdirectories; unticked scans only the immediate folder.
    - Use **×** to remove a source; **Remove All** to clear the list.

--- a/README.md
+++ b/README.md
@@ -206,7 +206,11 @@ window) showing all groups for final review.
 - Right-click any file row → **Set Action** → change its decision before executing.
 - If every file in a group is marked `delete`, an amber warning banner appears
   in the dialog. Clicking **Execute** shows a confirmation prompt before proceeding.
-- Click **Execute** to carry out all decisions:
+- Click **Execute**. With no rows highlighted, every decided row is
+  processed. Highlight one or more rows first (Ctrl/Shift-click) to
+  scope execution to just those — the button label changes to
+  **Execute Action (highlighted)** when in scope (#211).
+- The chosen rows are then carried out:
   - `delete` → file sent to the recycle bin (`send2trash`)
   - `keep` → marked as executed in the manifest (no file operation)
   - Files that no longer exist on disk are skipped and listed in a warning dialog.


### PR DESCRIPTION
## Summary

Three doc-only fixes to `README.md § Usage — GUI` surfaced during the [#262](https://github.com/jackal998/photo-manager/issues/262) inventory audit. Each issue gets its own commit so it can be reviewed (or reverted) independently.

## Commits

| Commit | Issue | Change |
|---|---|---|
| `41c286a` | [#264](https://github.com/jackal998/photo-manager/issues/264) | Step 1 — drop the stale ↑/↓ priority-arrows wording (removed in [#223](https://github.com/jackal998/photo-manager/pull/223)); clarify that source-list display is alphabetical and dedup priority is inferred from insertion order. |
| `019a657` | [#265](https://github.com/jackal998/photo-manager/issues/265) | Step 2 — three sub-edits: add the missing **Score** column row to the column table; replace the stale "Action › Set Action to Activated Files" menu path with the actual multi-select right-click flow; add the file-row / group-header double-click behaviour from [#198](https://github.com/jackal998/photo-manager/pull/198). |
| `feea283` | [#266](https://github.com/jackal998/photo-manager/issues/266) | Step 4 — rewrite the "Click Execute to carry out all decisions" bullet to reflect the highlight-scope semantic introduced in [#219](https://github.com/jackal998/photo-manager/pull/219) (button label switches to "Execute Action (highlighted)" when one or more rows are highlighted). Outcome sub-bullets stay intact — they're still correct. |

## Why three commits, not one

The original audit filed each finding as a separate issue so each could be reviewed and reverted as a focused doc fix. Splitting the commits along the same boundaries preserves that property: if any one fix needs rework, a single `git revert` handles it cleanly.

## Test plan

- [x] Doc-only PR — no source files touched, no tests to run
- [x] `docs_guard` doesn't fire — README touch only, no relevant code paths
- [ ] Reviewer: render the README diff on GitHub and confirm each issue's "Suggested edit" line matches the corresponding commit

Closes [#264](https://github.com/jackal998/photo-manager/issues/264)
Closes [#265](https://github.com/jackal998/photo-manager/issues/265)
Closes [#266](https://github.com/jackal998/photo-manager/issues/266)

🤖 Generated with [Claude Code](https://claude.com/claude-code)