### PR TITLE
chore: add PR template with pre-merge checklist (#271)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,22 @@
+## Pre-merge checklist
+
+- [ ] User-visible behaviour added/changed → updated `docs/features.md`
+- [ ] New file under `app/views/{dialogs,handlers,components,workers}/` → corresponding `qa/scenarios/sNN_*.py` driver added
+- [ ] Tests added (unit + qa scenario if user-facing)
+- [ ] No `--no-verify` used
+- [ ] Pre-PR hooks (`docs_guard`, `qa_scenario_guard`) passed locally
+
+For any item that legitimately doesn't apply, replace `[ ]` with `[N/A]` so reviewers can see at a glance that you considered it and made a deliberate call. See [`CONTRIBUTING.md`](../CONTRIBUTING.md#pr-template-and-pre-merge-checklist) for details.
+
+## Summary
+
+<1-3 bullets on what changed and why>
+
+## Test plan
+
+- [ ] `pytest` full suite passes
+- [ ] Per-file coverage floor (70%) clears
+- [ ] qa-batch scenarios pass (if user-facing)
+- [ ] Manual smoke if the change is hard to assert via tests
+
+Closes #N (where applicable)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,6 +31,42 @@ to miss on a fresh checkout:
 
 ---
 
+## PR template and pre-merge checklist
+
+Every new PR auto-fills from
+[`.github/PULL_REQUEST_TEMPLATE.md`](.github/PULL_REQUEST_TEMPLATE.md).
+GitHub picks it up automatically regardless of how the PR is opened
+(CLI, web UI, mobile, fork) — you don't need to copy it in by hand.
+
+The template puts the **Pre-merge checklist** above **Summary** on
+purpose: reviewers scanning a PR see the doc / test / qa-scenario
+boxes first, which makes drift cheap to catch even when local
+hooks (`docs_guard`, `qa_scenario_guard`) didn't run.
+
+**Bypass affordance.** For a checklist item that legitimately
+doesn't apply to your change, replace `[ ]` with `[N/A]`. That
+mirrors the project's `[docs-not-needed: <reason>]` convention but
+at line granularity, and it's reviewer-visible — the box doesn't
+silently disappear, it announces that you considered the rule and
+made a deliberate call. Don't delete checklist lines; leaving the
+`[N/A]` in keeps the template legible from PR to PR.
+
+Enforcement today is honor-system. A CI gate that fails on un-ticked
+boxes is a possible follow-up if drift recurs — see
+[#271](https://github.com/jackal998/photo-manager/issues/271) for
+the design discussion.
+
+CLI users opening a PR via `gh pr create` can pipe the template
+straight into the body:
+
+```
+gh pr create --body-file .github/PULL_REQUEST_TEMPLATE.md
+```
+
+The web UI does this for you automatically.
+
+---
+
 ## Adding a UI string
 
 **Every user-facing string in the app lives in `translations/<locale>.yml`,


### PR DESCRIPTION
## Pre-merge checklist

- [N/A] User-visible behaviour added/changed → updated `docs/features.md`
  *(docs-only / repo-config change; no app behaviour touched)*
- [N/A] New file under `app/views/{dialogs,handlers,components,workers}/` → corresponding `qa/scenarios/sNN_*.py` driver added
- [N/A] Tests added (unit + qa scenario if user-facing)
  *(no code change; sanity-checked `pytest` still green at 88.35%)*
- [x] No `--no-verify` used
- [x] Pre-PR hooks (`docs_guard`, `qa_scenario_guard`) passed locally

## Summary

- Adds `.github/PULL_REQUEST_TEMPLATE.md` so GitHub auto-fills every new PR (CLI / web UI / mobile / fork) with the project's convention shape plus an explicit doc / test / qa-scenario checklist.
- Section order is **Pre-merge checklist before Summary** per the #271 design call — reviewers scanning a PR see the checkboxes first, so drift is cheap to catch even when local hooks (`docs_guard`, `qa_scenario_guard`) didn't run.
- `[N/A]` is the documented bypass (line-granular mirror of the existing `[docs-not-needed]` convention); reviewer-visible so a skipped box announces a deliberate call instead of silently disappearing.
- `CONTRIBUTING.md` gets a new section explaining the template, the `[N/A]` bypass, the honor-system posture, and a `gh pr create --body-file` tip for CLI users.

Enforcement is honor-system to start. A CI gate failing on un-ticked boxes is a possible follow-up if drift recurs.

## Test plan

- [x] `pytest` full suite passes (1221 passed, 2 skipped; 88.35% global coverage)
- [x] Per-file coverage floor (70%) clears — no code changes, so baseline is unaffected
- [N/A] qa-batch scenarios pass (if user-facing) — no UI / scanner / QA-path changes
- [ ] **Post-merge verification:** open a throwaway one-commit PR against master to confirm GitHub auto-fills from the template (acceptance criterion can only be tested after this PR lands; close the throwaway without merging)

Closes #271