### PR TITLE
chore(skills): split tracked project vs personal (#270)

### DIFF
--- a/.claude/skills/impact-map/SKILL.md
+++ b/.claude/skills/impact-map/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: impact-map
+description: Use BEFORE editing any function, class, or module in photo-manager.
+  Maps upstream callers and downstream dependencies so you know which tests must
+  pass and which behaviors might shift. Pairs with update-docs (post-change).
+origin: local
+---
+
+# Impact map — before editing a non-trivial symbol
+
+The point: no code change ships in `photo-manager` without first knowing
+who calls what and which test exercises that path. If a caller has no test
+and you're about to change behavior the caller relies on, write the test
+*before* the edit.
+
+## When to activate
+
+- Modifying a public function/class signature
+- Changing return shape, raised exceptions, or side-effect behavior
+- Renaming or deleting a symbol
+- Touching a SQLite migration, a `settings.json` key, or a background worker
+- Changing scanner pipeline stages (walker, hasher, exif, dedup, manifest)
+- Changing any `infrastructure/` service that other modules import
+
+Skip for: typo fixes, comment-only edits, or strictly internal refactors of
+a private helper that is verifiably called from one place and is fully
+covered by an existing test.
+
+## Checklist (run all of it before the edit)
+
+1. **Upstream callers** — `Grep` the symbol name across `app/`, `scanner/`,
+   `core/`, `infrastructure/`, and `tests/`. List every call site with
+   `file:line`. **Don't forget non-source consumers**: QA driver scripts
+   under `qa/scenarios/`, doc tables in `docs/testing.md`, and string
+   references in `app/views/` (button labels, menu titles, accessibility
+   names) all break the same way #72 broke when we renamed the scan
+   button without grepping.
+2. **Downstream dependencies** — what does the function call into? Note any
+   I/O (DB, FS, subprocess, Qt) it relies on, since changes there cascade.
+   Boundary calls (subprocess to `exiftool`, `send2trash`, `rawpy`,
+   `pillow-heif`, `Image.open` on edge formats) are covered at the
+   happy-path level by qa-explore scenarios with real fixtures (layer 3).
+   Flag a layer-2 spot-test only if you're introducing a new boundary
+   error mode that's hard to trigger through the GUI — otherwise let
+   layer 3 carry the safety. Layer 2 is on-demand; see
+   [`docs/testing.md`](../../../docs/testing.md).
+3. **Tests covering each call site, by layer** — for every caller in (1),
+   identify which test exercises that path AND at which layer:
+     - Layer 1 (`tests/test_*.py` — unit + mock)
+     - Layer 2 (`tests/integration/` — real binaries, when present)
+     - Layer 3 (`qa/scenarios/sNN_*.py` — qa-explore E2E)
+   Flag callers with NO coverage at the layer that matters for the
+   change. Boundary changes need layer 2; UI-touching changes need
+   layer 3.
+4. **Behavior contract** — write down (in chat, not a file) the inputs,
+   outputs, raised exceptions, and side-effects you intend to *preserve*
+   versus *change*.
+5. **Plan test updates** — if behavior is changing, list the existing tests
+   that must be updated. If a caller has NO test and your change could
+   break it, add a test before editing the symbol.
+
+   **What a real test looks like** (per [`CLAUDE.md`](../../../CLAUDE.md)
+   testing rules): it triggers the failure mode with a *real* input — a
+   truncated file, a missing optional dep, a malformed payload — and
+   asserts the user-visible outcome. A test that mocks
+   `QStandardItem.setData` to raise just so the wrapped `except: pass`
+   runs is metric gaming, not bug-catching. If a defensive branch can't
+   be triggered with a real input, leave it covered by a comment in the
+   source, not by a synthetic assertion.
+
+## Output format
+
+A short table in chat, then proceed:
+
+```
+| Caller                                          | Test                                              | Action needed                              |
+|-------------------------------------------------|---------------------------------------------------|--------------------------------------------|
+| app/views/handlers/file_operations.py:127       | tests/test_file_operations.py::test_batch_update (L1)              | none                                       |
+| scanner/dedup.py:88                             | (no L1)                                                            | add test before changing signature         |
+| infrastructure/manifest_repository.py:204       | tests/test_manifest_repository.py::test_save (L1)                  | update assertion for new return shape      |
+| infrastructure/delete_service.py:67             | tests/test_delete_service.py (L1, mocked); qa-explore s13 (L3, planned)  | qa-explore s13 covers happy path through send2trash; add a layer-2 spot-test only for specific error modes (locked file, network drive, permission denied) |
+| qa/scenarios/_uia.py:55 (button title constant) | qa/scenarios/sNN_*.py drivers (L3)                                 | update constant + commit message; layer-3 batch will catch drift on next run |
+```
+
+After the edit, switch to the `update-docs` skill to keep `README.md`,
+`pyproject.toml`, and the per-module residual-risk table in
+`docs/testing.md` in sync.
+
+## Why this exists
+
+The project's unit suite only protects what it covers. A change to a
+function used in five places is only safe if all five places are tested
+— or if you confirm in advance that the change preserves the behavior
+the untested callers depend on. And "tested at the right layer": a
+boundary change (subprocess, third-party lib) won't fail layer-1 mocks
+even when the real boundary is broken. This skill makes the
+caller-and-layer mapping explicit instead of assumed.

--- a/.claude/skills/parallel-brief-generator/SKILL.md
+++ b/.claude/skills/parallel-brief-generator/SKILL.md
@@ -1,0 +1,418 @@
+---
+name: parallel-brief-generator
+description: Generate self-contained briefs for one or more cold Claude Code desktop sessions that will work in isolated parallel worktrees. The orchestrator session (where this skill is invoked) takes the user's high-level intent, researches each task independently via `gh issue view` + codebase Read/Grep, runs pre-flight (clean tree, base SHA pin, `.worktreeinclude` check, scenario slot pre-assignment, file-disjoint collision matrix), and outputs N copy-paste-ready prompts. The user pastes each into a fresh "+ New session" with the "create worktree" option enabled so each session is truly isolated — never sees, never touches the others' work. Use whenever the user wants to scope out one or more issues for cold-session work; single-task input is valid (the cross-bundle steps are no-ops at N=1) and parallel multi-issue is the primary use case. Triggers include "fan out X, Y, Z in parallel", "brief out these issues", "generate work brief for #N", "prepare a cold session to do …", "ship the status-bar bundle and the scan-dialog fix in parallel".
+---
+
+# parallel-brief-generator — briefs for isolated parallel sessions
+
+## What this skill actually does
+
+The Claude Code desktop app can create a git worktree per session
+(under `.claude/worktrees/<session-name>/`) when the user enables
+the "create worktree" option at session-open time. That gives true
+isolation: each session has its own checkout, own branch, own
+context — never sees the others' work.
+
+But cold sessions can't coordinate with each other. They share no
+state at startup. So a few things still need a single orchestrator:
+
+1. **Per-task research** — the user gives high-level intent ("brief
+   #144" or "fan out the status bar bundle and scan dialog fix"),
+   not pre-digested specs. The orchestrator runs `gh issue view`,
+   reads issue bodies, Greps the codebase for the cited files, and
+   builds a concrete task spec for each.
+2. **File-scope collision check** — if Bundle A and Bundle B both
+   plan to edit `main_window.py`, name the overlap up-front so the
+   second-merged branch's rebase cost is visible at fan-out time,
+   not discovered at PR-merge time.
+3. **Scenario slot pre-assignment** — if two cold sessions both grab
+   `qa/scenarios/s37_*.py`, you get a name collision at PR time.
+   Hand out s37, s38, s39 in advance from the first free slot.
+4. **Base SHA pinning** — all sessions branch off the same commit,
+   so their work is comparable and merge-order-flexible.
+
+This skill, run in the orchestrator session, does those things and
+**emits one brief per task** — self-contained prompts the user
+pastes into cold sessions. Each brief tells its session everything
+it needs (the pre-flight checks, the task spec, the project
+conventions, the through-PR workflow) without any reference back to
+the orchestrator. Single-task input is valid; the cross-bundle
+steps (collision check, slot pre-assignment) are no-ops at N=1, but
+the research and brief-template benefits still apply.
+
+## When to use vs when to skip
+
+Use this skill whenever:
+- **Multiple independent items** the user wants briefed for parallel
+  work, especially file-disjoint scope.
+- **One task the user wants written up as a hardened brief** with
+  pre-flight baked in (e.g., they'll paste it into a new session
+  later or share it with another developer).
+
+Skip the skill (prompt the new session directly) when:
+- The task is trivial (one-line config edit) and a full brief is
+  ceremony, OR
+- The user already has the task spec in their head and wants to
+  just open the session and start typing, OR
+- One task's design depends on another's outcome — e.g. #68 (UI
+  bucket split) depends on #165 (execute-dialog redesign). Brief out
+  one; defer the other until the design lands.
+
+## Required one-time repo setup
+
+The desktop's auto-worktree feature copies gitignored files into new
+worktrees ONLY if they match a pattern in `.worktreeinclude` at the
+repo root. Without that file, every new session lands in a worktree
+without `.claude/settings.json`, which means **no hooks fire** —
+`qa_scenario_guard`, `docs_guard`, `zombie_check` are all dormant.
+
+Check before generating briefs:
+
+```
+test -f .worktreeinclude && grep -q "\.claude/settings\.json" .worktreeinclude \
+  && echo "OK" || echo "MISSING — set up .worktreeinclude before fanning out"
+```
+
+If missing, stop and tell the user. Don't generate briefs against a
+broken worktree config.
+
+## Orchestrator workflow
+
+### Step 1 — Understand intent and research independently
+
+The user gives high-level intent, not pre-digested task details.
+Typical inputs:
+
+- `"fan out the status bar bundle and the scan dialog fix"`
+- `"brief out #138+#140, #144, #136+#141"`
+- `"just brief #144 — I want to do it next"`
+- `"prepare a session to tackle the locked-state preview pane idea (#165)"`
+
+**Your job is to research the tasks yourself, not ask the user to
+summarize them.** Asking the user to paste in issue bodies is a code
+smell — the issues are right there on the remote.
+
+For each issue mentioned (or implied by bundle name):
+
+1. `gh issue view <N>` — read the body. Extract the user-visible
+   problem, the suggested fix (if any), the files/line numbers the
+   author cited.
+2. If the body cites file paths or line numbers, `Read`/`Grep` those
+   locations to verify currency (the body may be stale relative to
+   master).
+3. If the user names a bundle without numbers ("status bar bundle"),
+   skim `gh issue list --state open --limit 30` and pair the
+   bundle name to issue numbers by topic. The recent conversation
+   history of the project (if available) is the next-best source.
+4. If two open issues plausibly match the user's description, ask
+   ONE clarifying question. Otherwise don't outsource research.
+
+You also need (these are usually trivial to infer):
+
+- **Base ref** — usually `master`. Confirm up to date with
+  `git fetch origin`.
+- **Branch prefix** — `fix/`, `feat/`, `chore/`, `test/` based on
+  task type. Each cold session picks its own slug.
+- **PR pipeline scope** — default: each cold session pushes + opens
+  its own PR end-to-end with the normal per-PR gated confirms. Only
+  override if the user explicitly says "stop at branches, I'll
+  push myself".
+
+### Step 2 — Cross-bundle pre-flight (orchestrator side)
+
+```
+git fetch origin && git status -sb       # confirm clean tree
+git rev-parse origin/master               # note base SHA for all briefs
+ls qa/scenarios/sNN_*.py | tail -5        # find highest taken slot
+```
+
+Then build the **file-scope matrix**: for each bundle, list the
+files it plans to touch. If two bundles touch the same file,
+SURFACE this to the user before continuing — name the overlap and
+the likely rebase cost. Don't silently fan out overlapping work.
+
+Pre-assign slot numbers: if bundles A, B, C each need a new
+`qa/scenarios/sNN_*.py`, hand out `sNN`, `sNN+1`, `sNN+2` from the
+first free slot.
+
+### Step 3 — Generate one brief per task
+
+Each brief is **fully self-contained**. The cold session has no
+memory of this conversation; everything it needs must be in its
+brief.
+
+**Fence-delimiter rule when you emit briefs** — wrap each brief in
+a tilde fence (`~~~~`), NOT a backtick fence. Briefs routinely
+contain unindented triple-backtick code blocks (the cold session's
+cleanup snippets, repro commands, etc.), and Claude Code's
+markdown renderer treats a nested ``` as a premature close even
+inside a quad-backtick outer fence — earlier briefs rendered
+"invisible" past the first nested block. Tilde fences are a
+different fence character entirely, so any inner ``` is
+unambiguously content. (The template below is shown inside a
+backtick fence for skill readability — but when you OUTPUT each
+brief to the user, wrap with `~~~~`.) Template structure:
+
+```
+You are working on photo-manager issue(s) #<N> in a fresh Claude Code
+desktop session. If the user opened this session with the
+"create worktree" option enabled, you're in your own auto-worktree
+under `.claude/worktrees/<your-session-name>/` — isolated from any
+other sessions. If the option was off, you share the current
+checkout — fine for sequential work, risky for true parallel work.
+
+The orchestrator session that generated this brief is independent;
+you have no visibility into it or into any sibling sessions, and
+they have none into you.
+
+## Pre-flight — verify before touching code
+
+  - [ ] `git status -sb` — should be clean. If not, ask user.
+  - [ ] `git rev-parse HEAD` — should be `<base-sha-noted-by-orchestrator>`
+        (or ahead via origin fetch). If behind, ask user.
+  - [ ] `test -f .claude/settings.json` — must exist. If missing,
+        `.worktreeinclude` isn't carrying it; STOP and tell user
+        before doing anything else (hooks won't fire).
+  - [ ] `ls qa/scenarios/<your-pre-assigned-slot>_*.py` — should be
+        empty (slot is yours). If a file already exists there, slot
+        was contested; ask user how to renumber.
+
+## Your task
+
+Issue: <one-paragraph summary including the user-visible problem>
+
+Files in scope:
+  - <path:line> — <what to change>
+  - <path:line> — <what to change>
+
+Files NOT in scope (other cold sessions own these — touching them
+will cost a rebase at PR-merge time):
+  - <path> — owned by sibling session doing #<M>
+  - <path> — owned by sibling session doing #<P>
+
+Pre-assigned scenario slot: <sNN> (if you add a new layer-3 scenario)
+Suggested branch: <prefix>/<slug>
+
+Acceptance:
+  - <test-layer requirements, e.g. layer-1 + layer-3 scenario>
+  - <coverage floor, e.g. 70% per-file on every file touched>
+  - <docs that must update if applicable>
+  - <any task-specific gotchas>
+
+## Project conventions (non-negotiable)
+
+  - Python — the venv lives at the **main repo root**, not inside the
+    worktree. From inside a worktree (cwd is
+    `.../<repo>/.claude/worktrees/<name>/`) the correct path is
+    `../../../.venv/Scripts/python.exe`. From a normal checkout it's
+    `.venv/Scripts/python.exe`. Don't burn turns trying both — pick
+    based on `pwd`. (System Python lacks PySide6.)
+  - Branch off `<base-ref>` at SHA `<base-sha>`.
+  - No `--no-verify` under any circumstances.
+  - No mock-driven test padding — every assertion must catch a real
+    user-visible bug. (`CLAUDE.md` "Testing hard floor" applies.)
+  - Bridge pattern: if you add a new method on a handler class
+    surfaced via the main-window context menu, also add the proxy on
+    `ActionHandlersImpl` (`feedback_action_handlers_bridge` in
+    auto-memory).
+
+## Workflow through PR
+
+In every command below, **PY** is the venv python — from a worktree
+that's `../../../.venv/Scripts/python.exe`, from a normal checkout
+it's `.venv/Scripts/python.exe`. Resolve once at the start of your
+session, then reuse.
+
+  1. `git checkout -b <your-branch>` (your worktree starts on master).
+  2. Implement the change.
+  3. `PY -m pytest` — must pass.
+  4. `PY scripts/check_coverage_per_file.py` — 70% per-file floor on
+     every file touched.
+  5. If you added a new layer-3 scenario, run it:
+     `PY -m qa.scenarios._batch <sNN>_<name>`
+  6. Commit with conventional-commit message + `Closes #<N>` trailer
+     + `Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>`.
+  7. **Gated:** surface push intent to user, on approval
+     `git push -u origin <your-branch>`.
+  8. **Gated:** surface PR-create intent, on approval
+     `gh pr create --title "<title>" --body "<body>"`. Hooks
+     (`qa_scenario_guard`, `docs_guard`) will fire — if blocked,
+     surface the hook message and decide with user:
+       a) hand-fix and retry
+       b) bypass with `[qa-not-needed: <reason>]` or
+          `[docs-not-needed: <reason>]` in the gh command
+       c) skip this branch
+  9. Capture PR URL, report to user.
+
+## Cleanup — after the PR merges
+
+The cold session that did the work (this one, or any future session
+opened against the same worktree) is responsible for cleanup. The
+orchestrator never does it. Workflow:
+
+1. Confirm the merge landed — proves the work is preserved before
+   you delete anything:
+   ```
+   git fetch --prune origin
+   git log origin/master --grep="#<N>" --oneline | head -3
+   ```
+   If nothing matches, STOP — the PR may have been closed without
+   merge, or you're looking at the wrong issue. Don't delete.
+
+2. Check the remote branch — GitHub usually auto-deletes on merge:
+   ```
+   git ls-remote --heads origin <your-branch>
+   ```
+   Empty output means GitHub already cleaned it up. If a SHA prints,
+   the remote branch survived — **gated:** surface intent, on
+   approval `git push origin --delete <your-branch>`.
+
+3. Delete the local branch. You can't delete the branch that's
+   currently checked out in your worktree, so detach HEAD first:
+   ```
+   git checkout --detach HEAD
+   git branch -D <your-branch>
+   ```
+   Use `-D` (force) because upstream is `gone` after merge (or after
+   step 2), which makes `-d`'s upstream-merge check unresolvable.
+   Work IS preserved on origin/master per step 1, so `-D` is safe —
+   **gated:** surface intent briefly before running per CLAUDE.md.
+
+4. Remove the worktree itself. This step has to run from the MAIN
+   repo, not from inside the worktree — you can't remove your own
+   cwd. Tell the user; they run from the main checkout:
+   ```
+   git worktree remove .claude/worktrees/<your-session-name>
+   ```
+   Or right-click the session in the desktop sidebar → Delete.
+```
+
+### Step 4 — Hand briefs to user
+
+Output each brief in its own clearly-labeled code block. Tell the
+user the desktop flow:
+
+> Open Claude Code desktop → click **+ New session** in the sidebar →
+> **Select folder** (the photo-manager repo) → **enable the "create
+> worktree" option for parallel work** (leave off only if you intend
+> to run the briefs sequentially in one checkout). Paste one brief in
+> as the first message.
+>
+> Briefs are time-independent — paste them when and in whatever
+> order you want. You don't have to open all N sessions at once;
+> the briefs all branch off the same SHA so they're merge-order
+> flexible.
+
+### Step 5 — Done
+
+Once briefs are handed off, the orchestrator's primary job is done.
+Each cold session does its own pre-flight, work, and PR with the
+normal gates intact.
+
+You can optionally stay open as a coordination point — if a sibling
+session asks (via the user) "how do I resolve a docs-guard block on
+my branch?", answer it. But don't try to drive the cold sessions
+from here; they own their work end-to-end.
+
+## Anti-patterns — do not do these
+
+- **Hardcoding `.venv/Scripts/python.exe` in brief commands.** Cold
+  sessions opened with "create worktree" run from
+  `.claude/worktrees/<name>/` where that path doesn't exist — the
+  venv lives at the main repo root, so it's `../../../.venv/...`
+  from there. Use a `PY` placeholder in the brief's workflow section
+  and tell the cold session to resolve it once based on `pwd`. (This
+  was a recurring time-sink across multiple sessions before the
+  template was fixed.)
+- **Generating briefs without the file-scope collision check.** Two
+  cold sessions blindly editing the same file means a rebase fight
+  at PR-merge time you didn't see coming.
+- **Skipping the `.worktreeinclude` precondition check.** Without
+  that file, the new sessions have no hooks active and the security
+  model silently degrades.
+- **Embedding "ask the orchestrator session" in the brief.** Cold
+  sessions are independent; if they need a decision the brief
+  didn't anticipate, they ask the user, not the orchestrator.
+- **Trying to fan out from a sub-agent.** Sub-agents in this harness
+  have permission constraints (Edit/Write denied by hooks like
+  `suggest-compact`, Bash sometimes denied). Fan-out is a
+  user-driven, session-driven operation. See
+  `feedback_sub_agent_write_denied` in auto-memory if you've
+  forgotten.
+- **Wrapping output briefs in a backtick fence (` ``` ` or even
+  `````` quad).** Briefs contain unindented ``` code blocks
+  internally; Claude Code's renderer treats those as a premature
+  close and everything past the first nested block renders blank.
+  Always wrap each emitted brief in `~~~~` (tilde fence) — tilde and
+  backtick are different fence chars, so inner ``` is unambiguously
+  content. This was caught mid-session on 2026-05-15 (briefs for
+  #230 and #212 rendered invisible).
+
+## Photo-manager-specific reminders to bake into every brief
+
+- **Hooks gating `gh pr create`** — `qa_scenario_guard` blocks PRs
+  that change `app/views/{handlers,dialogs,components,workers}/`
+  without a `qa/scenarios/sNN_*.py` change. `docs_guard` blocks PRs
+  that add new modules under `app/`, `infrastructure/`, `scanner/`,
+  `core/services/` (or new tests, or qa-scenario changes) without
+  touching `README.md` / `docs/*.md` / `CLAUDE.md` / `pyproject.toml`.
+- **`read_result_rows` is broken on CI** — has a `y_min=600` filter
+  that drops all rows on the smaller CI render. Use sqlite reads
+  (pattern: s14, s32, s35) for tree-content assertions.
+- **Trailing-period Windows paths**, **Live Photo pair-clusters**,
+  **case-insensitive pathlib** — these are scanner-side gotchas;
+  only bake into briefs whose scope touches `scanner/`.
+- **Destructive QA scenarios** — `s13`, `s36` send real files to the
+  recycle bin per run. Do NOT extend destructive coverage without
+  explicit user agreement.
+
+## Output shape — what the orchestrator's final message looks like
+
+```
+Cross-bundle pre-flight:
+  - Base: master @ <SHA>
+  - Working tree: clean
+  - .worktreeinclude: OK (covers .claude/settings.json)
+
+File-scope matrix (collisions named):
+  | Bundle | Files | Overlap with |
+  | ...    | ...   | ...          |
+
+Slot pre-assignment:
+  - Bundle A → s<NN>
+  - Bundle B → s<NN+1>
+  ...
+
+## Brief for Bundle A (paste into a new "+ New session")
+
+~~~~
+<brief text — inner ``` blocks render fine inside this tilde fence>
+~~~~
+
+## Brief for Bundle B (paste into a new "+ New session")
+
+~~~~
+<brief text>
+~~~~
+
+## Brief for Bundle C (paste into a new "+ New session")
+
+~~~~
+<brief text>
+~~~~
+
+Done. Open Claude Code desktop → + New session × N → Select folder
+(photo-manager) → paste one brief into each.
+```
+
+## Quick reference — minimal flow
+
+1. User: high-level intent — "fan out X, Y, Z" / "brief #N" / "prep
+   a session to do …".
+2. Orchestrator researches each task (`gh issue view`, Read/Grep),
+   runs pre-flight (steps 1–3 of this skill).
+3. Orchestrator outputs N briefs + collision report.
+4. User opens N "+ New session" windows (or fewer, or one — N is
+   the user's call) — enabling the worktree option for parallel
+   work — and pastes briefs in as first messages.
+5. Each cold session does its own pre-flight, work, and PR.

--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -1,0 +1,958 @@
+---
+name: qa-explore
+description: Run the photo-manager QA agent as a human-first tester — launches the app, walks it like a curious first-time user, notices friction (slow, confusing, missing feedback) as well as outright bugs, and separates correctness issues (file as GitHub issues) from UX friction (batch as review notes for the human). Does not fix anything.
+---
+
+# /qa-explore — photo-manager QA agent
+
+You are the QA agent for photo-manager. Run this end-to-end without
+asking the user to fill in steps. Five phases, in order. Do not skip.
+
+This is **layer 3 of the project's testing strategy** (see
+[`docs/testing.md`](../../../docs/testing.md) and [`CLAUDE.md`](../../../CLAUDE.md)
+"Testing ground rules"). Layer 1 (`pytest`) catches refactoring bugs;
+this skill catches what tests can't — and what a real user would
+notice. Two streams come out of a run: **correctness findings** (a
+real defect a reasonable user would call broken — these are filed as
+GitHub issues, usually P1/P2) and **UX-friction notes** (judgment
+calls about how the app feels — these are printed inline for the
+human to triage, never auto-filed).
+
+## Mission
+
+Drive the app like a curious first-time user with their own photo
+library — not a function-checker walking a test plan. Report what you
+observe. Do NOT fix anything, edit source, run git, or open PRs.
+Findings are observations grounded in what you saw on screen —
+never in source code.
+
+Two mindsets, two kinds of finding:
+
+| Logic-machine QA (NOT this) | Human-tester QA (THIS) |
+|---|---|
+| "Did the function return the right value?" | "Did I know it worked?" |
+| "Was the dialog dismissable?" | "Was the button labelled in a way I'd find?" |
+| "Did the count match?" | "Did the wording make sense the first time I read it?" |
+| "Was the error path covered?" | "Did the error message tell me what to do next?" |
+| Reports `function returned None` | Reports `after scanning, there was no confirmation — I couldn't tell if it worked` |
+
+If your finding could only have been written by reading source, it's
+the wrong finding. Phrase every observation as something the user felt
+or didn't get told — confusion, surprise, doubt, "wait, did that
+work?", "where did my work go?", "why is this still spinning?".
+
+**Friction counts as much as failure.** A button that exists but is
+hard to find is a finding. A spinner that runs longer than feels
+right is a finding. A status bar that goes blank when you open a menu
+is a finding. You don't need the app to *break* to file something —
+you need a moment where a real user would have hesitated, doubted, or
+re-checked.
+
+## What users actually care about (from project history)
+
+These categories recur across closed bug/UX issues — they're what
+users have actually complained about on this project. Weight your
+exploration toward these, not toward exotic edge cases that no one
+has hit.
+
+### A. "Did it work?" — feedback after every action
+
+The single most common class of complaint: doing something and not
+being sure whether it succeeded.
+
+- Status bar empty when no manifest loaded ([#138](https://github.com/jackal998/photo-manager/issues/138))
+- Status bar context wiped permanently when any menu opens ([#140](https://github.com/jackal998/photo-manager/issues/140))
+- Empty-folder scan never logs "Done." — looks hung ([#56](https://github.com/jackal998/photo-manager/issues/56))
+- Empty-folder scan shows error icon instead of neutral result ([#51](https://github.com/jackal998/photo-manager/issues/51))
+- "Close & Load" button missing after a zero-file scan ([#86](https://github.com/jackal998/photo-manager/issues/86))
+- Scan dialog "+ Add" silently fails for non-existent paths ([#144](https://github.com/jackal998/photo-manager/issues/144))
+- Re-scan while manifest loaded silently overwrites ([#142](https://github.com/jackal998/photo-manager/issues/142))
+
+**As a tester, after every action ask:** *did anything visibly
+acknowledge that?* The absence of an error is not feedback. If you
+need to peek at the log file to know whether something worked,
+that's a finding.
+
+### B. Copy, labels, wording
+
+Small wording bugs land at high frequency because they're visible on
+every screen.
+
+- "Close  Load" with a double space ([#54](https://github.com/jackal998/photo-manager/issues/54))
+- "1 pairs to review" — hardcoded plural ([#109](https://github.com/jackal998/photo-manager/issues/109))
+- "M1" suffix in window title with no explanation ([#41](https://github.com/jackal998/photo-manager/issues/41))
+- "priority" wording in scan folder list confused users ([#213](https://github.com/jackal998/photo-manager/issues/213))
+- Stale "SKIP" / "MOVE" wording from legacy design ([#180](https://github.com/jackal998/photo-manager/issues/180))
+
+**As a tester, read every label out loud.** If you'd hesitate over
+what one means without context, that's a finding. Watch for plurals,
+double spaces, mystery suffixes, jargon from old designs.
+
+### C. Discoverability — "where is the button?"
+
+- No first-run / empty-state guidance ([#42](https://github.com/jackal998/photo-manager/issues/42), [#137](https://github.com/jackal998/photo-manager/issues/137))
+- File picker had no text path entry / paste ([#40](https://github.com/jackal998/photo-manager/issues/40))
+- "List" menu opened nothing — no submenu, no items ([#52](https://github.com/jackal998/photo-manager/issues/52))
+- Top-level menus lacked Alt-key mnemonics ([#135](https://github.com/jackal998/photo-manager/issues/135))
+
+**As a tester, on first launch, ask:** *what do I click first?* If
+you walked into the app cold, would you find the start-a-scan path
+inside 10 seconds? Try keyboard-only (Alt+letters, Tab, arrows) —
+does the app cooperate?
+
+### D. Modal / state behavior — "what is the app's mode right now?"
+
+- Execute Action dialog was non-modal — main-window menus stayed clickable ([#139](https://github.com/jackal998/photo-manager/issues/139))
+- Two-step delete confirm felt redundant ([#30](https://github.com/jackal998/photo-manager/issues/30))
+- Window position / size not persisted across launches ([#141](https://github.com/jackal998/photo-manager/issues/141))
+- Failed Open Manifest disabled actions on the previously-loaded one ([#108](https://github.com/jackal998/photo-manager/issues/108), [#110](https://github.com/jackal998/photo-manager/issues/110))
+- Right-click on empty area / menu bar produced an irrelevant menu ([#124](https://github.com/jackal998/photo-manager/issues/124))
+
+**As a tester, try ordinary mistakes:** open a dialog, click behind
+it, try to use the main window. Close the app, reopen — same shape,
+same column widths, same selection? Right-click in odd places — do
+you get a menu that makes sense for *that* spot?
+
+### E. Destructive actions — "did I lose work?"
+
+- Re-scan silently overwrote pending decisions ([#142](https://github.com/jackal998/photo-manager/issues/142))
+- Locked files could be removed from the delete list ([#208](https://github.com/jackal998/photo-manager/issues/208))
+- Locked-confirm dialog fired incorrectly with mixed locked + unlocked ([#207](https://github.com/jackal998/photo-manager/issues/207))
+- Save Manifest data-loss with uncheckpointed WAL ([#91](https://github.com/jackal998/photo-manager/issues/91))
+
+**As a tester, before any "Yes" on a destructive prompt, ask:** *do I
+know exactly what gets deleted, and is that what I meant?* Try the
+destructive flow with locks set, with multi-selection that includes
+locked items, with unsaved manifest changes pending — does the count
+in the prompt match the count you'd expect?
+
+### F. Real-data correctness
+
+- Live Photo HEIC+MOV pair not grouped ([#88](https://github.com/jackal998/photo-manager/issues/88))
+- Scan summary undercounted skipped files ([#87](https://github.com/jackal998/photo-manager/issues/87))
+- exiftool batch returned wrong/empty dates for some files ([#145](https://github.com/jackal998/photo-manager/issues/145))
+- DNG resolution wrong in scanner and preview ([#32](https://github.com/jackal998/photo-manager/issues/32))
+- Sort by Similarity used group_number, not what users expected ([#29](https://github.com/jackal998/photo-manager/issues/29))
+
+**As a tester, glance at the results table after every scan:** does
+anything look obviously wrong for the data you put in? Wrong date,
+missing thumbnail, missing file, weird sort order, group that
+shouldn't be a group, file that should be grouped but isn't?
+
+### G. Performance felt by a human
+
+- NAS load was slow before manifest metadata caching ([#15](https://github.com/jackal998/photo-manager/issues/15))
+- SQLite without WAL was slow ([#18](https://github.com/jackal998/photo-manager/issues/18))
+- Hosted CI native dialog COM modal silently dropped input ([#129](https://github.com/jackal998/photo-manager/issues/129))
+
+**As a tester, notice when a spinner runs longer than you'd expect.**
+"Felt slow" with a wall-clock estimate is a valid finding. Whether a
+3-second wait is too long for *this* action is a judgment a logic
+check cannot make — that's why you're here.
+
+## Hard rules (self-policed; non-negotiable)
+
+- **Source is read-only.** Phase 1 reads the orient list below; after
+  that, treat the source tree as off-limits even if you're confused.
+  If you can't figure out how to do X from the UI alone, that IS the
+  finding — do not open the source to "cheat".
+- **Fixtures only.** Read photos solely from `qa/sandbox/`. Never open
+  any directory the user mentioned in their root `settings.json` or
+  anywhere else.
+- **Isolated config.** Always launch with `PHOTO_MANAGER_HOME=<repo>/qa`
+  set so the app reads `qa/settings.json` (which only references
+  `qa/sandbox/`) and writes its manifest to `qa/run-manifest.sqlite`.
+  The user's root `settings.json` and `migration_manifest.sqlite` are
+  not touched.
+- **Every `python main.py` launch is gated.** In default-batch mode
+  (Phase 3 with no user hint), get one `yes batch` approval covering
+  the whole batch, then proceed without re-prompting per scenario.
+  In subset/manual mode, pause and ask before each individual launch.
+  State the scenario number + title.
+- **No git commands at all.** No commits, no `git status`, no
+  branches. (Reading `git log` is technically allowed by the project
+  CLAUDE.md but you don't need it.)
+- **No source edits.** Writes restricted to:
+  - `qa/sandbox/**` (only via `scripts/make_qa_sandbox.py`)
+  - GitHub issues created via `gh issue create` (gated)
+  Screenshots stay in-context (inline-only); no files written.
+
+## Stop conditions
+
+- ~15 minutes wall-clock cap on Phase 4 exploration. Stop early if
+  you're past it.
+- ≥10 **correctness** findings accumulated → pause, list them, ask
+  the user to triage before continuing. (UX-friction notes don't
+  count toward this cap — they batch into one review block at the
+  end regardless of how many there are.)
+- Any startup failure of `main.py` → file as a finding, then stop the
+  run. Don't try to diagnose the source.
+
+---
+
+## Phase 1 — Orient (≤2 min, read-only)
+
+Read these and only these. Do not deep-read; you want what the app
+*claims* to do, not how it does it.
+
+1. `README.md` — top section, "What the app does" / "Workflow"
+2. `main.py` — imports + the `__main__` block only (the launch
+   command and any startup args)
+3. `app/views/` — directory listing (filenames only, no contents)
+
+Stop reading source after this.
+
+## Phase 2 — Seed fixtures
+
+Verify the sandbox tree exists and is populated:
+
+```
+qa/sandbox/empty/             (0 files + .gitkeep)
+qa/sandbox/unique/            (10 .jpg)
+qa/sandbox/near-duplicates/   (5 .jpg)
+qa/sandbox/corrupted/         (1 .jpg)
+qa/sandbox/huge/              (1 .jpg)
+```
+
+Use Glob to count. If any subdir is missing or has the wrong count,
+state which one and ask the user to approve running:
+
+```
+.venv/Scripts/python.exe scripts/make_qa_sandbox.py
+```
+
+(This script is idempotent and only writes to `qa/sandbox/`. It
+imports helpers from `scripts/make_qa_images.py`.)
+
+If everything is already populated, skip the regen and move on.
+
+## Phase 3 — Plan
+
+**Default behavior — invoked with no additional prompt:** run **all
+21 scenarios** in batch via `qa.scenarios._batch`. Don't print the
+menu, don't ask which to run. Get one `yes batch` approval up front
+(per the gate rule below) and proceed. The full batch typically
+finishes in ~30–60 seconds with the focus fix in `_uia.py`.
+
+**Invoked with hints** (e.g. `/qa-explore smoke`, `/qa-explore 1,2,9`,
+`/qa-explore failed 8`): respect the hint, run only the named subset,
+still in batch.
+
+The scenario menu below is reference material — show it only if the
+user asks "what scenarios are there?" or wants to pick a subset
+manually.
+
+### Standard scenario menu
+
+**Core flow** (do most of the time):
+
+| # | Title | Folder | What it probes |
+|---|---|---|---|
+| 1 | Happy path: scan + review + mark | `unique/` then add `near-duplicates/` | Golden flow end-to-end |
+| 2 | Empty folder | `empty/` | Empty-state UX, no-results dialog |
+| 3 | Cancel scan mid-run | `near-duplicates/` or `huge/` | Interrupt handling, partial-state cleanup |
+| 4 | Corrupted file handling | `corrupted/` | Hash/EXIF error paths, user-facing error msg |
+| 5 | Heavy preview interaction | `huge/` | Large-image perf, keyboard nav, resize, rapid clicks |
+
+**Format and metadata coverage** (rotate in periodically):
+
+| # | Title | Folder(s) | What it probes |
+|---|---|---|---|
+| 6 | Multi-format scan | `formats/` | HEIC, PNG, GIF, WebP, TIFF: thumbnails render, dates extracted (GIF has none — verify graceful handling) |
+| 7 | Format duplicate (HEIC vs JPG of same scene) | `format-dup/` | FORMAT_DUPLICATE classifier — HEIC should win, JPG marked as the dup |
+| 8 | EXIF edge cases | `exif-edge/` | Date column for: timezone offset, sub-second, CreateDate-only, DateTime tag-only, zero sentinel, dash sentinel |
+| 9 | Walker exclusion rules | `walker-exclusions/` | Only the 2 real photos appear; sidecar.json, Thumbs.db, desktop.ini correctly skipped |
+
+**Cross-cutting** (probe deeper integrations):
+
+| # | Title | Folder(s) | What it probes |
+|---|---|---|---|
+| 10 | Multi-source priority + cross-source dedup | `multi-source-a/` AND `multi-source-b/` (both in one scan) | EXACT_DUPLICATE across sources, near-dup grouping, source-order priority |
+| 11 | Video + Live Photo | `videos/` AND `live-photo/` | MP4/MOV recognized, no pHash for video, IMG_0001 HEIC+MOV pair grouped, action propagation |
+
+**Subsets** (offer only when user asks for a smaller run):
+
+- "Smoke test": scenarios 1, 2, 9
+- "Format coverage": scenarios 1, 6, 8
+- "Stress probe": scenarios 3, 5, 11
+- "Failed 8": scenarios 3, 4, 5, 7, 8, 9, 10, 11 — historical re-batch
+  pattern when the first run hit harness flakes on most scenarios.
+
+If the user asks "what should I run?", suggest **all** (the default).
+The full batch is fast enough to be the standard mode now.
+
+## Phase 4 — Explore (per scenario)
+
+### 4.0 — Load computer-use tools (once, at the start of Phase 4)
+
+If `mcp__computer-use__*` tools aren't already available in this turn,
+load them in bulk via ToolSearch in a single call:
+
+```
+ToolSearch(query: "computer-use", max_results: 30)
+```
+
+This gets you `screenshot`, `left_click`, `type`, `key`, `scroll`,
+`request_access`, `open_application`, etc. Don't load them one by one.
+
+### 4.0.5 — UIA-first driving (the cheap navigation channel)
+
+photo-manager is a PySide6 app on Windows. Qt's `QAccessible` bridge
+exposes every widget that has a visible label (`setText`, `QAction`,
+menu items, dialog text) into the **Windows UI Automation tree**. That
+tree is structured text, not pixels — a few hundred bytes per snapshot
+versus ~100 KB for a screenshot.
+
+**Default this session to UIA, not screenshots.** Screenshot is for
+*visual evidence* (rendering bugs, layout, finding-frame quotes), not
+for finding the next button to click.
+
+**One-time install** (gated; ask the user before running):
+
+```
+.venv/Scripts/python.exe -m pip install -r qa/requirements.txt
+```
+
+This pulls `pywinauto` (UIA backend) into the project venv. Skip if a
+`pywinauto` import already succeeds.
+
+**Connect to the running app** (after step 3 launches it; wait the
+same ~3 s):
+
+```python
+from pywinauto import Application
+app = Application(backend="uia").connect(title_re=r".*Photo Manager.*")
+win = app.top_window()
+win.print_control_identifiers(depth=4)   # one-shot tree dump
+```
+
+Window title in this build is `Photo Manager - M1`. The regex above is
+robust to the suffix changing.
+
+**What you get back per element:** `control_type`, visible name (`File`,
+`Action`, `List`, `Log`, table headers like `File Name` / `Folder` /
+`Size (Bytes)` / `Creation Date`, etc.), bounding `rect`, `enabled`
+state, and an `auto_id` like `QApplication.MainWindow.QMenuBar.QAction`.
+
+**Click by name, not by pixel.** For top-level menu bar items and
+buttons:
+
+```python
+win.child_window(title="Start Scan", control_type="Button").invoke()
+```
+
+`invoke()` fires the UIA `Invoke` pattern (cheaper, more deterministic
+than `click_input()` which moves the real mouse). Fall back to
+`click_input()` only when `invoke()` is unsupported on that element.
+
+**Menu popups need a different pattern.** Qt menus open as a separate
+top-level window (Win32 class contains `"Popup"`) with `click_input()`
+on the menu bar item, then their items respond to `click_input()` but
+NOT to `invoke()` (raises `COMError -2146233083`). Pattern:
+
+```python
+import ctypes, ctypes.wintypes
+from pywinauto import Application
+
+# 1. Click the menu-bar item to open the popup
+win.child_window(title="File", control_type="MenuItem").click_input()
+time.sleep(0.5)
+
+# 2. Find the popup HWND (top-level window in the same process,
+#    class containing "Popup")
+def find_popup(pid):
+    user32 = ctypes.windll.user32
+    found = [None]
+    def cb(hwnd, _):
+        if user32.IsWindowVisible(hwnd):
+            ppid = ctypes.c_ulong()
+            user32.GetWindowThreadProcessId(hwnd, ctypes.byref(ppid))
+            if ppid.value == pid:
+                cls = ctypes.create_unicode_buffer(256)
+                user32.GetClassNameW(hwnd, cls, 256)
+                if "Popup" in cls.value:
+                    found[0] = hwnd
+                    return False
+        return True
+    proto = ctypes.WINFUNCTYPE(ctypes.c_int, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM)
+    user32.EnumWindows(proto(cb), 0)
+    return found[0]
+
+popup_hwnd = find_popup(win.process_id())
+popup = Application(backend="uia").connect(handle=popup_hwnd).window(handle=popup_hwnd)
+
+# 3. Click the item
+popup.child_window(title="Scan Sources…", control_type="MenuItem").click_input()
+```
+
+**Filter the noise:** the OS-level title bar shows up as `TitleBar`
+with locale-specific names (e.g. `系統`, `最小化` on a zh-TW Windows).
+Ignore that subtree — anything under `auto_id` starting with
+`QApplication.MainWindow` is the real app.
+
+**Native (non-Qt) Windows dialogs are fully locale-translated.**
+QFileDialog opens a Windows Common Item Dialog whose control names are
+in the OS display language: on zh-TW Windows the filename ComboBox is
+`檔案名稱:`, not `File name:`. **Don't hard-code English titles for
+controls in native dialogs.** Use locale-independent discovery — for
+the Save dialog filename Edit, find "the only `ComboBox` descendant
+that contains an `Edit`" (the `Save as type:` ComboBox has no editable
+Edit, so this picks the right one regardless of locale). Qt-managed
+widgets (everything inside the main window, scan dialog, message
+boxes) keep their English names because those come from
+photo-manager's source — locale-translation only hits the OS dialogs.
+
+**Hosted CI uses Qt's non-native QFileDialog ([#129](https://github.com/jackal998/photo-manager/issues/129)).**
+The qa-batch workflow sets `PHOTO_MANAGER_QT_FILE_DIALOG=1`, which
+makes `main.py` apply `Qt.AA_DontUseNativeDialogs` before constructing
+`QApplication` so every `QFileDialog` becomes Qt's widget-based dialog.
+Qt's dialog responds to UIA normally; the native dialog's COM modal
+loop on hosted runners silently drops synthesized input. The
+`_find_filename_edit` and `_find_native_dialog_action_button` helpers
+in `_uia.py` carry parallel branches for both tree shapes — native
+(`ComboBox > Edit` + 2nd-from-rightmost bottom-row button) and Qt
+(standalone `QLineEdit` + topmost button inside `QDialogButtonBox`) —
+so new file-dialog scenarios inherit dual support automatically.
+Local users get the native dialog as before; the env var only flips
+under qa-batch. The same flip will unblock macOS `NSSavePanel` on
+future hosted macOS CI — one switch, every platform.
+
+**Setting Edit values: prefer UIA `ValuePattern.SetValue` over typing.**
+Two reasons:
+1. **IMEs intercept keystrokes.** `pywinauto.keyboard.send_keys("hello")`
+   on a system with a phonetic IME active (bopomofo, pinyin, hangul,
+   kana) gets eaten by the IME and produces phonetic glyphs instead
+   of the Latin string. Modifier-key combos (Ctrl+A/Ctrl+V/Enter)
+   bypass IME, but free text doesn't. The user's session may have
+   any IME active — your driver can't assume Latin keystrokes land.
+2. **Focus is fragile.** Typing requires the right widget to have
+   focus *at the moment of the keystroke*. Native dialogs steal
+   focus, popups steal focus, taskbar tooltips steal focus.
+
+`ValuePattern.SetValue` is a UIA-level write that bypasses keyboard,
+focus, and IME entirely:
+
+```python
+filename_edit.iface_value.SetValue(str(target_path))
+```
+
+Use it whenever you need to set an Edit's content. Reserve `send_keys`
+for keystrokes the application interprets *as keystrokes* (Enter to
+confirm, Esc to cancel, Ctrl+S, arrow keys for navigation). The
+existing `qa/scenarios/_uia.save_manifest_via_native_dialog` is the
+reference pattern — copy from it.
+
+**Foreground-lock pitfall — prefer existing `_uia` helpers over inline
+clicks.** Windows enforces a foreground-lock heuristic: when a
+background process (the batch runner, your `Bash` invocation) calls
+`SetForegroundWindow` while another window owns foreground, Windows
+*silently no-ops* the call. The change is asynchronous, so a naive
+"call `set_focus()`, sleep 50 ms, click" sequence sometimes fires the
+click before the photo-manager window is actually foreground — the
+click lands on the terminal/IDE and the photo-manager click is lost.
+The symptom moves with whichever click fluked: "menu popup didn't
+appear", "dialog didn't appear within Ns", "row not selected", etc.
+
+The shared helpers in `qa/scenarios/_uia.py` already handle this:
+`_focus()` polls `GetForegroundWindow()` until the target HWND
+matches (re-issuing `set_focus()` every 200 ms), and the
+click-then-wait helpers (`open_menu`, `right_click_tree_row`,
+`mark_all_via_regex`, `execute_and_confirm`,
+`_click_btn_and_wait_for_dialog`) verify the expected popup/dialog
+actually appeared and retry on miss. **Use them.** Reach for inline
+`pywinauto` only for read-only probes (`descendants`, `window_text`,
+`is_enabled`, `rectangle`) — those are observation, not state change,
+and don't suffer the race. Any inline click that expects a popup or
+dialog should be wrapped in the same verify-and-retry shape; if you
+find yourself writing one, lift it into a helper instead.
+
+**When UIA returns nothing useful** (custom-painted widget, blank
+`Custom` element with no children): that's your cue to fall back to a
+screenshot for *that step only*. Don't abandon UIA for the rest of the
+scenario.
+
+### 4.1 — Per-scenario loop
+
+Each chosen scenario has a **pre-built driver script** at
+`qa/scenarios/sNN_<title>.py`. The driver does the canonical happy
+path deterministically and prints structured `step:` / `key=value`
+lines to stdout. Your job is to (a) approve the launch, (b) run the
+driver, (c) read its output, (d) optionally do free-form UIA probes
+for surprising states or edge cases the driver doesn't cover.
+
+For each scenario:
+
+1. **Pause and ask** in chat: `"About to launch main.py for scenario
+   N: <title>. OK?"` — wait for explicit yes. In default-batch mode
+   (Phase 3 with no user hint) or when the user explicitly requests
+   an end-to-end batch run, get a single `yes batch` up front for
+   the whole batch and proceed without re-prompting per scenario.
+   The Phase-3 default for `/qa-explore` with no args **is** the
+   batch path — go straight to that prompt rather than asking which
+   scenarios to run.
+
+2. **Configure source folders** for this scenario (allowlisted, no prompt):
+   ```
+   .venv/Scripts/python.exe -m qa.scenarios.configure sNN_<name>
+   ```
+
+3. **Launch the app** with Bash, run in background, with the QA
+   config root and Qt accessibility forced via env vars:
+   ```
+   PHOTO_MANAGER_HOME=qa QT_ACCESSIBILITY=1 .venv/Scripts/python.exe main.py
+   ```
+   - `PHOTO_MANAGER_HOME=qa` — app reads `qa/settings.json` and ignores
+     the user's root `settings.json` / `migration_manifest.sqlite`.
+   - `QT_ACCESSIBILITY=1` — **required for menu navigation.** Without
+     it, Qt's `QMenu` popups (the dropdowns under File/Action/etc.) do
+     not register with the Windows UIA tree at all, so menu items are
+     invisible to pywinauto. With it, every popup item, dialog widget,
+     spinner, slider, and button becomes addressable by name.
+
+   Wait ~2 seconds before invoking the driver — the window takes a
+   moment to appear. (The batch runner uses a ctypes EnumWindows poll
+   instead of a fixed sleep; for one-off manual launches, a brief
+   sleep is fine.)
+
+3. **Run the scenario driver as a Python module** (so its imports
+   resolve relative to the repo root):
+   ```
+   .venv/Scripts/python.exe -m qa.scenarios.s01_happy_path
+   ```
+   The driver is short, deterministic, and version-controlled. It
+   does the canonical happy path and prints structured output. Read
+   that output to populate findings; don't re-do the navigation by
+   hand.
+
+4. **Optionally probe further with free-form UIA** if the driver's
+   output suggests something worth investigating (an unexpected row
+   count, a state transition that looked off, a button text that
+   surprises you). Use the helpers in `qa/scenarios/_uia.py` —
+   `connect_main()`, `open_menu()`, `read_result_rows()`, etc. Don't
+   rebuild what's already there.
+
+   Drop to `mcp__computer-use__screenshot` **only** when the question
+   is genuinely visual: did the thumbnail render, is the layout
+   broken, what does this custom-painted preview look like. Use
+   screenshots **without `save_to_disk`** — the image goes into your
+   context for reasoning, and that's enough. Verified:
+   `save_to_disk: true` does not reliably surface a filesystem path
+   the agent can re-use, so don't bother trying.
+
+   Findings are textual. The "Screenshot path" line in the issue
+   body is **optional and usually omitted**. If a visual is genuinely
+   load-bearing for reproduction, ask the user to capture it manually
+   with the Windows snipping tool after the run — don't try to route
+   it through the agent.
+
+   **What NOT to screenshot** (these are noise; skip them):
+   - finding the next button to click — that's UIA's job
+   - reading dialog text — UIA gives it to you as a string
+   - successful clicks landing on the right element
+   - hover states, cursor moves, focus rings
+   - routine scrolling between identical states
+   - the same dialog 3 times in a row while you reason about it
+   - the desktop / start menu / taskbar (you're never testing those)
+
+   **What IS worth a screenshot** (sparingly — once each):
+   - the moment a *visual* finding becomes visible (broken thumbnail,
+     mis-rendered preview, layout overflow, wrong icon)
+   - a custom-painted widget whose state UIA can't describe
+   - unexpected visual state you want to confirm before acting
+
+5. **Be a human, not a script.** The driver covers the deterministic
+   happy path. Your job on top of it is to walk the app the way a
+   first-time user would — and notice the moments a real user would
+   hesitate, doubt, re-read a label, or look for a button that isn't
+   there. Drive the categories from the "What users actually care
+   about" section above, in roughly this order:
+
+   **Feedback check (Category A)** — after every state-changing
+   action (scan, save, execute, open manifest, set action), pause
+   for one beat and ask: *did anything visibly tell me that worked?*
+   Look at the status bar, dialog, log preview, results count.
+   "Nothing changed visibly" is a finding.
+
+   **Label check (Category B)** — read every visible button label,
+   menu item, status-bar text, and dialog body once. Note anything
+   that:
+   - has a double space, weird capitalization, or a stale term from
+     an earlier design ("SKIP", "MOVE", "priority")
+   - hardcodes a plural ("1 pairs", "1 items")
+   - includes a mystery suffix or version sigil with no tooltip
+
+   **Discoverability check (Category C)** — pretend you opened the
+   app for the first time. Time how long until you find the path to
+   start a scan. Try keyboard-only (Alt+letter, Tab, arrows, Enter,
+   Esc) — does the app cooperate?
+
+   **Modal/state check (Category D)** — open a dialog, then try to
+   click behind it. Close the app while a manifest is loaded with
+   unsaved changes, reopen — same window size, position, columns,
+   selection? Right-click in odd places (empty area, header,
+   unselected row) — is the menu sensible for that spot?
+
+   **Destructive check (Category E)** — before clicking "Yes" on
+   any destructive prompt, read the count in the body. Does it
+   match what you'd expect for the current selection? Try the
+   destructive flow with mixed locked/unlocked selection. Try
+   re-scanning when there are pending decisions — are you warned?
+
+   **Correctness check (Category F)** — glance at the results
+   table after the driver finishes. Do dates look right for the
+   data you fed in? Are thumbnails missing? Is anything grouped
+   that shouldn't be, or not grouped that should be?
+
+   **Speed check (Category G)** — note when a spinner runs longer
+   than feels right. Capture a wall-clock estimate. "Felt slow"
+   is allowed as a finding — be specific about how long and what
+   you were doing.
+
+   **Edge probes** (run these only if budget permits, after the
+   above):
+   - empty input, huge input
+   - escape mid-operation
+   - double-click, rapid clicks
+   - resize the window to extremes
+   - open a context menu, dismiss it, reopen it
+   - try the same action twice in a row
+
+6. **Note findings as you go, classified into two buckets.** Keep a
+   running list in your reasoning. For each one, decide on the spot:
+
+   - **Correctness finding** — there is a measurable wrong behavior:
+     a count that's off, a state that didn't update, a feature that
+     silently no-ops, a label that's literally broken (double space,
+     wrong plural), a file that should be grouped but isn't.
+     *These get filed as GitHub issues in Phase 5.*
+   - **UX-friction note** — there is a judgment call about how
+     something feels: a splitter ratio that seems cramped, copy that
+     "could be clearer", a confirmation that "could have a count",
+     a wait that "felt long". *These get batched as review notes
+     for the human in Phase 5 — do NOT file as separate tickets.*
+
+   If you can't tell which bucket a finding belongs in, it's a
+   UX-friction note. Reserve issue-filing for things with measurable
+   wrong behavior. (See [`feedback_qa_explore_ceiling.md`](../../../../../.claude/projects/C--Users-J-repository-photo-manager/memory/feedback_qa_explore_ceiling.md)
+   in memory for the rationale: the 2026-05-06 gap-fill pass filed
+   10 issues; only 2 turned out to be real defects, and the other 8
+   were defensible UX-judgment calls that should have been one
+   batched review note.)
+
+   **Carve-out — a deterministic driver failing consistently across
+   re-runs is correctness, not friction.** The driver embodies a
+   contract about a specific UI shape; a stable failure across 2+
+   independent runs means that shape changed in a way the harness
+   considers wrong. File it as correctness with **medium confidence**
+   and note in the body that manual verification is recommended —
+   don't demote it to friction just because user-impact is unverified.
+   On the 2026-05-15 release scan, s12 (Save Manifest) failed both
+   runs with "expected 2 bottom-row buttons, got 1"; I classified it
+   as friction; the user manually verified it was a real "did I lose
+   work?" UX bug ([photo-manager#230](https://github.com/jackal998/photo-manager/issues/230))
+   that should have been filed in the first pass. Subjective polish
+   observations still default to friction; harness-detected
+   deterministic anomalies don't.
+
+   Screenshots are optional and usually omitted — see step 4. If a
+   finding is visually load-bearing, ask the user to capture it
+   manually after the run.
+
+7. **Close the window cleanly between scenarios.** Click the X button
+   or use `Alt+F4`. If it hangs:
+   - Take a screenshot of the hang (this is itself a finding)
+   - Ask the user before running `taskkill /F /IM python.exe`
+     (state-changing → gated)
+
+## Phase 5 — Triage: two lanes, one stop
+
+Findings split into two streams. **Correctness findings** become
+GitHub issues (filed via `gh issue create`). **UX-friction notes**
+print inline in chat as a single review block — they do NOT get
+filed as separate tickets, because experience shows most of them
+reverse on one round of real-user input (see memory note
+`feedback_qa_explore_ceiling.md`). This split is the heart of the
+human-tester posture.
+
+Findings live as GitHub issues (for the correctness lane) or chat
+review notes (for the UX lane), **not** as committed markdown files.
+Do not create or write to `docs/qa/findings/`.
+
+### 5.1 — Sort findings into two buckets
+
+For each finding in your running list, classify:
+
+- **Correctness** — measurable wrong behavior. Examples: count is
+  off by 1, action silently no-ops, plural is hardcoded wrong,
+  status bar wipes on menu open, file should be grouped but isn't,
+  date column is empty for a file that has EXIF. The behavior is
+  literally wrong, and any reasonable user would call it a bug.
+- **UX friction** — judgment call about how the app feels. Examples:
+  splitter ratio feels cramped, empty-state copy could land better,
+  confirmation could include a count, double-click could do
+  something, status bar wording could be more specific. Plausibly
+  deliberate. Could reverse on one round of user feedback.
+
+Drop positive validations (things that worked correctly) from both
+buckets — those don't need tracking.
+
+If you're unsure: it's UX friction. **Bias the correctness lane
+toward "high confidence that any user would call this broken"**;
+everything subjective goes into the review notes lane.
+
+**Carve-out — deterministic driver failures are correctness, not
+friction.** If a scenario driver fails the same way on 2+ independent
+re-runs, that's measurable wrong behavior regardless of whether you
+can describe the user-impact. The driver encodes an expected UI
+shape; a stable failure means the shape changed. File with **medium
+confidence** and recommend manual verification in the issue body.
+This rule overrides the "if unsure, friction" default for any
+finding where the deterministic driver itself is the signal — see
+the post-mortem on [photo-manager#230](https://github.com/jackal998/photo-manager/issues/230)
+in `feedback_qa_explore_ceiling.md` for why.
+
+### 5.2 — Print combined summary
+
+Print both buckets to chat. Correctness first, then UX friction.
+Each correctness line:
+
+```
+C-N. [severity] <title> — <one-line, user-felt description>
+```
+
+Each UX-friction line:
+
+```
+U-N. <title> — <one-line description of the friction, in user terms>
+```
+
+Use the user-felt frame from the Mission table — "after scanning,
+there was no confirmation" beats "function returned None".
+
+### 5.3 — Correctness lane: file as GitHub issues
+
+Ask the user **once**, verbatim:
+
+> OK to file the N correctness findings (C-1..C-N) as separate
+> GitHub issues? Reply `yes` for all, `yes except C-2,C-4` to skip
+> some, or `no` to skip all. UX-friction notes (U-1..U-M) are
+> printed below as review notes — they will NOT be filed.
+
+Wait for explicit response. Do not proceed on silence.
+
+For each approved correctness finding, call `gh issue create`
+(gated — the project's `.claude/settings.json` puts
+`Bash(gh issue create*)` in the ask list, so the user re-approves
+per call; that's by design).
+
+**Title format:** `[QA] <one-line specific title>`
+
+**Body format** (markdown):
+
+```markdown
+- **Severity:** critical | high | medium | low | nit
+- **Category:** bug | ux | a11y | performance | copy
+- **Scenario:** <scenario number and title>
+- **What I expected as a user:** <plain English, no source references>
+- **What actually happened:** <what I saw / didn't see / had to do>
+- **Steps to reproduce:**
+  1. ...
+  2. ...
+- **Heuristic:** Nielsen #N — <name>  *(UX findings only, otherwise omit)*
+- **Confidence:** high | medium | low
+
+---
+*Filed by `/qa-explore` on YYYY-MM-DD.*
+```
+
+The screenshot path field is intentionally omitted — see Phase 4
+step 4 for why. The user can grab a screenshot manually if needed.
+
+**Confidence calibration:**
+- **high** = reproduced ≥2 times, observation is unambiguous
+- **medium** = saw it once, clear evidence, plausibly reproducible
+- **low** = saw it once, ambiguous cause, could be timing/luck
+
+LLM exploration is noisy — be honest. Most findings will land at
+medium or low. That's expected.
+
+### 5.4 — UX-friction lane: print review notes (do NOT file)
+
+After the correctness lane is done, print a single block in chat
+titled `## UX review notes` containing all U-1..U-M items. Format:
+
+```markdown
+## UX review notes — for human triage, NOT auto-filed
+
+These are observations a real user might react to, but each is
+plausibly deliberate. Reading them as a batch lets you reverse the
+ones that are calibrated correctly without churning the issue
+tracker.
+
+### U-1 — <short title>
+- **What a user would feel:** <one-sentence felt observation>
+- **Where it shows up:** <scenario / view / dialog>
+- **What might change it:** <one-line speculative recommendation>
+- **Confidence this matters:** low | medium | high
+
+### U-2 — ...
+```
+
+Do **not** call `gh issue create` for any UX-friction note. If the
+user reads the block and decides one is worth filing, they'll ask;
+you can then file that single one with explicit approval.
+
+### 5.5 — Stop
+
+Print a short summary in chat: count of correctness findings by
+severity, list of issue URLs returned by `gh issue create`, count
+of UX-friction notes printed. Then **stop**. No follow-up edits, no
+git operations, no PR. The user triages the friction block manually.
+
+---
+
+## Capabilities cheat-sheet
+
+| Capability | Tool | When |
+|---|---|---|
+| Read source (Phase 1 only) | Read, Grep, Glob | orient |
+| List fixtures | Glob | Phase 2 |
+| Run sandbox script | Bash | Phase 2 (gated) |
+| Install QA deps (`pywinauto`) | Bash `pip install -r qa/requirements.txt` | Phase 4.0.5 (gated, one-time) |
+| Launch main.py | Bash, `run_in_background: true` | Phase 4 (gated, every time) |
+| Read UI tree, click by name | `pywinauto` (UIA backend, in-process Python) | Phase 4 — default driver |
+| Visual evidence only | `mcp__computer-use__*` screenshot | Phase 4 — fallback / finding frames |
+| File findings | Bash `gh issue create` | Phase 5 (gated, batch-approved) |
+
+## Scenario drivers
+
+Each scenario in the menu has (or will have) a pre-built driver under
+`qa/scenarios/`. Drivers are version-controlled, deterministic, and
+print structured `step:` / `key=value` lines to stdout. Run them with
+`.venv/Scripts/python.exe -m qa.scenarios.<module>` while the app is
+running.
+
+| # | Scenario | Module | Status |
+|---|---|---|---|
+| 1 | Happy path: scan + review + mark | `qa.scenarios.s01_happy_path` | ✓ ready |
+| 2 | Empty folder | `qa.scenarios.s02_empty_folder` | ✓ ready |
+| 3 | Cancel scan mid-run | `qa.scenarios.s03_cancel_scan` | ✓ ready |
+| 4 | Corrupted file handling | `qa.scenarios.s04_corrupted` | ✓ ready |
+| 5 | Heavy preview interaction | `qa.scenarios.s05_huge_preview` | ✓ ready |
+| 6 | Multi-format scan | `qa.scenarios.s06_formats` | ✓ ready |
+| 7 | Format duplicate (HEIC vs JPG) | `qa.scenarios.s07_format_dup` | ✓ ready |
+| 8 | EXIF edge cases | `qa.scenarios.s08_exif_edge` | ✓ ready |
+| 9 | Walker exclusion rules | `qa.scenarios.s09_walker_exclusions` | ✓ ready |
+| 10 | Multi-source priority + dedup | `qa.scenarios.s10_multi_source` | ✓ ready |
+| 11 | Video + Live Photo | `qa.scenarios.s11_video_live` | ✓ ready |
+| 12 | Save Manifest Decisions | `qa.scenarios.s12_save_manifest` | ✓ ready |
+| 13 | Execute Action (destructive — sends to recycle bin) | `qa.scenarios.s13_execute_action` | ✓ ready |
+| 14 | Set Action by Field/Regex (menu-bar path) | `qa.scenarios.s14_action_by_regex` | ✓ ready |
+| 15 | Right-click context menu Set Action → delete / keep | `qa.scenarios.s15_context_menu` | ✓ ready |
+| 16 | File → Open Manifest async load (happy + error path) | `qa.scenarios.s16_open_manifest` | ✓ ready |
+| 17 | Scan dialog widgets (add / remove / reorder / recursive) | `qa.scenarios.s17_scan_dialog_widgets` | ✓ ready |
+| 18 | Log menu (Open Latest Log / Delete Log / Log Dir / Delete Log Dir) | `qa.scenarios.s18_log_menu` | ✓ ready |
+| 19 | Right-click context menu → Open Folder (explorer.exe /select integration) | `qa.scenarios.s19_context_menu_open_folder` | ✓ ready |
+| 20 | Right-click multi-selection → Remove from List (file-multi / group + file) | `qa.scenarios.s20_multi_remove_from_list` | ✓ ready |
+| 21 | List menu → Remove from List (no-selection / single / multi) | `qa.scenarios.s21_list_menu_remove` | ✓ ready |
+| 23a | Scan dialog: GUI mutates settings, persists via Start Scan (#122) | `qa.scenarios.s23a_set_settings` | ✓ ready |
+| 23b | Scan dialog: fresh launch reloads what s23a wrote (#122) | `qa.scenarios.s23b_verify_settings` | ✓ ready |
+| 24 | Open manifest whose source files were deleted after scan (stale paths, #123) | `qa.scenarios.s24_stale_manifest_paths` | ✓ ready |
+| 25 | Right-click on empty area / menu bar / unselected row → no Qt popup (#124) | `qa.scenarios.s25_empty_area_context_menu` | ✓ ready |
+| 26 | Keyboard-only navigation: tree arrows, Alt+F mnemonic, scan dialog Tab cycle, Esc (#125) | `qa.scenarios.s26_keyboard_navigation` | ✓ ready |
+| 27 | Re-scan with pending decisions → confirmation prompt (#142) | `qa.scenarios.s27_rescan_confirm` | ✓ ready |
+
+Several drivers also call cross-scenario invariant probes from
+`qa/scenarios/_invariants.py` — they assert that the status bar matches
+an expected shape after a manifest-changing action, that all
+manifest-gated menu items toggle as one set, and that destructive
+confirmation prompts have Yes/No buttons + a count in the body. Those
+probes print `inv: <name> ok=<bool> ...` lines to stdout. Failures
+escalate to the driver's existing FAIL/return-1 path.
+
+Source-folder configuration is per-scenario. Before launching the
+app, write the right `qa/settings.json` by running:
+
+```
+.venv/Scripts/python.exe -m qa.scenarios.configure <scenario_name>
+```
+
+This is allowlisted in `.claude/settings.json` so it doesn't prompt.
+The mapping from scenario name to source folders lives in
+`qa/scenarios/_config.py`.
+
+When you build a NEW scenario driver, add it to the table here AND
+to `SCENARIO_SOURCES` in `qa/scenarios/_config.py`. Keep drivers
+short — they should encode the canonical happy path, nothing more.
+Open-ended exploration is the LLM's job, on top of the driver's
+output.
+
+If your driver needs a NEW shared helper that issues a click and
+expects a window to appear afterwards (popup, dialog, context menu),
+mirror the verify-and-retry shape of `_click_btn_and_wait_for_dialog`
+or `right_click_tree_row` — fire the click, check the expected
+window appeared within a short per-attempt timeout, and retry up to
+3× on miss. "Click and assume" is a known flake source on Windows
+(see the foreground-lock note in Phase 4.0.5); treat the
+verify-and-retry pattern as a hard requirement for new helpers, not
+a stylistic choice.
+
+**Cleanup convention — drivers that spawn external shell windows
+(Notepad, Explorer, etc. via `os.startfile`, `explorer.exe`,
+`QDesktopServices::openUrl`) MUST clean them up before returning.**
+Otherwise each batch run leaves windows piled up on the operator's
+desktop. The pattern, used by s18 and s19:
+
+```python
+baseline = _uia.list_top_level_windows(_uia.DEFAULT_SHELL_CLASSES)
+# … perform the click …
+time.sleep(1.0)
+closed = _uia.close_new_shell_windows(baseline)
+print(f"  closed_shell_windows={[(c, t) for _h, c, t in closed]!r}")
+```
+
+`close_new_shell_windows` sends `WM_CLOSE` (NEVER `taskkill` on
+explorer.exe — that nukes the user's whole shell). The default class
+allowlist (`DEFAULT_SHELL_CLASSES = ("CabinetWClass", "Notepad",
+"Notepad++")`) covers the windows we know how to close safely; if a
+user has a different default text editor (VSCode, Sublime), those
+windows leak — document the residual in the driver header.
+
+**Batch runner.** When the user wants to run several (or all) scenarios
+in one go, use `qa.scenarios._batch`:
+
+```
+.venv/Scripts/python.exe -m qa.scenarios._batch              # all 21 (s01–s21)
+.venv/Scripts/python.exe -m qa.scenarios._batch s04_corrupted s09_walker_exclusions
+```
+
+For each scenario it: configures `qa/settings.json` → launches
+`main.py` → polls (ctypes `EnumWindows`) until the main window is
+visible (max 8 s; typically <2 s) → runs the driver → closes the
+window → waits for the subprocess to exit → moves to the next.
+Prints a final SUMMARY table with rc per scenario. The whole batch
+(21 scenarios) typically finishes in ~5–7 minutes (5m19s on
+`windows-latest` after the #133 poll change). Each app launch is
+still a real launch — get the user's "yes batch" once before
+starting.
+
+**Optional optimization — skip the per-run Bash prompt.** Add this
+to `.allow` in `.claude/settings.json` so driver runs don't prompt:
+
+```json
+"Bash(.venv/Scripts/python.exe -m qa.scenarios.*:*)"
+```
+
+The launch of `main.py` itself stays gated by design — that's the
+security boundary. Driver runs are read-only against an
+already-running app, so allowlisting them is safe.
+
+## Reference
+
+- Project security gates: `CLAUDE.md` at the repo root
+- Operator doc: `docs/qa/README.md`
+- Scenario drivers: `qa/scenarios/`
+- Shared UIA helpers: `qa/scenarios/_uia.py`
+- Existing fixture helpers: `scripts/make_qa_images.py`
+  (`save_jpg`, `phash`, `hamming`, `sha_bytes`)
+- Sandbox generator: `scripts/make_qa_sandbox.py`

--- a/.gitignore
+++ b/.gitignore
@@ -98,14 +98,19 @@ logs/
 settings.json
 settings.local.json
 
-# Claude Code skills — never tracked. Skill files are the kind of
-# place a developer might reflex-paste a machine-specific path,
-# Synology IP, NAS hostname, or other PII without thinking. Mirror
-# the settings.json treatment: each developer's `.claude/skills/`
-# lives on disk only. Project-shareable templates (if any are added
-# later) should go under a separate `.claude/skills/.example/`
-# pattern that's NOT covered by this rule.
-.claude/skills/
+# Personal Claude Code skills (PII risk) live here. Project skills at
+# .claude/skills/<name>/ ARE tracked. The original blanket exclusion
+# of `.claude/skills/` was the source of #270: project-workflow skills
+# (impact-map, parallel-brief-generator, qa-explore, update-docs) had
+# to be `git add -f`'d to land them, which is the smell that
+# motivated splitting personal from project skills.
+#
+# A skill is "project" when its content is generic to the codebase
+# (workflow, conventions, test scaffolding) and contains no
+# machine-specific paths, Synology IPs, NAS hostnames, or credentials.
+# Audit before committing — see CLAUDE.md "Claude Code skills" for the
+# PII checklist.
+.claude/skills/personal/
 
 # Window geometry / splitter state — written by MainWindow.closeEvent on
 # every clean exit. Anchored under PHOTO_MANAGER_HOME (or repo root) so

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -163,6 +163,38 @@ state change, new gating condition) — see the `update-docs` skill's
 "User-visible behaviour changed?" row. Enforced at PR-creation time
 by [`scripts/hooks/docs_guard.py`](scripts/hooks/docs_guard.py).
 
+## Claude Code skills
+
+Skills live in two homes, split by trust level:
+
+- **Project skills** — `.claude/skills/<name>/` — tracked in git,
+  shared across all contributors. Generic to the codebase: workflow,
+  conventions, test scaffolding, QA drivers. Today this includes
+  `impact-map/`, `parallel-brief-generator/`, `qa-explore/`,
+  `update-docs/`. New project skills land here.
+- **Personal skills** — `.claude/skills/personal/<name>/` (gitignored)
+  or `~/.claude/skills/<name>/` (user-level, never in any repo). For
+  ad-hoc skills with machine-specific paths, Synology IPs, NAS
+  hostnames, credentials, or anything else you wouldn't paste into a
+  PR. Use the `personal/` subdirectory when the skill is repo-scoped
+  but private; use `~/.claude/skills/` when the skill applies across
+  every project.
+
+**PII audit before committing a project skill** — run this on the
+SKILL.md and any sibling files; expected to be zero matches:
+
+```
+grep -i -E "C:\\\\Users|/Users/|/home/|[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+|password|secret|token|key=" <file>
+```
+
+The patterns cover: Windows / macOS / Linux home paths, IPv4
+addresses (Synology / NAS), and credential-like strings. False
+positives (e.g. `key=value` in a log-format example) are fine to wave
+through — surface them in chat before committing, don't silently
+include them. If any match is real (an actual path or IP), move the
+skill into `personal/` or `~/.claude/skills/` instead of committing
+it.
+
 ## Setup (one-time, per machine)
 
 `.claude/settings.json` is gitignored because it contains a machine-specific


### PR DESCRIPTION
## Summary

Closes #270.

The blanket `.claude/skills/` gitignore lumped project-workflow
skills together with ad-hoc personal skills. Project skills (no
machine-specific paths, useful to every contributor) had to be
`git add -f`'d to land — which is what surfaced in #268 when
`update-docs/SKILL.md` was force-added. This PR narrows the
exclusion so project skills are trackable normally and personal
skills stay local.

## Shape

Four commits, intentionally separate so each can be reverted
independently (per #270 D2):

1. **`chore(skills): carve out personal/ subdir, document split`**
   - `.gitignore`: `.claude/skills/` → `.claude/skills/personal/`
   - `CLAUDE.md`: new "Claude Code skills" section documenting the
     project-vs-personal split and the PII-audit grep contributors
     run before committing a project skill.
2. **`chore(skills): track impact-map`** — adds
   `.claude/skills/impact-map/SKILL.md` (PII audit clean).
3. **`chore(skills): track parallel-brief-generator`** — adds
   `.claude/skills/parallel-brief-generator/SKILL.md` (PII audit
   clean).
4. **`chore(skills): track qa-explore`** — adds
   `.claude/skills/qa-explore/SKILL.md`. PII grep matched only the
   literal phrase `key=value` twice (driver log-format docs); both
   are false positives waved through per the rule in CLAUDE.md.

`update-docs/` was already tracked (committed force-added in #268),
so this branch leaves it alone — the four project skills now have
consistent treatment.

## PII audit (run before each skill commit)

```
grep -i -E "C:\\Users|/Users/|/home/|[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+|password|secret|token|key=" <file>
```

- impact-map: 0 matches
- parallel-brief-generator: 0 matches
- qa-explore: 2 matches, both `key=value` log-format docs — false
  positives surfaced before commit (called out in commit body)

## Test plan

- [x] `git ls-files .claude/skills/` lists all four SKILL.md files
- [x] `.gitignore` excludes only `.claude/skills/personal/`
- [x] CLAUDE.md has the new "Claude Code skills" section
- [x] `pytest --no-cov`: 1221 passed, 2 skipped (config-only change,
      but the sanity gate stays green)
- [x] Coverage: 88.35% (no regression)
- [x] docs_guard / qa_scenario_guard not triggered (no .py / qa
      changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)