### PR TITLE
ci: port docs_guard + qa_scenario_guard to server-side gates

### DIFF
--- a/.github/workflows/pr-gates.yml
+++ b/.github/workflows/pr-gates.yml
@@ -1,0 +1,71 @@
+name: pr-gates
+
+# Server-side enforcement of the two PreToolUse gates that previously
+# only fired inside a Claude Code session configured via .claude/settings.json
+# (which is gitignored and per-machine). Without this workflow, a PR opened
+# from the GitHub web UI / mobile app / a fork / a teammate's machine
+# bypasses both gates silently. See #273.
+#
+# Hooks involved:
+#   - scripts/hooks/docs_guard.py        — blocks doc-relevant code without docs
+#   - scripts/hooks/qa_scenario_guard.py — blocks user-facing code without QA driver
+#
+# Both scripts share an exit-2-on-block contract, a [<key>-not-needed: <reason>]
+# bypass token convention, and a DIFF_BASE env var for the diff base. Tests
+# in tests/test_{docs,qa_scenario}_guard.py cover the gate logic exhaustively;
+# this workflow just wires the same logic into CI.
+#
+# Status posture: REQUIRED, matching tests.yml. Per the #273 acceptance
+# criteria ("match tests.yml posture") these gates encode substantive
+# correctness rules (docs/features.md staleness, missing QA coverage) and a
+# red status should block merge until resolved.
+
+on:
+  # Run on every PR regardless of target branch — stacked PRs (whose base is
+  # another feature branch, not master) need per-stage gate enforcement too.
+  # Without this, intermediate PRs in a multi-PR feature chain bypass the
+  # gates entirely. See tests.yml / qa-batch.yml for the matching pattern.
+  pull_request:
+
+concurrency:
+  group: pr-gates-${{ github.ref }}
+  cancel-in-progress: true
+
+# Public-repo hardening: workflow is read-only, no write back to the repo.
+permissions:
+  contents: read
+
+jobs:
+  gates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    env:
+      # Diff base must be the PR's actual base (origin/<base.ref>), not always
+      # origin/master. This matters for stacked PRs targeting a feature branch:
+      # diffing against master would surface files from earlier PRs in the
+      # stack as "changed", firing the gates on already-reviewed code.
+      DIFF_BASE: origin/${{ github.event.pull_request.base.ref }}
+      # PR title + body feed the bypass-token check ([docs-not-needed: ...] /
+      # [qa-not-needed: ...]). Passed via env (not shell args) so PR bodies
+      # containing $(...), backticks, or quotes can't break the invocation.
+      PR_TITLE: ${{ github.event.pull_request.title }}
+      PR_BODY: ${{ github.event.pull_request.body }}
+    steps:
+      # fetch-depth: 0 so `git diff origin/<base>...HEAD` has full history
+      # to compute the merge-base. Without it the diff returns nothing and
+      # both gates silently no-op.
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      # Two separate steps so each gate gets its own pass/fail line in the
+      # GitHub Actions UI — triage is one click instead of grepping a log.
+      - name: docs_guard
+        run: python scripts/hooks/docs_guard.py --ci
+
+      - name: qa_scenario_guard
+        run: python scripts/hooks/qa_scenario_guard.py --ci

--- a/README.md
+++ b/README.md
@@ -566,5 +566,13 @@ Setup: `.claude/settings.json` is gitignored. Copy
 `.claude/settings.json.example` to `.claude/settings.json` on a fresh
 checkout to install all three.
 
+Server-side mirror: `qa_scenario_guard` and `docs_guard` also run in
+CI via [`.github/workflows/pr-gates.yml`](.github/workflows/pr-gates.yml)
+(#273), so the same gate decision applies to PRs opened from the web
+UI, a fork, mobile, or a machine without `.claude/settings.json`
+configured. The bypass tokens work identically server-side (CI parses
+PR title + body). `zombie_check` stays local-only — it inspects host
+processes and has no CI analogue.
+
 ---
 

--- a/scripts/hooks/docs_guard.py
+++ b/scripts/hooks/docs_guard.py
@@ -30,10 +30,19 @@ Hook protocol
 * exit 0 — allow the tool call.
 * exit 2 — BLOCK the tool call. Stderr is shown to Claude; tool input
   is rejected. Per Claude Code hook docs.
+
+CI mode
+-------
+Invoke with ``--ci`` to run the same gate against a GitHub Actions
+pull-request payload (see ``.github/workflows/pr-gates.yml``). Reads
+``PR_TITLE`` + ``PR_BODY`` from the environment for bypass-token
+detection, and ``DIFF_BASE`` (default ``origin/master``) for the
+diff base. Same exit-2-on-block contract; same bypass token.
 """
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -92,11 +101,19 @@ _BEHAVIOURAL_TRIGGER_DIFF_THRESHOLD = 10
 _BYPASS_PATTERN = re.compile(r"\[docs-not-needed:[^\]]*\]")
 
 
+def _diff_base() -> str:
+    """Resolve the base ref for the branch-diff. CI mode sets DIFF_BASE
+    to ``origin/<github.event.pull_request.base.ref>`` so stacked PRs
+    diff against their immediate parent, not always master."""
+    return os.environ.get("DIFF_BASE", "origin/master")
+
+
 def _changed_files() -> list[str]:
-    """Return files changed on the current branch vs origin/master."""
+    """Return files changed on the current branch vs the diff base."""
+    base = _diff_base()
     try:
         out = subprocess.check_output(
-            ["git", "diff", "--name-only", "origin/master...HEAD"],
+            ["git", "diff", "--name-only", f"{base}...HEAD"],
             text=True, stderr=subprocess.DEVNULL,
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -105,7 +122,7 @@ def _changed_files() -> list[str]:
 
 
 def _new_files() -> set[str]:
-    """Return files ADDED on this branch vs origin/master.
+    """Return files ADDED on this branch vs the diff base.
 
     Renames / modifications of existing files don't trigger the guard
     on most patterns — we only want to flag NEW source modules and
@@ -113,12 +130,13 @@ def _new_files() -> set[str]:
     or are typically smaller-scope and don't warrant a doc update.)
     Falls back to the full changed list if git can't distinguish.
     """
+    base = _diff_base()
     try:
         out = subprocess.check_output(
             [
                 "git", "diff", "--name-status",
                 "--diff-filter=A",  # added only
-                "origin/master...HEAD",
+                f"{base}...HEAD",
             ],
             text=True, stderr=subprocess.DEVNULL,
         )
@@ -146,9 +164,10 @@ def _behavioural_modify_qualifies(path: str) -> bool:
     Used to keep this trigger from blocking on edits that genuinely
     don't shift user-visible behaviour.
     """
+    base = _diff_base()
     try:
         numstat_out = subprocess.check_output(
-            ["git", "diff", "--numstat", "origin/master...HEAD", "--", path],
+            ["git", "diff", "--numstat", f"{base}...HEAD", "--", path],
             text=True, stderr=subprocess.DEVNULL,
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -163,7 +182,7 @@ def _behavioural_modify_qualifies(path: str) -> bool:
         return True
     try:
         diff_out = subprocess.check_output(
-            ["git", "diff", "-U0", "origin/master...HEAD", "--", path],
+            ["git", "diff", "-U0", f"{base}...HEAD", "--", path],
             text=True, stderr=subprocess.DEVNULL,
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -216,29 +235,27 @@ def _docs_touched(changed: list[str]) -> list[str]:
     return [f for f in changed if any(p.match(f) for p in _DOC_FILE_PATTERNS)]
 
 
-def main() -> int:
-    try:
-        payload = json.load(sys.stdin)
-    except (ValueError, json.JSONDecodeError):
-        return 0
+def check(pr_text: str) -> tuple[int, str]:
+    """Run the gate against the current branch.
 
-    if payload.get("tool_name") != "Bash":
-        return 0
-    cmd = (payload.get("tool_input") or {}).get("command") or ""
-    if "gh pr create" not in cmd:
-        return 0
+    ``pr_text`` is searched for the bypass token — pass the
+    ``gh pr create`` command line in PreToolUse mode, or the PR
+    title + body concatenated in CI mode.
 
-    if _BYPASS_PATTERN.search(cmd):
-        return 0
+    Returns ``(exit_code, stderr_message)``. ``exit_code`` is 0
+    (allow) or 2 (block). When 0, ``stderr_message`` is empty.
+    """
+    if _BYPASS_PATTERN.search(pr_text):
+        return 0, ""
 
     changed = _changed_files()
     if not changed:
-        return 0
+        return 0, ""
 
     added = _new_files()
     relevant = _doc_relevant(changed, added)
     if not relevant:
-        return 0
+        return 0, ""
 
     docs = _docs_touched(changed)
 
@@ -271,8 +288,7 @@ def main() -> int:
             "       user-visible (e.g. an internal refactor that preserves",
             "       behaviour byte-for-byte).",
         ]
-        sys.stderr.write("\n".join(msg_lines) + "\n")
-        return 2
+        return 2, "\n".join(msg_lines) + "\n"
 
     if docs:
         # At least one doc file was touched — accept the PR; we're
@@ -280,7 +296,7 @@ def main() -> int:
         # update the exactly-correct line." The qa-scenario-guard
         # applies the same coarse rule. (Behavioural-modify changes
         # take the strict path above.)
-        return 0
+        return 0, ""
 
     msg_lines = [
         "docs guard fired — blocking `gh pr create`.",
@@ -307,8 +323,41 @@ def main() -> int:
         "       command (title or body) — the reason will be visible in",
         "       review so the choice is auditable.",
     ]
-    sys.stderr.write("\n".join(msg_lines) + "\n")
-    return 2
+    return 2, "\n".join(msg_lines) + "\n"
+
+
+def _run_ci() -> int:
+    """CI mode: read PR title + body from env vars; check the diff."""
+    pr_text = (
+        os.environ.get("PR_TITLE", "")
+        + "\n"
+        + os.environ.get("PR_BODY", "")
+    )
+    rc, msg = check(pr_text)
+    if msg:
+        sys.stderr.write(msg)
+    return rc
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "--ci":
+        return _run_ci()
+
+    try:
+        payload = json.load(sys.stdin)
+    except (ValueError, json.JSONDecodeError):
+        return 0
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+    cmd = (payload.get("tool_input") or {}).get("command") or ""
+    if "gh pr create" not in cmd:
+        return 0
+
+    rc, msg = check(cmd)
+    if msg:
+        sys.stderr.write(msg)
+    return rc
 
 
 if __name__ == "__main__":

--- a/scripts/hooks/qa_scenario_guard.py
+++ b/scripts/hooks/qa_scenario_guard.py
@@ -29,10 +29,19 @@ Hook protocol
   is rejected. Per Claude Code hook docs.
 * any other non-zero exit — surfaced to the user but does NOT block.
   We deliberately use exit 2 for the enforcement path.
+
+CI mode
+-------
+Invoke with ``--ci`` to run the same gate against a GitHub Actions
+pull-request payload (see ``.github/workflows/pr-gates.yml``). Reads
+``PR_TITLE`` + ``PR_BODY`` from the environment for bypass-token
+detection, and ``DIFF_BASE`` (default ``origin/master``) for the
+diff base. Same exit-2-on-block contract; same bypass token.
 """
 from __future__ import annotations
 
 import json
+import os
 import re
 import subprocess
 import sys
@@ -47,11 +56,19 @@ QA_SCENARIO_PATTERN = re.compile(r"^qa/scenarios/s\d+.*\.py$")
 BYPASS_PATTERN = re.compile(r"\[qa-not-needed:[^\]]*\]")
 
 
+def _diff_base() -> str:
+    """Resolve the base ref for the branch-diff. CI mode sets DIFF_BASE
+    to ``origin/<github.event.pull_request.base.ref>`` so stacked PRs
+    diff against their immediate parent, not always master."""
+    return os.environ.get("DIFF_BASE", "origin/master")
+
+
 def _changed_files() -> list[str]:
-    """Return files changed on the current branch vs origin/master."""
+    """Return files changed on the current branch vs the diff base."""
+    base = _diff_base()
     try:
         out = subprocess.check_output(
-            ["git", "diff", "--name-only", "origin/master...HEAD"],
+            ["git", "diff", "--name-only", f"{base}...HEAD"],
             text=True, stderr=subprocess.DEVNULL,
         )
     except (subprocess.CalledProcessError, FileNotFoundError):
@@ -59,26 +76,24 @@ def _changed_files() -> list[str]:
     return [line.strip() for line in out.splitlines() if line.strip()]
 
 
-def main() -> int:
-    try:
-        payload = json.load(sys.stdin)
-    except (ValueError, json.JSONDecodeError):
-        return 0  # don't block on malformed input — fail open
+def check(pr_text: str) -> tuple[int, str]:
+    """Run the gate against the current branch.
 
-    if payload.get("tool_name") != "Bash":
-        return 0
-    cmd = (payload.get("tool_input") or {}).get("command") or ""
-    if "gh pr create" not in cmd:
-        return 0
+    ``pr_text`` is searched for the bypass token — pass the
+    ``gh pr create`` command line in PreToolUse mode, or the PR
+    title + body concatenated in CI mode.
 
-    if BYPASS_PATTERN.search(cmd):
-        return 0
+    Returns ``(exit_code, stderr_message)``. ``exit_code`` is 0
+    (allow) or 2 (block). When 0, ``stderr_message`` is empty.
+    """
+    if BYPASS_PATTERN.search(pr_text):
+        return 0, ""
 
     changed = _changed_files()
     if not changed:
-        # No diff against origin/master — nothing to check (or no remote).
+        # No diff against the base — nothing to check (or no remote).
         # Don't block; CI / review will surface other issues if relevant.
-        return 0
+        return 0, ""
 
     user_facing = [
         f for f in changed if any(p.match(f) for p in USER_FACING_PATTERNS)
@@ -106,10 +121,43 @@ def main() -> int:
             "       command (title or body) — the reason will be visible in",
             "       review so the choice is auditable.",
         ]
-        sys.stderr.write("\n".join(msg_lines) + "\n")
-        return 2
+        return 2, "\n".join(msg_lines) + "\n"
 
-    return 0
+    return 0, ""
+
+
+def _run_ci() -> int:
+    """CI mode: read PR title + body from env vars; check the diff."""
+    pr_text = (
+        os.environ.get("PR_TITLE", "")
+        + "\n"
+        + os.environ.get("PR_BODY", "")
+    )
+    rc, msg = check(pr_text)
+    if msg:
+        sys.stderr.write(msg)
+    return rc
+
+
+def main() -> int:
+    if len(sys.argv) > 1 and sys.argv[1] == "--ci":
+        return _run_ci()
+
+    try:
+        payload = json.load(sys.stdin)
+    except (ValueError, json.JSONDecodeError):
+        return 0  # don't block on malformed input — fail open
+
+    if payload.get("tool_name") != "Bash":
+        return 0
+    cmd = (payload.get("tool_input") or {}).get("command") or ""
+    if "gh pr create" not in cmd:
+        return 0
+
+    rc, msg = check(cmd)
+    if msg:
+        sys.stderr.write(msg)
+    return rc
 
 
 if __name__ == "__main__":

--- a/tests/test_docs_guard.py
+++ b/tests/test_docs_guard.py
@@ -386,3 +386,77 @@ class TestBehaviouralModifyTrigger:
             behavioural_qualifies=True,  # would have qualified if scope included workers
         )
         assert rc == 0
+
+
+# ── CI mode (#273) ────────────────────────────────────────────────────────
+
+
+class TestCiMode:
+    """The ``--ci`` entry point used by .github/workflows/pr-gates.yml.
+
+    Three regressions worth catching:
+      1. ``--ci`` flag not detected → falls through to the stdin path,
+         which hangs (no stdin) or errors. CI runs become red for the
+         wrong reason.
+      2. ``PR_BODY`` env var unset → silent crash or, worse, silent
+         pass that bypasses the gate.
+      3. ``DIFF_BASE`` env var ignored → diff is computed against
+         ``origin/master`` for stacked PRs whose base is a feature
+         branch, surfacing files from earlier stages as false positives.
+    """
+
+    def test_ci_mode_blocks_when_pr_body_empty_and_docs_missing(
+        self, monkeypatch, capsys
+    ):
+        """Doc-relevant change, no bypass token, no docs touched →
+        exit 2. PR_BODY explicitly unset (PRs from the web UI can have
+        an empty body)."""
+        mod = _load_hook()
+        monkeypatch.setattr(mod, "_changed_files", lambda: [
+            "app/views/dialogs/new_dialog.py",
+        ])
+        monkeypatch.setattr(mod, "_new_files", lambda: {
+            "app/views/dialogs/new_dialog.py",
+        })
+        monkeypatch.setattr(sys, "argv", ["docs_guard.py", "--ci"])
+        monkeypatch.setenv("PR_TITLE", "feat: new dialog")
+        monkeypatch.delenv("PR_BODY", raising=False)
+        rc = mod.main()
+        assert rc == 2
+        assert "new_dialog.py" in capsys.readouterr().err
+
+    def test_ci_mode_honours_bypass_token_in_pr_body(self, monkeypatch):
+        """CI mode must read PR_BODY for the bypass token — otherwise
+        PRs opened from the web UI can't use the documented escape
+        valve."""
+        mod = _load_hook()
+        monkeypatch.setattr(mod, "_changed_files", lambda: [
+            "app/views/dialogs/new_dialog.py",
+        ])
+        monkeypatch.setattr(mod, "_new_files", lambda: {
+            "app/views/dialogs/new_dialog.py",
+        })
+        monkeypatch.setattr(sys, "argv", ["docs_guard.py", "--ci"])
+        monkeypatch.setenv("PR_TITLE", "feat: new dialog")
+        monkeypatch.setenv(
+            "PR_BODY", "details here\n[docs-not-needed: internal scaffold]\n"
+        )
+        assert mod.main() == 0
+
+    def test_diff_base_env_var_overrides_default(self, monkeypatch):
+        """DIFF_BASE plumbing: the git diff command must include the
+        env-supplied base, not always ``origin/master``."""
+        mod = _load_hook()
+        captured: list[list[str]] = []
+
+        def fake_check_output(cmd, **kwargs):
+            captured.append(cmd)
+            return ""
+
+        monkeypatch.setattr(mod.subprocess, "check_output", fake_check_output)
+        monkeypatch.setenv("DIFF_BASE", "origin/feat/parent-branch")
+        mod._changed_files()
+        assert captured, "expected git diff to be invoked"
+        assert any(
+            "origin/feat/parent-branch...HEAD" in arg for arg in captured[0]
+        )

--- a/tests/test_qa_scenario_guard.py
+++ b/tests/test_qa_scenario_guard.py
@@ -238,3 +238,56 @@ class TestBypassTokenShape:
             changed=["app/views/handlers/file_operations.py"],
         )
         assert rc == 2
+
+
+# ── CI mode (#273) ────────────────────────────────────────────────────────
+
+
+class TestCiMode:
+    """The ``--ci`` entry point used by .github/workflows/pr-gates.yml.
+
+    Mirrors the regressions tested in test_docs_guard.py::TestCiMode —
+    same shape, same failure modes, same fix.
+    """
+
+    def test_ci_mode_blocks_when_user_facing_change_lacks_qa(
+        self, monkeypatch, capsys
+    ):
+        mod = _load_hook(monkeypatch)
+        monkeypatch.setattr(mod, "_changed_files", lambda: [
+            "app/views/handlers/file_operations.py",
+        ])
+        monkeypatch.setattr(sys, "argv", ["qa_scenario_guard.py", "--ci"])
+        monkeypatch.setenv("PR_TITLE", "feat: lock state")
+        monkeypatch.delenv("PR_BODY", raising=False)
+        rc = mod.main()
+        assert rc == 2
+        assert "file_operations.py" in capsys.readouterr().err
+
+    def test_ci_mode_honours_bypass_token_in_pr_body(self, monkeypatch):
+        mod = _load_hook(monkeypatch)
+        monkeypatch.setattr(mod, "_changed_files", lambda: [
+            "app/views/handlers/file_operations.py",
+        ])
+        monkeypatch.setattr(sys, "argv", ["qa_scenario_guard.py", "--ci"])
+        monkeypatch.setenv("PR_TITLE", "refactor: rename internal fn")
+        monkeypatch.setenv(
+            "PR_BODY", "details\n[qa-not-needed: pure rename, no UX change]\n"
+        )
+        assert mod.main() == 0
+
+    def test_diff_base_env_var_overrides_default(self, monkeypatch):
+        mod = _load_hook(monkeypatch)
+        captured: list[list[str]] = []
+
+        def fake_check_output(cmd, **kwargs):
+            captured.append(cmd)
+            return ""
+
+        monkeypatch.setattr(mod.subprocess, "check_output", fake_check_output)
+        monkeypatch.setenv("DIFF_BASE", "origin/feat/parent-branch")
+        mod._changed_files()
+        assert captured, "expected git diff to be invoked"
+        assert any(
+            "origin/feat/parent-branch...HEAD" in arg for arg in captured[0]
+        )


### PR DESCRIPTION
## Summary
- Closes #273. Ports `docs_guard` + `qa_scenario_guard` from client-side `PreToolUse` hooks (which fire only inside Claude Code sessions with `.claude/settings.json` configured) to server-side CI via new `pr-gates.yml` workflow.
- Refactor: extract `check(pr_text) -> (rc, msg)` from `main()` + add `--ci` mode reading `PR_TITLE` / `PR_BODY` / `DIFF_BASE` env vars. Existing stdin entry point unchanged — all 47 prior tests pass unmodified.
- Required status check posture (matches `tests.yml`).

## Test plan
- [x] pytest — 1227 passed, 88.35% coverage
- [x] per-file coverage floor (70%) — 49/49 clear
- [ ] CI smoke (this PR): `pr-gates.yml` runs on the PR itself — should pass (README touched, no user-facing files)
- [ ] Throwaway smoke PRs (4) per #273 acceptance — fail/pass × docs/qa

🤖 Generated with [Claude Code](https://claude.com/claude-code)