### PR TITLE
feat(skills): /pr-review Gate 6 + settings deny baseline (follow-up #272)

### DIFF
--- a/.claude/settings.json.example
+++ b/.claude/settings.json.example
@@ -50,6 +50,16 @@
       "Bash(gh issue create*)",
       "Bash(gh issue close*)"
     ],
+    "deny": [
+      "Bash(sudo *)",
+      "Bash(sudo)",
+      "Bash(rm -rf /*)",
+      "Bash(rm -rf /)",
+      "Bash(curl * | sh*)",
+      "Bash(curl * | bash*)",
+      "Bash(wget * | sh*)",
+      "Bash(wget * | bash*)"
+    ],
     "additionalDirectories": [
       "<USER_HOME>/.claude"
     ]

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -225,6 +225,33 @@ worth surfacing — these are advisory, not gating:
 Limit to 3 observations. If you have more, pick the highest-impact
 three and say "+N more available on request".
 
+### Gate 6 — harness-security cross-promote
+
+Independent of Gates 1–5 (does not gate them). If the diff touches
+any of the following paths, emit an ℹ️ pointer to `/security-scan`
+in the output's "Harness security" section:
+
+- `.claude/**` (settings, agents, skills, hooks config)
+- `scripts/hooks/**` (project-side PreToolUse / Stop hooks)
+- `settings.json` / `settings.local.json` / `.mcp.json`
+- `CLAUDE.md` *only* when the touched lines change agent
+  permissions, install instructions, or hook directives (skip
+  for prose/section edits)
+
+Reason: `/pr-review` checks app-level drift (features.md, qa
+scenarios). It does NOT check harness-level risks — prompt
+injection in `CLAUDE.md`, command injection in hooks,
+over-permissive `Bash(*)` allow lists, MCP supply chain. Those
+are what `/security-scan` (AgentShield) catches. When a PR
+touches the harness, route the reviewer to the right tool.
+
+The pointer is **informational only**. It never flags ⚠ or ✗,
+never blocks, and never affects the Verdict line. It is a
+routing reminder, not a finding.
+
+If the diff does NOT touch any harness path, skip this gate
+entirely (do not emit an empty "Harness security" section).
+
 ## Output template
 
 Emit exactly this structure in chat. Use `## CLEAN` (no findings) or
@@ -249,9 +276,20 @@ Diff: origin/master...HEAD   |   Files in scope: <N behaviour-bearing> / <total>
 - <observation 1>
 - <observation 2>
 
+## Harness security
+ℹ️ This PR touches harness/config: <files>
+   Run `/security-scan` before merging — `/pr-review`'s rubric
+   does not check harness risks (prompt injection in CLAUDE.md,
+   hook command injection, over-permissive Bash allow-list,
+   MCP supply-chain).
+
 ## Verdict
 <one-line summary: CLEAN / N⚠ / M✗ / N ⚠ + M ✗>
 ```
+
+(Omit the **Harness security** section entirely when Gate 6
+finds no harness/config files touched — don't emit an empty
+header.)
 
 For a clean PR:
 
@@ -295,10 +333,17 @@ When the user runs `/pr-review` (with or without a PR number):
 
 6. **Scan for drive-by observations** (Gate 5). Limit to 3.
 
-7. **Emit the report** in the output-template structure. End with
+7. **Check harness-config touch** (Gate 6). If any file in the
+   diff matches `.claude/**`, `scripts/hooks/**`,
+   `settings.json` / `settings.local.json` / `.mcp.json`, or
+   a permissions/install line in `CLAUDE.md` — include the
+   "Harness security" section pointing at `/security-scan`.
+   Otherwise omit the section.
+
+8. **Emit the report** in the output-template structure. End with
    the Verdict line.
 
-8. **Stop.** Do NOT post anything to the PR. Wait for the user.
+9. **Stop.** Do NOT post anything to the PR. Wait for the user.
 
 ## Anti-patterns — what NOT to flag
 

--- a/news/288.feature
+++ b/news/288.feature
@@ -1,0 +1,1 @@
+Add `permissions.deny` block to `settings.json.example` (sudo, pipe-to-shell, `rm -rf /`) and add Gate 6 to `/pr-review` routing harness/config changes to `/security-scan` (follow-up to #272).


### PR DESCRIPTION
## Pre-merge checklist

- [N/A] User-visible behaviour added/changed → updated `docs/features.md` *(skill + settings template; not user-visible code)*
- [N/A] New file under `app/views/{dialogs,handlers,components,workers}/` → corresponding `qa/scenarios/sNN_*.py` driver added
- [N/A] Tests added (unit + qa scenario if user-facing) *(skill is text; settings.json.example validated as JSON)*
- [x] No `--no-verify` used
- [x] Pre-PR hooks (`docs_guard`, `qa_scenario_guard`) passed locally — both fire CLEAN (diff has no behaviour files)

## Summary

PR-A in a two-step refinement of `/pr-review` (PR-B coming with G7–G10, backtest-calibrated).

- **Gate 6 added to `/pr-review`** — when a diff touches `.claude/**`, `scripts/hooks/**`, `settings.json`/`settings.local.json`/`.mcp.json`, or permissions/install lines in `CLAUDE.md`, the skill emits a `Harness security` section pointing at `/security-scan`. Informational only (never ⚠/✗, never affects the Verdict line). Routing reminder, not a finding.
- **`permissions.deny` block added to `.claude/settings.json.example`** — `sudo`, pipe-to-shell variants, `rm -rf /`. Closes the AgentShield HIGH finding "No deny list configured" on the canonical template. Existing gitignored `settings.json` files need manual update on contributor machines (one-time, ~30 sec).

Follow-up to #272 (the original `/pr-review` skill).

## AgentShield baseline (2026-05-17)

Ran `npx ecc-agentshield@1.4.0 scan` against `.claude/`. Result: **Grade B (83/100)**.

| Category | Score |
|---|---|
| Secrets | 100 |
| Permissions | 14 *(this PR addresses)* |
| Hooks | 100 |
| MCP Servers | 100 |
| Agents | 100 |

11 findings total — 0 critical, 6 high, 2 medium, 2 low, 1 info. Most are duplicates across `settings.json` and `settings.local.json` (and this worktree's copies). **Three unique issues:**

| Finding | Severity | Disposition |
|---|---|---|
| No `permissions.deny` configured | HIGH | **Fixed in this PR** (settings.json.example) |
| `Bash(python -m pip show *)` wildcard flagged HIGH (interpreter access) | HIGH | Filed as #286 — real risk low (`pip show` is read-only); decision needed |
| No PreToolUse hooks in `settings.local.json` | MEDIUM | Known FP — `settings.local.json` is an overlay; `settings.json` provides hooks |
| No Stop hooks at project scope | LOW | Filed as #287 — global hooks cover the gap; decision needed |
| `--no-verify` prohibition (good practice) | INFO | Correct detection; no action |

## Self-backtest

Ran `/pr-review` mentally against this PR-A's own diff:

```
PR review — feat/pr-review-g6-security-baseline (1 commit, 3 files touched)
Diff: origin/master...HEAD   |   Files in scope: 0 / 3 behaviour-bearing

## CLEAN
No behaviour-bearing changes — diff touches only meta/tooling
(.claude/, news/).

## Harness security
ℹ️ This PR touches harness/config: .claude/settings.json.example,
   .claude/skills/pr-review/SKILL.md
   Run /security-scan before merging — /pr-review's rubric does
   not check harness risks (prompt injection in CLAUDE.md, hook
   command injection, over-permissive Bash allow-list, MCP supply-chain).

## Verdict
CLEAN — meta/tooling-only PR; Gate 6 routed to /security-scan
```

Both gates produce the expected output — Gate 6 correctly classifies its own PR as a harness-touching change and routes to `/security-scan`.

## Test plan

- [x] `pytest` full suite passes — **1341 passed, 2 skipped**
- [x] `python -c "import json; json.load(open('.claude/settings.json.example'))"` — JSON template valid
- [x] `test_docs_guard.py` 33/33 cases pass
- [x] AgentShield baseline run + finding tracked
- [x] Self-backtest of `/pr-review` against this PR

## Reviewer note

After merge, contributors with existing `settings.json` will see no automatic deny-block — they need to manually add the new block from the updated `settings.json.example`. I can write a one-line note in CONTRIBUTING.md if that's preferable (didn't want to over-scope this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)