### PR TITLE
feat(skills): /pr-review Gate 11 — PII audit on project skills

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -511,6 +511,75 @@ Severity: all ⚠. Gate 10 doesn't ✗-block; it flags for reviewer
 attention because the line between "real test of error branch"
 and "padding" requires human judgement.
 
+### Gate 11 — PII audit on project skills
+
+Fire only when the diff adds or modifies files under
+`.claude/skills/<name>/` (NOT `.claude/skills/personal/<name>/` —
+that path is gitignored by design). Same scope as the
+"PII audit before committing a project skill" rule in
+[`CLAUDE.md`](../../../CLAUDE.md) — Gate 11 enforces what CLAUDE.md
+asks the author to do manually.
+
+For each added/modified line in those files, look for:
+
+- **Absolute home paths.** `C:\Users\<name>\…`, `/Users/<name>/…`,
+  `/home/<name>/…`. A real path leaks the author's username.
+  Placeholders (`<USER>`, `~/`, `$HOME`, `%USERPROFILE%`) are
+  fine.
+- **IPv4 addresses.** `\d+\.\d+\.\d+\.\d+`. Most often NAS,
+  Synology, or VPN endpoints. Filter out:
+  - Software version numbers (`1.0.0.0`, `pyqt6 6.6.1`)
+  - RFC 5737 documentation IPs (`192.0.2.0/24`, `198.51.100.0/24`,
+    `203.0.113.0/24`)
+  - RFC 1918 ranges *in commented examples* (`192.168.0.0/24` in
+    "block this subnet" context — fine; bare `192.168.1.42` as a
+    config target — flag)
+- **Credential-shaped literals.** Tokens with provider-specific
+  prefixes — `ghp_…` (36+ chars), `AKIA[0-9A-Z]{16}`, JWT (three
+  dot-separated base64 segments ≥10 chars each), generic ≥32-char
+  high-entropy strings next to `key=` / `token=` / `password=` /
+  `secret=`.
+
+**Critical filtering rule — pattern descriptions are NOT literal values.**
+A skill that documents its own scan (like Gate 7's pattern list,
+or a regex example in a README) will contain text like
+`password\s*=\s*["'][^"']+["']` — that's the REGEX, not a
+hardcoded password. DO NOT flag pattern descriptions.
+
+Specifically, do NOT flag:
+
+- Pattern strings inside backticks / code blocks that
+  describe what to LOOK for (regex literals, glob patterns,
+  CLI invocations).
+- Variable names containing the trigger word: `LOCK_KEY`,
+  `auth_token_param`, `password_field`, `api_key_setting`.
+- Test-fixture placeholders: `"test-key"`, `"dummy-token"`,
+  `"changeme"`, `"…"`, `"<your-token-here>"`.
+- Comments referencing the concept: `# Don't commit secrets`,
+  `// API key goes in env var`.
+- Strings whose value is obviously a category label, not a
+  credential: `"key=value"` (a format-string description),
+  `"password"` (a UI label).
+
+When in doubt, surface the match in chat and ASK the user:
+"line N matches pattern X — placeholder or real?" rather than
+silently flagging or silently dismissing. This is one of the
+rare gates where false-positive-aversion AND false-negative-
+aversion BOTH matter (an unflagged real token is catastrophic;
+a noisy false flag erodes trust).
+
+Severity escalation:
+
+- ✗ for a confirmed-real GitHub / AWS / Slack token. Recommend
+  rotate-then-force-push-to-scrub. Don't ship.
+- ⚠ for likely-real home path / IP / generic credential shape.
+- ℹ️ for "matches pattern but probably FP — confirm please".
+
+If the diff doesn't add or modify any
+`.claude/skills/<name>/` file (and `.claude/skills/personal/`
+is correctly gitignored — Gate 11 doesn't reach into personal
+skills), skip this gate entirely.
+
 ## Output template
 
 Emit exactly this structure in chat. Use `## CLEAN` (no findings) or
@@ -546,6 +615,10 @@ Diff: origin/master...HEAD   |   Files in scope: <N behaviour-bearing> / <total>
 
 ## Test quality (Gate 10)
 ⚠ <file:line> — <anti-pattern>: <evidence>
+
+## PII audit (Gate 11)
+⚠ <file:line> — <category>: <evidence>
+ℹ️ <file:line> — possible <category>: <evidence> — confirm placeholder vs real
 
 ## Harness security (Gate 6)
 ℹ️ This PR touches harness/config: <files>
@@ -641,10 +714,19 @@ When the user runs `/pr-review` (with or without a PR number):
     `pytest.skip()` in body, stub-AttributeError, branch-reached-only
     assertions. Emit ⚠ per the gate rules. Omit if no test touch.
 
-12. **Emit the report** in the output-template structure. End with
+12. **PII audit on project skills** (Gate 11). If the diff
+    adds or modifies any `.claude/skills/<name>/` file (NOT
+    `.claude/skills/personal/`), pattern-scan added/modified
+    lines for home paths, IPv4, credential-shaped literals.
+    Apply the critical filter rule — patterns descriptions in
+    code blocks are NOT literal values. Surface ⚠/ℹ️/✗ per the
+    gate rules, or ask in chat when uncertain. Omit if no
+    project-skill touch.
+
+13. **Emit the report** in the output-template structure. End with
     the Verdict line.
 
-13. **Stop.** Do NOT post anything to the PR. Wait for the user.
+14. **Stop.** Do NOT post anything to the PR. Wait for the user.
 
 ## Anti-patterns — what NOT to flag
 

--- a/news/294.feature
+++ b/news/294.feature
@@ -1,0 +1,1 @@
+Add `/pr-review` Gate 11 (PII audit on project skills) — pattern-scans added/modified lines in `.claude/skills/<name>/` for home paths, IPv4, credential-shaped literals, with a critical filter rule that distinguishes pattern descriptions from literal values.


### PR DESCRIPTION
## Pre-merge checklist

- [N/A] User-visible behaviour added/changed → updated `docs/features.md` *(skill text only)*
- [N/A] New file under `app/views/{dialogs,handlers,components,workers}/` → corresponding `qa/scenarios/sNN_*.py` driver added
- [N/A] Tests added (unit + qa scenario if user-facing) *(skill is text; backtests documented in PR body)*
- [x] No `--no-verify` used
- [x] Pre-PR hooks (`docs_guard`, `qa_scenario_guard`) passed locally

## Summary

Follow-up to #272 retro. The CLAUDE.md "PII audit before committing a project skill" rule was previously a manual reminder. Gate 11 turns it into an automatic `/pr-review` check.

- **Fires only** when the diff adds/modifies files under `.claude/skills/<name>/` (NOT `.claude/skills/personal/` — gitignored by design).
- **Patterns scanned:** absolute home paths (`C:\Users\<name>`, `/Users/<name>/`, `/home/<name>/`), IPv4 addresses, credential-shaped literals (GitHub tokens, AWS keys, JWTs, generic ≥32-char strings near `key=`/`token=`/`password=`/`secret=`).
- **Critical filter rule:** Pattern descriptions are NOT literal values. A skill that documents its own scan (like Gate 7's regex list, or this Gate 11 itself) contains text describing patterns — that's the regex, not a hardcoded credential.
- **Severity tiers:** ✗ for confirmed-real tokens (rotate + scrub), ⚠ for likely-real PII, ℹ️ for "matches but probably FP, please confirm". Gate ASKS in chat when uncertain — this is the rare gate where FP-aversion AND FN-aversion both matter.

## Backtests (4/4 pass)

Applying my own retro lesson — at least one real-PR empirical backtest per new gate. Filing the parallel-brief-generator bug [#292](https://github.com/jackal998/photo-manager/issues/292) at the same time addresses the upstream defect from the retro.

| Backtest | Source | Raw matches | After filter | Verdict |
|---|---|---|---|---|
| **A** | Current `.claude/skills/` on master | 8 | 0 ⚠ — all are Gate 7's own pattern descriptions + qa-explore's `key=value` log-format docs | ✓ |
| **B** | [PR #284](https://github.com/jackal998/photo-manager/pull/284) (original `/pr-review`) | 0 | 0 ⚠ | ✓ |
| **C** | [PR #276](https://github.com/jackal998/photo-manager/pull/276) (skills split) | 4 | 0 ⚠ — `key=value` log-format references, the PII regex itself in CLAUDE.md text the PR added | ✓ |
| **Self** | This PR's diff | several | 0 ⚠ — my Gate 11 description necessarily discusses credential keywords inside code blocks; filter rule applies | ✓ |

**The self-backtest is particularly satisfying** — Gate 11 has to be smart enough to NOT flag itself even though its own definition contains every trigger keyword. The filter rule (`pattern descriptions are NOT literal values`) is the discriminator that makes both happen.

## Test plan

- [x] `pytest` full suite passes — **1415 passed, 2 skipped**
- [x] Per-file coverage floor (70%) clears — all 49 files
- [x] 4/4 backtests produce expected output (documented above)
- [x] Output template + walkthrough updated (Gate 11 → step 12; walkthrough renumbered)

## What this completes

With Gate 11, `/pr-review` now has 11 gates covering all four review dimensions the original brief called out (semantic drift, harness security, app-level patterns, code quality), plus PII discipline that was previously honor-system.

| Dimension | Gate(s) |
|---|---|
| Semantic drift (features.md / qa scenarios) | 1–5 |
| Harness routing | 6 |
| App-level security | 7 |
| DB safety | 8 |
| Performance / threading | 9 |
| Test quality | 10 |
| PII / contributor privacy | 11 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)