### PR TITLE
docs(claude.md): clarify per-action vs per-pipeline gating

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@ For each gated action, surface a one-paragraph summary BEFORE acting:
 
 When classification is ambiguous, treat as gated, not as ungated.
 
+**Per gated action, not per pipeline.** One outline + one "yes" approves
+only the actions named in that outline. If you discover a follow-up
+gated step mid-task (push → PR → news fragment → comment), each one
+needs its own surface + "yes" before acting. "Let's go" / "ship it" /
+"looks good" approve the next gated action *only*, not the rest of
+the pipeline.
+
 ## Always-on rules
 
 - Reversible actions preferred; propose a backup before destructive ones

--- a/news/295.doc
+++ b/news/295.doc
@@ -1,0 +1,1 @@
+Clarify CLAUDE.md "Security gates" — per gated action, not per pipeline.


### PR DESCRIPTION
## Pre-merge checklist

- [N/A] User-visible behaviour added/changed → updated `docs/features.md`
  *(docs-only PR; CLAUDE.md is contributor-facing not user-facing.)*
- [N/A] New file under `app/views/{dialogs,handlers,components,workers}/` → corresponding `qa/scenarios/sNN_*.py` driver added
- [N/A] Tests added (unit + qa scenario if user-facing)
  *(no code change; sanity-checked pytest still green at 88%.)*
- [x] No `--no-verify` used
- [x] Pre-PR hooks (`docs_guard`, `qa_scenario_guard`) passed locally
  *(also gated server-side by `pr-gates.yml`.)*

## Summary

- Clarifies the existing "Security gates" section: per gated action, not per pipeline.
- Names the failure mode: a session can outline a 4-step pipeline (push → PR → news fragment → comment), receive one "let's go", and proceed without further surface-and-yes cycles.
- Names the trigger phrases that loosen interpretation: "let's go" / "ship it" / "looks good" approve the NEXT gated action only, not the rest.
- Motivated by a session that batched `gh issue create` + multiple `git push` + `gh pr create` approvals under a single "let's go" and required two mid-session corrections to tighten interpretation.

Scope: **project CLAUDE.md only** (version-controlled, diffable in review, benefits all contributors + future Claude sessions on this repo). The `~/.claude/CLAUDE.md` user-global equivalent is intentionally NOT touched — the canonical rule travels with the repo.

## Test plan

- [x] `pytest` full suite passes (1415 passed, 2 skipped, 88% coverage)
- [x] Per-file coverage floor (70%) clears — no code changes, baseline unaffected
- [N/A] qa-batch scenarios pass (if user-facing) — docs-only
- [x] Diff is 7 added lines under existing clause; no other changes
