### PR TITLE
docs(claude.md): pointer to user-global decision-style preferences

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,6 +3,14 @@
 These rules apply to every session, not just one. They supplement, not
 replace, the global `~/.claude/CLAUDE.md`.
 
+## My decision style
+
+See `~/.claude/CLAUDE.md` "My decision style — pick tech, surface gates."
+tl;dr: my input is conceptual ("transparent, traceable, visible
+long-term"); pick the technical approach yourself and tell me what +
+why. Ask me only on gated actions (next section), manual blockers,
+or high irreversible risk.
+
 ## Security gates — confirm in chat before acting, every time
 
 The following actions require my explicit "yes" in chat before you do them,

--- a/news/296.doc
+++ b/news/296.doc
@@ -1,0 +1,1 @@
+Add CLAUDE.md pointer to user-global "My decision style" preferences (#296).


### PR DESCRIPTION
## Pre-merge checklist

- [N/A] User-visible behaviour added/changed → updated `docs/features.md`
  *(docs-only; CLAUDE.md is contributor-facing.)*
- [N/A] New file under `app/views/{dialogs,handlers,components,workers}/` → corresponding `qa/scenarios/sNN_*.py` driver added
- [N/A] Tests added (unit + qa scenario if user-facing)
  *(no code change.)*
- [x] No `--no-verify` used
- [x] Pre-PR hooks (`docs_guard`, `qa_scenario_guard`) passed locally
  *(also gated server-side by `pr-gates.yml`.)*

## Summary

- Adds a 5-line "My decision style" section near the top of project `CLAUDE.md` that points at a canonical section in `~/.claude/CLAUDE.md`.
- The canonical preferences (pick the tech approach, ask only on gates/blockers/risk, surface choice+reason) live in the user-global file — they're about the owner's interaction posture across every project, not project-specific conventions.
- The project pointer exists for **discoverability**: a session reading just project `CLAUDE.md` (e.g. during PR review or via git history) sees the rule's existence + a 1-line tl;dr without having to cross-reference user-global.

## Two-file design

| File | Scope | Content |
|---|---|---|
| `~/.claude/CLAUDE.md` (not in this PR) | User-global, cross-project | Canonical 60+ line section: ASK / DON'T ASK / Always-on tax / "What this is NOT" guard |
| `<project>/CLAUDE.md` (THIS PR) | Project-committed | 5-line pointer + tl;dr |

The user-global edit was made out-of-band (lives at `~/.claude/CLAUDE.md` on the owner's machine; not in this repo).

## Why not put the full text in project CLAUDE.md

The preferences are about **how the owner works with Claude**, not about project conventions. Putting the full text in project CLAUDE.md would bind every contributor's Claude sessions to one user's interaction style. The pointer pattern keeps the canonical text user-scoped while still making it discoverable from the project.

## Coordination with #295

This PR and #295 (which clarifies "per gated action, not per pipeline" in the Security gates section) both touch project `CLAUDE.md` but at different locations:
- #295 — inserts under existing "Security gates" section (line 28 area)
- THIS PR — inserts after the intro paragraph (line 5 area), before "Security gates"

No textual conflict expected. Whoever merges second pays a trivial rebase.

## Test plan

- [x] `pytest` full suite passes (1415 passed, 2 skipped, 88% coverage at last run)
- [x] Per-file coverage floor (70%) clears — no code changes, baseline unaffected
- [N/A] qa-batch scenarios pass — docs-only
- [x] Diff is 8 added lines under intro paragraph; no other changes
