### PR TITLE
chore(skills): split pr-review SKILL.md via progressive disclosure

### DIFF
--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -251,334 +251,31 @@ routing reminder, not a finding.
 
 If the diff does NOT touch any harness path, skip this gate
 entirely (do not emit an empty "Harness security" section).
+### Gates 7-11 — application-level pattern scans
 
-### Gate 7 — app-level security pattern scan
+Five gates that scan the diff for concrete dangerous, buggy, or
+sloppy patterns. Each has narrow trigger conditions and its own
+rubric. The **full rubrics** (patterns, anti-patterns, severity
+tiers, output format per gate) live in
+[`app-gates.md`](app-gates.md) — read that file's section for
+each gate that fires on this diff.
 
-Scan the diff for concrete dangerous patterns. **Only flag ⚠ when
-you can point at a specific file:line and name the pattern.** Do
-NOT flag "this looks insecure" without concrete evidence.
+| Gate | Fires when | What it catches |
+|---|---|---|
+| 7 | Diff is behaviour-bearing | SQL injection (f-string `execute`), hardcoded secrets, unsafe deserialisation (`pickle.load`, `yaml.load`), shell injection (`subprocess shell=True` with interpolation), `eval`/`exec` on diff content, path traversal |
+| 8 | `_MIGRATIONS` (in `infrastructure/manifest_repository.py`) or `CREATE TABLE migration_manifest` (in `scanner/manifest.py`) touched | Non-additive migrations, mid-list insertion, missing companion edits to `ManifestRow` + schema SQL, missing README schema-table update |
+| 9 | `scanner/**.py`, `app/views/workers/**.py`, or new `QThread` / `QRunnable` / `ThreadPoolExecutor` added | Per-row I/O in a loop, nested O(N²) over filesystem paths, subprocess-in-loop without `-stay_open` batching, `QThread.run()` without progress/cancel, subprocess without timeout |
+| 10 | `tests/test_*.py` or `tests/integration/test_*.py` added/modified | Monkeypatch-to-cover-defensive (`QStandardItem.setData` raising etc.), forced feature-flag fallback, undocumented `@pytest.mark.skip`, `pytest.skip()` in body, stub-AttributeError, branch-reached-only assertions |
+| 11 | `.claude/skills/<name>/` files added/modified (NOT `.claude/skills/personal/`) | Absolute home paths, IPv4 addresses, credential-shaped literals — with the **critical filter rule** that pattern descriptions inside code blocks are NOT literal values |
 
-Patterns to flag (each ⚠ with file:line):
+For each gate whose trigger fires:
+1. Read the corresponding section in [`app-gates.md`](app-gates.md).
+2. Apply the patterns + anti-patterns described there.
+3. Emit findings in the gate's output section (see Output template
+   below). Omit the section if zero findings on that gate.
 
-- **SQL injection via f-string / `%` formatting**
-  - `cursor.execute(f"... {var} ...")` — flag.
-  - `conn.execute("...%s..." % var)` — flag.
-  - `cursor.execute("... " + var + " ...")` — flag.
-  - Parameterised queries (`cursor.execute("... ?", (var,))`) are
-    fine; never flag those.
-  - The project uses `sqlite3` directly (see
-    `infrastructure/manifest_repository.py`). Any new
-    `execute(...)` call in a PR diff is worth a 5-second look.
-
-- **Hardcoded secrets**
-  - Regex-style: `API_KEY\s*=\s*["'][A-Za-z0-9_-]{16,}["']`,
-    `password\s*=\s*["'][^"']+["']`, `token\s*=\s*["'][A-Za-z0-9._-]{20,}["']`.
-  - GitHub tokens (`ghp_…`), AWS keys (`AKIA…`), JWT-shaped strings.
-  - Test fixtures using literally `"test-key"` / `"dummy"` are NOT
-    secrets — don't flag those.
-
-- **Unsafe deserialisation**
-  - `pickle.load(...)` / `pickle.loads(...)` on data from disk,
-    network, or user input — flag.
-  - `yaml.load(...)` without `Loader=SafeLoader` — flag. Suggest
-    `yaml.safe_load`.
-  - `marshal.loads(...)` from untrusted sources — flag.
-  - Internal-only pickled caches the project itself wrote (and
-    fingerprints with a hash) MAY be acceptable; flag for review
-    rather than ✗.
-
-- **Shell injection via `subprocess`**
-  - `subprocess.run(..., shell=True)` with an f-string or `%`
-    formatted argv — flag.
-  - `subprocess.Popen(f"... {var} ...", shell=True)` — flag.
-  - `subprocess.run(["bin", arg1, arg2])` (list form, no shell)
-    is fine.
-  - The scanner pipeline shells out to `exiftool`. Any new
-    subprocess call needs list-form argv with no shell, AND a
-    timeout if it could hang on bad input.
-
-- **`eval` / `exec` / `compile` on diff content**
-  - Any `eval(...)` / `exec(...)` of strings derived from file
-    content, user input, or settings — flag ✗ (rare in this
-    project; if it appears, it's almost certainly wrong).
-
-- **Path traversal**
-  - User-supplied filename joined into a path without
-    `pathlib.Path.resolve()` + containment check — flag when
-    the resulting path is then opened for write/delete.
-  - Pure-read with `Image.open(path)` on scanned filesystem
-    paths is fine — the project's job IS to read those.
-
-Anti-patterns (do NOT flag):
-
-- Internal constants named `*_KEY` that are NOT secrets (e.g.
-  `LOCK_KEY = "is_locked"` — column name, not credential).
-- f-strings in log messages (`logger.info(f"scanning {path}")`).
-- f-strings in `print()` for QA scenarios.
-- Subprocess calls with hardcoded argv (no interpolation).
-- Refactors that just move existing code without changing its
-  shape — if the f-string SQL was already there pre-PR, it's not
-  this PR's bug.
-
-When you DO flag, emit one line per finding:
-
-```
-⚠ <file:line> — <pattern name>: <one-line evidence quote>
-```
-
-Severity escalation: `eval`/`exec` on diff content → ✗.
-Everything else → ⚠.
-
-### Gate 8 — SQLite migration safety
-
-Fire only when the diff touches the `_MIGRATIONS` list in
-`infrastructure/manifest_repository.py` OR the schema SQL block in
-`scanner/manifest.py` (`CREATE TABLE migration_manifest`).
-
-For each new entry, check:
-
-1. **Additive only.** `ADD COLUMN` semantics (the project uses
-   `ALTER TABLE … ADD COLUMN`). Never `DROP COLUMN`,
-   `RENAME COLUMN`, or `ALTER COLUMN TYPE` — SQLite can't do
-   those safely without a table rebuild, and old manifests would
-   break. If you see one, ✗ flag.
-
-2. **Appended at end, not inserted into the middle.** The order
-   of `_MIGRATIONS` IS the migration order — each new row must
-   land after every existing row. Inserting into the middle
-   re-orders migration application and could fail mid-list on an
-   already-migrated DB. ✗ flag if mid-list insertion.
-
-3. **Backward-compatible defaults.**
-   - `INTEGER` / `REAL` / `TEXT` columns: nullable (no default)
-     OR `DEFAULT 0` / `DEFAULT 0.0` / `DEFAULT ''` — safe.
-   - `NOT NULL` without a default on existing data → ⚠ (older
-     manifests would fail the migration).
-   - The existing convention is `INTEGER NOT NULL DEFAULT 0`
-     for flags and `REAL` (nullable) for scores. Match it.
-
-4. **Idempotency.** The repo's `_apply_migrations` does `ALTER
-   TABLE` and swallows the "duplicate column" error — safe to
-   re-run. Don't break that invariant (e.g., by replacing with
-   `CREATE TABLE`-style schema).
-
-5. **Companion edits.** A new migration row MUST also appear:
-   - In the `CREATE TABLE migration_manifest` schema in
-     `scanner/manifest.py` (so new manifests have the column
-     from the start, not via migration).
-   - As a field on `ManifestRow` (or equivalent dataclass) in
-     `scanner/dedup.py` if read by the scanner.
-   - If absent in either, ⚠ flag the mismatch.
-
-6. **README schema table.** The README has a manifest schema
-   table. If the migration adds a user-facing column (visible
-   in the UI), `update-docs` should have flagged a README touch.
-   If README wasn't touched, ⚠ suggest updating the schema table.
-
-Output format:
-
-```
-⚠ <_MIGRATIONS line> — <issue>: <evidence>
-```
-
-### Gate 9 — performance & threading
-
-Fire when the diff touches `scanner/**.py`, `app/views/workers/**.py`,
-or adds a `QThread` / `QRunnable` / `ThreadPoolExecutor`. Look for
-the specific bug patterns that have hit this codebase before
-(see the `photo-scanner-patterns` skill).
-
-Patterns to flag:
-
-- **Per-row I/O inside a loop over files.**
-  - `for row in rows: data = Path(row.path).read_bytes()` —
-    flag if the loop runs over thousands of files. The scanner
-    explicitly does single-read SHA-256 + pHash + EXIF from one
-    `read_bytes()` — don't add a second `read_bytes()` per row
-    in a different stage.
-  - `for row in rows: Image.open(row.path)` inside a hot loop
-    without batching → ⚠.
-
-- **Nested loop over filesystem paths.**
-  - `for a in all_paths: for b in all_paths: ...` — flag as O(N²)
-    even if N looks small (NAS scans hit 100k+ files).
-  - Pairwise near-duplicate scanners must use the outer-vs-inner
-    placement from `photo-scanner-patterns`; flag if the new code
-    appears to do pHash compare in the inner loop.
-
-- **Subprocess in a loop without `-stay_open` batching.**
-  - `for path in paths: subprocess.run(["exiftool", path], ...)` —
-    flag. The project batches via `-stay_open` for thousands of
-    files; per-file spawn is the documented 10–100× slowdown.
-
-- **Blocking call inside a `QThread.run()` without progress / cancel.**
-  - New `class FooWorker(QThread)` whose `run()` has no `emit()`
-    progress and no `if self._cancel: return` check → ⚠ for
-    "user can't tell what's happening / can't abort".
-  - The pattern documented in
-    [`photo-scanner-patterns`](../personal/photo-scanner-patterns/SKILL.md)
-    (if present, else in skills index) — match it.
-
-- **`subprocess.run` without a timeout in user-facing code.**
-  - If a subprocess can hang on a malformed file (e.g.,
-    `exiftool` on a corrupted HEIC), and the call is in a
-    user-facing thread (not the dedicated scanner pipeline that
-    has its own timeout layer), → ⚠ "add a `timeout=` kwarg".
-
-Anti-patterns (do NOT flag):
-
-- A single `read_bytes()` per row in the scanner pipeline — that's
-  the documented design.
-- O(N²) over tiny lists (group decisions in a single dedup group,
-  typically <100 elements) — that's bounded; don't be pedantic.
-- A QThread without progress when the workload is sub-second
-  (e.g., loading a small config file).
-- `subprocess.run` of internal scripts the project itself ships
-  with a known runtime.
-
-Cross-reference: this gate complements but does not duplicate
-the `photo-scanner-patterns` skill — that skill is invoked
-during *writing* code; Gate 9 catches the same issues during
-*reviewing* the resulting diff.
-
-### Gate 10 — test-padding detection
-
-This project explicitly forbids mock-driven coverage padding
-(see [`CLAUDE.md`](../../../CLAUDE.md) "Testing ground rules").
-Gate 10 surfaces the specific anti-patterns called out there.
-
-Fire only when the diff adds or modifies files matching
-`tests/test_*.py` or `tests/integration/test_*.py`.
-
-Flag ⚠ when ANY of these appear in a new/modified test:
-
-- **Monkeypatching a stdlib / Qt method to raise just to cover an
-  except-pass branch.**
-  - `monkeypatch.setattr(QStandardItem, "setData", lambda *a: 1/0)`
-    — flag. The CLAUDE.md anti-pattern list names this exact one.
-  - `monkeypatch.setattr(Image, "getexif", lambda self: None)` —
-    flag if used only to cover the `if not exif: return None`
-    guard. The right test is a real fixture file with no EXIF.
-  - `monkeypatch.setattr(Path, "read_bytes", lambda *a: (_ for _ in ()).throw(OSError))`
-    when no real OSError condition is reproduced — flag.
-
-- **Forcing a feature-flag constant to False to cover a fallback
-  branch the project doesn't actually have.**
-  - `pm.scanner.hasher._HASH_AVAILABLE = False` — flag if PIL is
-    a hard dep. The fallback branch is dead defense; document it
-    in source, don't synthetic-cover it.
-
-- **`@pytest.mark.skip` with no comment.**
-  - `@pytest.mark.skip` at function scope → ⚠ "skipped without
-    justification". A comment naming the reason + linking an
-    issue is OK; raw skip is not.
-
-- **`pytest.skip(...)` inside a test body** without a clearly
-  external condition (e.g., "skipping on Windows because
-  `pillow-heif` isn't installed there"). If the body just has
-  `pytest.skip("not implemented yet")`, flag — the right move is
-  to delete the test or actually implement it.
-
-- **Stub object that lacks the attribute the SUT calls, only to
-  exercise the `AttributeError`-caught branch.**
-  - `class FakeImage: pass; assert load_exif(FakeImage()) is None`
-    when `load_exif` only catches `AttributeError` from missing
-    `getexif` → flag. A real "image without EXIF" fixture
-    exercises the same branch honestly.
-
-- **A test whose only assertion is "this branch was reached"**,
-  e.g., `assert called_path is True` after forcing the branch
-  with a mock — flag. Real tests assert observable behaviour, not
-  internal control-flow.
-
-Anti-patterns (do NOT flag):
-
-- Legitimate mocks of EXTERNAL services (network, GitHub API,
-  hardware) where the boundary is genuinely uncontrollable in
-  CI — those are fine.
-- Mocks of pure-functional helpers to isolate the unit under
-  test — fine. The flag is specifically about mocking to reach
-  defensive code that doesn't have a real failure mode.
-- Tests that use real fixtures (corrupted-image files, manifests
-  with missing columns) to trigger error branches — those are
-  the correct shape.
-- Tests with detailed `# why this monkeypatch is realistic`
-  comments naming a real-world condition the patch simulates
-  (slow NAS, dropped network, OOM). The comment IS the
-  justification.
-
-Severity: all ⚠. Gate 10 doesn't ✗-block; it flags for reviewer
-attention because the line between "real test of error branch"
-and "padding" requires human judgement.
-
-### Gate 11 — PII audit on project skills
-
-Fire only when the diff adds or modifies files under
-`.claude/skills/<name>/` (NOT `.claude/skills/personal/<name>/` —
-that path is gitignored by design). Same scope as the
-"PII audit before committing a project skill" rule in
-[`CLAUDE.md`](../../../CLAUDE.md) — Gate 11 enforces what CLAUDE.md
-asks the author to do manually.
-
-For each added/modified line in those files, look for:
-
-- **Absolute home paths.** `C:\Users\<name>\…`, `/Users/<name>/…`,
-  `/home/<name>/…`. A real path leaks the author's username.
-  Placeholders (`<USER>`, `~/`, `$HOME`, `%USERPROFILE%`) are
-  fine.
-- **IPv4 addresses.** `\d+\.\d+\.\d+\.\d+`. Most often NAS,
-  Synology, or VPN endpoints. Filter out:
-  - Software version numbers (`1.0.0.0`, `pyqt6 6.6.1`)
-  - RFC 5737 documentation IPs (`192.0.2.0/24`, `198.51.100.0/24`,
-    `203.0.113.0/24`)
-  - RFC 1918 ranges *in commented examples* (`192.168.0.0/24` in
-    "block this subnet" context — fine; bare `192.168.1.42` as a
-    config target — flag)
-- **Credential-shaped literals.** Tokens with provider-specific
-  prefixes — `ghp_…` (36+ chars), `AKIA[0-9A-Z]{16}`, JWT (three
-  dot-separated base64 segments ≥10 chars each), generic ≥32-char
-  high-entropy strings next to `key=` / `token=` / `password=` /
-  `secret=`.
-
-**Critical filtering rule — pattern descriptions are NOT literal values.**
-A skill that documents its own scan (like Gate 7's pattern list,
-or a regex example in a README) will contain text like
-`password\s*=\s*["'][^"']+["']` — that's the REGEX, not a
-hardcoded password. DO NOT flag pattern descriptions.
-
-Specifically, do NOT flag:
-
-- Pattern strings inside backticks / code blocks that
-  describe what to LOOK for (regex literals, glob patterns,
-  CLI invocations).
-- Variable names containing the trigger word: `LOCK_KEY`,
-  `auth_token_param`, `password_field`, `api_key_setting`.
-- Test-fixture placeholders: `"test-key"`, `"dummy-token"`,
-  `"changeme"`, `"…"`, `"<your-token-here>"`.
-- Comments referencing the concept: `# Don't commit secrets`,
-  `// API key goes in env var`.
-- Strings whose value is obviously a category label, not a
-  credential: `"key=value"` (a format-string description),
-  `"password"` (a UI label).
-
-When in doubt, surface the match in chat and ASK the user:
-"line N matches pattern X — placeholder or real?" rather than
-silently flagging or silently dismissing. This is one of the
-rare gates where false-positive-aversion AND false-negative-
-aversion BOTH matter (an unflagged real token is catastrophic;
-a noisy false flag erodes trust).
-
-Severity escalation:
-
-- ✗ for a confirmed-real GitHub / AWS / Slack token. Recommend
-  rotate-then-force-push-to-scrub. Don't ship.
-- ⚠ for likely-real home path / IP / generic credential shape.
-- ℹ️ for "matches pattern but probably FP — confirm please".
-
-If the diff doesn't add or modify any
-`.claude/skills/<name>/` file (and `.claude/skills/personal/`
-is correctly gitignored — Gate 11 doesn't reach into personal
-skills), skip this gate entirely.
+If a gate's trigger does NOT fire, skip its rubric entirely — don't
+read its section, don't emit an empty header.
 
 ## Output template
 
@@ -687,46 +384,19 @@ When the user runs `/pr-review` (with or without a PR number):
    "Harness security" section pointing at `/security-scan`.
    Otherwise omit the section.
 
-8. **Run app-level security scan** (Gate 7). Read the full diff
-   for SQL-injection patterns, hardcoded secrets, unsafe
-   deserialisation, `subprocess` with shell-injection, `eval`/
-   `exec`. For each match, emit ⚠ (or ✗ for `eval`/`exec`) with
-   file:line + the matched pattern. Omit the section if zero
-   findings.
+8. **Run application-level gates (7-11)** per
+   [`app-gates.md`](app-gates.md). For each gate whose trigger
+   fires (see trigger table in §Review rubric above), read that
+   gate's section in `app-gates.md` and apply its rubric. Emit
+   findings in the corresponding section of the output template.
+   **Omit any gate's section if zero findings**, the same as
+   Gate 6. If no gate's trigger fires on this diff, skip reading
+   `app-gates.md` entirely.
 
-9. **Check SQLite migration safety** (Gate 8). If the diff
-   touches `_MIGRATIONS` in `infrastructure/manifest_repository.py`
-   or the `CREATE TABLE migration_manifest` block in
-   `scanner/manifest.py`, verify additive-only, appended-at-end,
-   backward-compatible defaults, and companion edits to dataclass
-   + schema SQL. Emit ⚠/✗ per the gate rules. Omit if no migration
-   touch.
+9. **Emit the report** in the output-template structure. End with
+   the Verdict line.
 
-10. **Check performance & threading** (Gate 9). If the diff touches
-    `scanner/**.py` or adds workers, scan for per-row I/O,
-    nested-loop O(N²), subprocess-in-loop without batching,
-    QThread without progress/cancel, subprocess without timeout.
-    Emit ⚠ per the gate rules. Omit if no perf-relevant touch.
-
-11. **Check test quality** (Gate 10). If the diff adds/modifies
-    `tests/test_*.py` files, scan for monkeypatch-to-cover-defensive,
-    forced-feature-flag, undocumented `pytest.mark.skip`,
-    `pytest.skip()` in body, stub-AttributeError, branch-reached-only
-    assertions. Emit ⚠ per the gate rules. Omit if no test touch.
-
-12. **PII audit on project skills** (Gate 11). If the diff
-    adds or modifies any `.claude/skills/<name>/` file (NOT
-    `.claude/skills/personal/`), pattern-scan added/modified
-    lines for home paths, IPv4, credential-shaped literals.
-    Apply the critical filter rule — patterns descriptions in
-    code blocks are NOT literal values. Surface ⚠/ℹ️/✗ per the
-    gate rules, or ask in chat when uncertain. Omit if no
-    project-skill touch.
-
-13. **Emit the report** in the output-template structure. End with
-    the Verdict line.
-
-14. **Stop.** Do NOT post anything to the PR. Wait for the user.
+10. **Stop.** Do NOT post anything to the PR. Wait for the user.
 
 ## Anti-patterns — what NOT to flag
 

--- a/.claude/skills/pr-review/app-gates.md
+++ b/.claude/skills/pr-review/app-gates.md
@@ -1,0 +1,357 @@
+# pr-review — application-level gates (7–11)
+
+This file holds the detailed rubrics for `/pr-review`'s
+application-level pattern matching. The main
+[`SKILL.md`](SKILL.md) keeps Gates 1–6 (semantic drift + harness
+routing — the core review flow) and points here for the
+application-level rubric details.
+
+Read this file when the corresponding gate's trigger fires on a
+diff. If a gate's trigger doesn't fire (e.g., no `_MIGRATIONS`
+touch → skip Gate 8), don't bother reading its section.
+
+## Contents
+
+- [Gate 7 — app-level security pattern scan](#gate-7--app-level-security-pattern-scan) — SQLi, secrets, deserialisation, shell injection, eval/exec, path traversal
+- [Gate 8 — SQLite migration safety](#gate-8--sqlite-migration-safety) — additive only, appended at end, backward-compatible defaults, idempotency, companion edits
+- [Gate 9 — performance & threading](#gate-9--performance--threading) — per-row I/O, O(N²), subprocess in loop, QThread without progress/cancel, missing timeout
+- [Gate 10 — test-padding detection](#gate-10--test-padding-detection) — monkeypatch-to-cover-defensive, forced feature flags, undocumented skip
+- [Gate 11 — PII audit on project skills](#gate-11--pii-audit-on-project-skills) — home paths, IPv4, credential-shaped literals, with the pattern-vs-literal filter rule
+
+---
+
+## Gate 7 — app-level security pattern scan
+
+Scan the diff for concrete dangerous patterns. **Only flag ⚠ when
+you can point at a specific file:line and name the pattern.** Do
+NOT flag "this looks insecure" without concrete evidence.
+
+Patterns to flag (each ⚠ with file:line):
+
+- **SQL injection via f-string / `%` formatting**
+  - `cursor.execute(f"... {var} ...")` — flag.
+  - `conn.execute("...%s..." % var)` — flag.
+  - `cursor.execute("... " + var + " ...")` — flag.
+  - Parameterised queries (`cursor.execute("... ?", (var,))`) are
+    fine; never flag those.
+  - The project uses `sqlite3` directly (see
+    `infrastructure/manifest_repository.py`). Any new
+    `execute(...)` call in a PR diff is worth a 5-second look.
+
+- **Hardcoded secrets**
+  - Regex-style: `API_KEY\s*=\s*["'][A-Za-z0-9_-]{16,}["']`,
+    `password\s*=\s*["'][^"']+["']`, `token\s*=\s*["'][A-Za-z0-9._-]{20,}["']`.
+  - GitHub tokens (`ghp_…`), AWS keys (`AKIA…`), JWT-shaped strings.
+  - Test fixtures using literally `"test-key"` / `"dummy"` are NOT
+    secrets — don't flag those.
+
+- **Unsafe deserialisation**
+  - `pickle.load(...)` / `pickle.loads(...)` on data from disk,
+    network, or user input — flag.
+  - `yaml.load(...)` without `Loader=SafeLoader` — flag. Suggest
+    `yaml.safe_load`.
+  - `marshal.loads(...)` from untrusted sources — flag.
+  - Internal-only pickled caches the project itself wrote (and
+    fingerprints with a hash) MAY be acceptable; flag for review
+    rather than ✗.
+
+- **Shell injection via `subprocess`**
+  - `subprocess.run(..., shell=True)` with an f-string or `%`
+    formatted argv — flag.
+  - `subprocess.Popen(f"... {var} ...", shell=True)` — flag.
+  - `subprocess.run(["bin", arg1, arg2])` (list form, no shell)
+    is fine.
+  - The scanner pipeline shells out to `exiftool`. Any new
+    subprocess call needs list-form argv with no shell, AND a
+    timeout if it could hang on bad input.
+
+- **`eval` / `exec` / `compile` on diff content**
+  - Any `eval(...)` / `exec(...)` of strings derived from file
+    content, user input, or settings — flag ✗ (rare in this
+    project; if it appears, it's almost certainly wrong).
+
+- **Path traversal**
+  - User-supplied filename joined into a path without
+    `pathlib.Path.resolve()` + containment check — flag when
+    the resulting path is then opened for write/delete.
+  - Pure-read with `Image.open(path)` on scanned filesystem
+    paths is fine — the project's job IS to read those.
+
+Anti-patterns (do NOT flag):
+
+- Internal constants named `*_KEY` that are NOT secrets (e.g.
+  `LOCK_KEY = "is_locked"` — column name, not credential).
+- f-strings in log messages (`logger.info(f"scanning {path}")`).
+- f-strings in `print()` for QA scenarios.
+- Subprocess calls with hardcoded argv (no interpolation).
+- Refactors that just move existing code without changing its
+  shape — if the f-string SQL was already there pre-PR, it's not
+  this PR's bug.
+
+When you DO flag, emit one line per finding:
+
+```
+⚠ <file:line> — <pattern name>: <one-line evidence quote>
+```
+
+Severity escalation: `eval`/`exec` on diff content → ✗.
+Everything else → ⚠.
+
+---
+
+## Gate 8 — SQLite migration safety
+
+Fire only when the diff touches the `_MIGRATIONS` list in
+`infrastructure/manifest_repository.py` OR the schema SQL block in
+`scanner/manifest.py` (`CREATE TABLE migration_manifest`).
+
+For each new entry, check:
+
+1. **Additive only.** `ADD COLUMN` semantics (the project uses
+   `ALTER TABLE … ADD COLUMN`). Never `DROP COLUMN`,
+   `RENAME COLUMN`, or `ALTER COLUMN TYPE` — SQLite can't do
+   those safely without a table rebuild, and old manifests would
+   break. If you see one, ✗ flag.
+
+2. **Appended at end, not inserted into the middle.** The order
+   of `_MIGRATIONS` IS the migration order — each new row must
+   land after every existing row. Inserting into the middle
+   re-orders migration application and could fail mid-list on an
+   already-migrated DB. ✗ flag if mid-list insertion.
+
+3. **Backward-compatible defaults.**
+   - `INTEGER` / `REAL` / `TEXT` columns: nullable (no default)
+     OR `DEFAULT 0` / `DEFAULT 0.0` / `DEFAULT ''` — safe.
+   - `NOT NULL` without a default on existing data → ⚠ (older
+     manifests would fail the migration).
+   - The existing convention is `INTEGER NOT NULL DEFAULT 0`
+     for flags and `REAL` (nullable) for scores. Match it.
+
+4. **Idempotency.** The repo's `_apply_migrations` does `ALTER
+   TABLE` and swallows the "duplicate column" error — safe to
+   re-run. Don't break that invariant (e.g., by replacing with
+   `CREATE TABLE`-style schema).
+
+5. **Companion edits.** A new migration row MUST also appear:
+   - In the `CREATE TABLE migration_manifest` schema in
+     `scanner/manifest.py` (so new manifests have the column
+     from the start, not via migration).
+   - As a field on `ManifestRow` (or equivalent dataclass) in
+     `scanner/dedup.py` if read by the scanner.
+   - If absent in either, ⚠ flag the mismatch.
+
+6. **README schema table.** The README has a manifest schema
+   table. If the migration adds a user-facing column (visible
+   in the UI), `update-docs` should have flagged a README touch.
+   If README wasn't touched, ⚠ suggest updating the schema table.
+
+Output format:
+
+```
+⚠ <_MIGRATIONS line> — <issue>: <evidence>
+```
+
+---
+
+## Gate 9 — performance & threading
+
+Fire when the diff touches `scanner/**.py`, `app/views/workers/**.py`,
+or adds a `QThread` / `QRunnable` / `ThreadPoolExecutor`. Look for
+the specific bug patterns that have hit this codebase before
+(see the `photo-scanner-patterns` skill).
+
+Patterns to flag:
+
+- **Per-row I/O inside a loop over files.**
+  - `for row in rows: data = Path(row.path).read_bytes()` —
+    flag if the loop runs over thousands of files. The scanner
+    explicitly does single-read SHA-256 + pHash + EXIF from one
+    `read_bytes()` — don't add a second `read_bytes()` per row
+    in a different stage.
+  - `for row in rows: Image.open(row.path)` inside a hot loop
+    without batching → ⚠.
+
+- **Nested loop over filesystem paths.**
+  - `for a in all_paths: for b in all_paths: ...` — flag as O(N²)
+    even if N looks small (NAS scans hit 100k+ files).
+  - Pairwise near-duplicate scanners must use the outer-vs-inner
+    placement from `photo-scanner-patterns`; flag if the new code
+    appears to do pHash compare in the inner loop.
+
+- **Subprocess in a loop without `-stay_open` batching.**
+  - `for path in paths: subprocess.run(["exiftool", path], ...)` —
+    flag. The project batches via `-stay_open` for thousands of
+    files; per-file spawn is the documented 10–100× slowdown.
+
+- **Blocking call inside a `QThread.run()` without progress / cancel.**
+  - New `class FooWorker(QThread)` whose `run()` has no `emit()`
+    progress and no `if self._cancel: return` check → ⚠ for
+    "user can't tell what's happening / can't abort".
+  - The pattern documented in
+    [`photo-scanner-patterns`](../personal/photo-scanner-patterns/SKILL.md)
+    (if present, else in skills index) — match it.
+
+- **`subprocess.run` without a timeout in user-facing code.**
+  - If a subprocess can hang on a malformed file (e.g.,
+    `exiftool` on a corrupted HEIC), and the call is in a
+    user-facing thread (not the dedicated scanner pipeline that
+    has its own timeout layer), → ⚠ "add a `timeout=` kwarg".
+
+Anti-patterns (do NOT flag):
+
+- A single `read_bytes()` per row in the scanner pipeline — that's
+  the documented design.
+- O(N²) over tiny lists (group decisions in a single dedup group,
+  typically <100 elements) — that's bounded; don't be pedantic.
+- A QThread without progress when the workload is sub-second
+  (e.g., loading a small config file).
+- `subprocess.run` of internal scripts the project itself ships
+  with a known runtime.
+
+Cross-reference: this gate complements but does not duplicate
+the `photo-scanner-patterns` skill — that skill is invoked
+during *writing* code; Gate 9 catches the same issues during
+*reviewing* the resulting diff.
+
+---
+
+## Gate 10 — test-padding detection
+
+This project explicitly forbids mock-driven coverage padding
+(see [`CLAUDE.md`](../../../CLAUDE.md) "Testing ground rules").
+Gate 10 surfaces the specific anti-patterns called out there.
+
+Fire only when the diff adds or modifies files matching
+`tests/test_*.py` or `tests/integration/test_*.py`.
+
+Flag ⚠ when ANY of these appear in a new/modified test:
+
+- **Monkeypatching a stdlib / Qt method to raise just to cover an
+  except-pass branch.**
+  - `monkeypatch.setattr(QStandardItem, "setData", lambda *a: 1/0)`
+    — flag. The CLAUDE.md anti-pattern list names this exact one.
+  - `monkeypatch.setattr(Image, "getexif", lambda self: None)` —
+    flag if used only to cover the `if not exif: return None`
+    guard. The right test is a real fixture file with no EXIF.
+  - `monkeypatch.setattr(Path, "read_bytes", lambda *a: (_ for _ in ()).throw(OSError))`
+    when no real OSError condition is reproduced — flag.
+
+- **Forcing a feature-flag constant to False to cover a fallback
+  branch the project doesn't actually have.**
+  - `pm.scanner.hasher._HASH_AVAILABLE = False` — flag if PIL is
+    a hard dep. The fallback branch is dead defense; document it
+    in source, don't synthetic-cover it.
+
+- **`@pytest.mark.skip` with no comment.**
+  - `@pytest.mark.skip` at function scope → ⚠ "skipped without
+    justification". A comment naming the reason + linking an
+    issue is OK; raw skip is not.
+
+- **`pytest.skip(...)` inside a test body** without a clearly
+  external condition (e.g., "skipping on Windows because
+  `pillow-heif` isn't installed there"). If the body just has
+  `pytest.skip("not implemented yet")`, flag — the right move is
+  to delete the test or actually implement it.
+
+- **Stub object that lacks the attribute the SUT calls, only to
+  exercise the `AttributeError`-caught branch.**
+  - `class FakeImage: pass; assert load_exif(FakeImage()) is None`
+    when `load_exif` only catches `AttributeError` from missing
+    `getexif` → flag. A real "image without EXIF" fixture
+    exercises the same branch honestly.
+
+- **A test whose only assertion is "this branch was reached"**,
+  e.g., `assert called_path is True` after forcing the branch
+  with a mock — flag. Real tests assert observable behaviour, not
+  internal control-flow.
+
+Anti-patterns (do NOT flag):
+
+- Legitimate mocks of EXTERNAL services (network, GitHub API,
+  hardware) where the boundary is genuinely uncontrollable in
+  CI — those are fine.
+- Mocks of pure-functional helpers to isolate the unit under
+  test — fine. The flag is specifically about mocking to reach
+  defensive code that doesn't have a real failure mode.
+- Tests that use real fixtures (corrupted-image files, manifests
+  with missing columns) to trigger error branches — those are
+  the correct shape.
+- Tests with detailed `# why this monkeypatch is realistic`
+  comments naming a real-world condition the patch simulates
+  (slow NAS, dropped network, OOM). The comment IS the
+  justification.
+
+Severity: all ⚠. Gate 10 doesn't ✗-block; it flags for reviewer
+attention because the line between "real test of error branch"
+and "padding" requires human judgement.
+
+---
+
+## Gate 11 — PII audit on project skills
+
+Fire only when the diff adds or modifies files under
+`.claude/skills/<name>/` (NOT `.claude/skills/personal/<name>/` —
+that path is gitignored by design). Same scope as the
+"PII audit before committing a project skill" rule in
+[`CLAUDE.md`](../../../CLAUDE.md) — Gate 11 enforces what CLAUDE.md
+asks the author to do manually.
+
+For each added/modified line in those files, look for:
+
+- **Absolute home paths.** `C:\Users\<name>\…`, `/Users/<name>/…`,
+  `/home/<name>/…`. A real path leaks the author's username.
+  Placeholders (`<USER>`, `~/`, `$HOME`, `%USERPROFILE%`) are
+  fine.
+- **IPv4 addresses.** `\d+\.\d+\.\d+\.\d+`. Most often NAS,
+  Synology, or VPN endpoints. Filter out:
+  - Software version numbers (`1.0.0.0`, `pyqt6 6.6.1`)
+  - RFC 5737 documentation IPs (`192.0.2.0/24`, `198.51.100.0/24`,
+    `203.0.113.0/24`)
+  - RFC 1918 ranges *in commented examples* (`192.168.0.0/24` in
+    "block this subnet" context — fine; bare `192.168.1.42` as a
+    config target — flag)
+- **Credential-shaped literals.** Tokens with provider-specific
+  prefixes — `ghp_…` (36+ chars), `AKIA[0-9A-Z]{16}`, JWT (three
+  dot-separated base64 segments ≥10 chars each), generic ≥32-char
+  high-entropy strings next to `key=` / `token=` / `password=` /
+  `secret=`.
+
+**Critical filtering rule — pattern descriptions are NOT literal values.**
+A skill that documents its own scan (like Gate 7's pattern list,
+or a regex example in a README) will contain text like
+`password\s*=\s*["'][^"']+["']` — that's the REGEX, not a
+hardcoded password. DO NOT flag pattern descriptions.
+
+Specifically, do NOT flag:
+
+- Pattern strings inside backticks / code blocks that
+  describe what to LOOK for (regex literals, glob patterns,
+  CLI invocations).
+- Variable names containing the trigger word: `LOCK_KEY`,
+  `auth_token_param`, `password_field`, `api_key_setting`.
+- Test-fixture placeholders: `"test-key"`, `"dummy-token"`,
+  `"changeme"`, `"…"`, `"<your-token-here>"`.
+- Comments referencing the concept: `# Don't commit secrets`,
+  `// API key goes in env var`.
+- Strings whose value is obviously a category label, not a
+  credential: `"key=value"` (a format-string description),
+  `"password"` (a UI label).
+
+When in doubt, surface the match in chat and ASK the user:
+"line N matches pattern X — placeholder or real?" rather than
+silently flagging or silently dismissing. This is one of the
+rare gates where false-positive-aversion AND false-negative-
+aversion BOTH matter (an unflagged real token is catastrophic;
+a noisy false flag erodes trust).
+
+Severity escalation:
+
+- ✗ for a confirmed-real GitHub / AWS / Slack token. Recommend
+  rotate-then-force-push-to-scrub. Don't ship.
+- ⚠ for likely-real home path / IP / generic credential shape.
+- ℹ️ for "matches pattern but probably FP — confirm please".
+
+If the diff doesn't add or modify any
+`.claude/skills/<name>/` file (and `.claude/skills/personal/`
+is correctly gitignored — Gate 11 doesn't reach into personal
+skills), skip this gate entirely.

--- a/news/298.misc
+++ b/news/298.misc
@@ -1,0 +1,1 @@
+Split `pr-review` SKILL.md (801 lines) via progressive disclosure: Gates 7-11 moved into sibling `app-gates.md`; SKILL.md now 471 lines under Anthropic's 500-line ceiling.


### PR DESCRIPTION
## Pre-merge checklist

- [N/A] User-visible behaviour added/changed → updated `docs/features.md`
- [N/A] New file under `app/views/{dialogs,handlers,components,workers}/`
- [N/A] Tests added (skill is text only)
- [x] No commit-hook bypass flag used
- [x] Pre-PR hooks passed locally

## Summary

Per [Anthropic's SKILL.md best-practices](https://platform.claude.com/docs/en/agents-and-tools/agent-skills/best-practices) (May 2026): "Keep SKILL.md body under 500 lines for optimal performance. Split content into separate files when approaching this limit."

`pr-review` grew **0 → 801 lines across 4 PRs** in the recent build-out (#284 + #288 + #290 + #294). Each PR was disciplined but the cumulative size now exceeds Anthropic's recommended ceiling by 60%. This PR applies progressive disclosure to bring it back under.

## What changed

| File | Before | After |
|---|---|---|
| `SKILL.md` | 801 lines | **471 lines** (under 500 ceiling) |
| `app-gates.md` (new) | — | 357 lines |

**Layout:**
- `SKILL.md` keeps **Gates 1-6** (semantic drift + harness routing — the core review flow), the invocation contract, output template, walkthrough, anti-patterns, post-back gate, and "why this exists" rationale.
- `app-gates.md` (new sibling) holds the **full rubrics for Gates 7-11** (app-level security, SQLite migration safety, perf/threading, test-padding, PII audit) with a TOC at top per Anthropic's "reference files >100 lines" rule.
- `SKILL.md`'s Gates 7-11 section is now a compact trigger-summary table + pointer to `app-gates.md`. Walkthrough steps 8-12 (one per gate) consolidate into a single step 8 referencing `app-gates.md` by trigger condition.

**Why this layout:**
- One-level-deep reference (SKILL.md → app-gates.md) per Anthropic's "Avoid deeply nested references" rule.
- The trigger table in SKILL.md tells Claude WHICH gates fire on the current diff; Claude reads only the relevant sections of `app-gates.md`, saving context on diffs that touch only a subset.
- No information lost — every word of Gates 7-11 rubric moved verbatim to `app-gates.md` with only heading-level adjustment (`### → ##` since they're top-level in the sub-file).

## Self-backtest via `/pr-review`

Diff = SKILL.md edit + new app-gates.md + `news/298.misc`.

| Gate | Verdict |
|---|---|
| Gate 1 | CLEAN (meta-only exclusion) |
| Gate 6 | Fires (`.claude/**` touched) — harness pointer |
| Gate 7-10 | Omit (no app files touched) |
| Gate 11 | Fires (touched `.claude/skills/pr-review/`), scans diff; `app-gates.md` contains many pattern descriptions inside code blocks (Gate 7's regex examples, Gate 11's own description). **Critical filter rule applies → 0 ⚠.** |

✓ Expected output for a meta-tooling PR restructuring a skill.

## Test plan

- [x] `pytest` full suite passes — **1415 passed, 2 skipped**
- [x] Per-file coverage floor (70%) clears — all 49 files
- [x] `SKILL.md` 471 lines (under 500 ceiling)
- [x] `app-gates.md` 357 lines (under 500)
- [x] `/pr-review` self-backtest produces expected output
- [x] No information lost (Gates 7-11 content moved verbatim)

## Related

Third PR in the post-#294 skills-audit cleanup series:
- [#297](https://github.com/jackal998/photo-manager/pull/297) — `parallel-brief-generator` description trim (open)
- This PR — `pr-review` split
- Coming next: PR-D3 — `qa-explore` split (958 lines, biggest of the three)

Generated with [Claude Code](https://claude.com/claude-code)
