### PR TITLE
chore(deny): extend permissions.deny with ssh, chmod 777, > /dev/

### DIFF
--- a/.claude/settings.json.example
+++ b/.claude/settings.json.example
@@ -58,7 +58,10 @@
       "Bash(curl * | sh*)",
       "Bash(curl * | bash*)",
       "Bash(wget * | sh*)",
-      "Bash(wget * | bash*)"
+      "Bash(wget * | bash*)",
+      "Bash(chmod 777*)",
+      "Bash(ssh *)",
+      "Bash(* > /dev/*)"
     ],
     "additionalDirectories": [
       "<USER_HOME>/.claude"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -229,3 +229,9 @@ home path. To enable the security gates above on a fresh checkout:
    (e.g. `C:/Users/J` on Windows, `/home/you` on Linux, `/Users/you` on macOS)
 3. Restart your Claude Code session, then run `/permissions` to confirm the
    `ask` rules are loaded
+
+When `.claude/settings.json.example` changes (new `ask` / `deny`
+entries, new hooks), your local `.claude/settings.json` does NOT
+auto-update — it's gitignored. Diff the example against your local
+copy after pulling and port over any new entries by hand. Watch for
+PRs that touch the example file (e.g. #288, #291).

--- a/news/303.feature
+++ b/news/303.feature
@@ -1,0 +1,1 @@
+Extend `permissions.deny` in `settings.json.example` with `ssh *`, `chmod 777*`, and `* > /dev/*` (AgentShield MEDIUM follow-up to #288).


### PR DESCRIPTION
## Summary

Closes #291.

AgentShield baseline re-scan post-#288 surfaced 14 MEDIUM findings
that collapse to **3 unique missing deny rules**. Adds them to
`.claude/settings.json.example`:

- `Bash(chmod 777*)` — world-writable permissions (defense-in-depth
  for WSL contributors; no-op on Windows)
- `Bash(ssh *)` — agent could exfiltrate via SSH
- `Bash(* > /dev/*)` — writing to device files (defense-in-depth for
  WSL; no-op on Windows)

Final `deny` array has 11 entries.

## Manual-update note for existing contributors

`.claude/settings.json` is gitignored and does NOT auto-update from
example-file changes. Existing contributors must port these three
entries into their local `.claude/settings.json` by hand after
pulling. This PR adds a paragraph to the `CLAUDE.md` Setup section
documenting the diff-and-port workflow so future deny-list additions
don't silently miss already-checked-out copies.

## Out of scope

- `.claude/settings.json` itself (gitignored, machine-specific)
- #286 (pip show wildcard) and #287 (project Stop hooks) — tracked separately

## Test plan

- [x] JSON parses (`json.load` on the example file)
- [x] `pytest` — 1415 passed, 2 skipped, 88.05% total coverage
- [ ] Manual: copy new entries into local `.claude/settings.json`, restart Claude Code, `/permissions` shows the three new deny rules

[docs-not-needed: settings template + Setup paragraph already updated; no module/behaviour change]

🤖 Generated with [Claude Code](https://claude.com/claude-code)