### PR TITLE
chore(settings): regression-test legacy sources.list migration shim

### DIFF
--- a/app/views/dialogs/scan_dialog.py
+++ b/app/views/dialogs/scan_dialog.py
@@ -599,7 +599,14 @@ class ScanDialog(QDialog):
             ]
             self._source_list.set_entries(entries)
         else:
-            # Migrate from the legacy three-key format (iphone / takeout / jdrive)
+            # Migration shim (since the 2025 "sources.list" rollout):
+            # users upgrading from pre-sources.list builds still carry
+            # only the legacy sources.{iphone,takeout,jdrive} keys.
+            # Removing this branch silently empties their source list
+            # on first launch -- no error, no warning, just zero sources.
+            # tests/test_settings_migration.py pins the contract; a PR
+            # that intentionally drops this shim must drop that test
+            # too and ship a migration story. See #258.
             entries = []
             for key in ("iphone", "takeout", "jdrive"):
                 path = self.settings.get(f"sources.{key}", "")

--- a/news/304.misc
+++ b/news/304.misc
@@ -1,0 +1,1 @@
+Pin the legacy `sources.{iphone,takeout,jdrive}` → `sources.list` migration shim in `ScanDialog._load_from_settings` with a layer-1 regression test, so a future cleanup PR cannot silently empty source lists for users upgrading from a pre-`sources.list` build (#258).

--- a/tests/test_settings_migration.py
+++ b/tests/test_settings_migration.py
@@ -1,0 +1,86 @@
+"""Regression test pinning the legacy-keys -> sources.list migration shim.
+
+The shim lives in ``ScanDialog._load_from_settings``: when
+``sources.list`` is absent it reconstructs the dialog's source list
+from the legacy ``sources.{iphone,takeout,jdrive}`` keys. Users
+upgrading from a pre-``sources.list`` build still carry those legacy
+keys in their settings.json; deleting the shim silently empties their
+source list on first launch with no error or warning.
+
+A future PR that intentionally drops the shim must remove this test in
+the same commit, with a migration story for upgraders (see #258).
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from app.views.dialogs.scan_dialog import ScanDialog
+from infrastructure.settings import JsonSettings
+
+
+def _write_settings(tmp_path, data: dict) -> JsonSettings:
+    """Write ``data`` to a tmp settings.json and return a JsonSettings."""
+    path = tmp_path / "settings.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return JsonSettings(path)
+
+
+def test_legacy_keys_reconstruct_sources_list_when_sources_list_missing(
+    qapp, tmp_path
+):
+    """Old settings.json with sources.{iphone,takeout} but no sources.list
+    must populate the dialog's source list from the legacy keys.
+
+    Failure mode being pinned: deleting the shim leaves the dialog with
+    an empty source list on first launch for any user upgrading from a
+    pre-sources.list build.
+    """
+    settings = _write_settings(
+        tmp_path,
+        {
+            "sources": {
+                "iphone": "C:/test/iphone",
+                "takeout": "C:/test/takeout",
+                # jdrive intentionally absent -> only 2 entries reconstructed
+                # list intentionally absent -> triggers the shim
+            }
+        },
+    )
+
+    dlg = ScanDialog(settings=settings)
+    try:
+        entries = dlg._source_list.entries()
+        assert len(entries) == 2
+        paths = {e.path for e in entries}
+        assert paths == {"C:/test/iphone", "C:/test/takeout"}
+        assert all(e.recursive is True for e in entries)
+    finally:
+        dlg.deleteLater()
+
+
+def test_sources_list_takes_precedence_when_both_present(qapp, tmp_path):
+    """When ``sources.list`` AND legacy keys both exist, ``sources.list``
+    wins. Pins the precedence so the shim cannot accidentally clobber
+    new-format data written by a current build.
+    """
+    settings = _write_settings(
+        tmp_path,
+        {
+            "sources": {
+                "list": [{"path": "C:/new", "recursive": False}],
+                "iphone": "C:/legacy",  # would otherwise be picked
+            }
+        },
+    )
+
+    dlg = ScanDialog(settings=settings)
+    try:
+        entries = dlg._source_list.entries()
+        assert len(entries) == 1
+        assert entries[0].path == "C:/new"
+        assert entries[0].recursive is False
+    finally:
+        dlg.deleteLater()


### PR DESCRIPTION
## Summary

Pins the legacy-keys → `sources.list` migration shim in `ScanDialog._load_from_settings` so a future cleanup PR cannot delete it silently. Users upgrading from a pre-`sources.list` build still carry only the legacy `sources.{iphone,takeout,jdrive}` keys; dropping the shim would silently empty their source list on first launch — no error, no warning.

- New layer-1 regression test `tests/test_settings_migration.py` (2 cases): reconstruct from legacy keys when `sources.list` is absent, and `sources.list` wins when both formats coexist.
- Expanded inline comment at the shim site naming the migration year + data-loss risk + pointer to the test contract.

No behaviour change; comment + new test only.

Closes #258

## Test plan

- [x] `pytest tests/test_settings_migration.py -v` — both cases pass
- [x] `pytest` (full suite) — 1417 passed, 2 skipped, 87.95% coverage
- [x] `scripts/check_coverage_per_file.py` — all 54 files clear 70% floor (scan_dialog.py at 92%)

[docs-not-needed: small contained regression test, no user-visible behavior change]
[qa-not-needed: comment-only change in scan_dialog.py with no behaviour delta; the new layer-1 test pins the existing shim contract directly]

🤖 Generated with [Claude Code](https://claude.com/claude-code)