### PR TITLE
chore(skills): add agent-driven PR review flow (submitted + fetch siblings)

### DIFF
--- a/.claude/skills/github-pr-review-fetch/SKILL.md
+++ b/.claude/skills/github-pr-review-fetch/SKILL.md
@@ -1,0 +1,302 @@
+---
+name: github-pr-review-fetch
+description: Read submitted review feedback from a GitHub PR into the current session, structured for an agent to address each finding. Use when a dev agent resumes work on a PR after a separate review agent (or human reviewer) has posted findings — this skill fetches all submitted reviews, all line-anchored review threads, all issue-style PR comments, and presents them as a structured to-do list. Inbound counterpart to github-pr-review-pending / github-pr-review-submitted (which are outbound).
+origin: local
+---
+
+# GitHub PR review — fetch incoming feedback
+
+This is the **inbound** counterpart to the two outbound posting
+skills (`github-pr-review-pending`, `github-pr-review-submitted`).
+Use it when a dev agent resumes work on a PR and needs to
+**ingest review feedback** that was posted by a separate review
+agent (or by a human reviewer). The skill fetches:
+
+1. All **submitted reviews** on the PR (state = `COMMENTED`,
+   `CHANGES_REQUESTED`, `APPROVED`, or `DISMISSED`), with the
+   review-level body and the `event` value.
+2. All **line-anchored review threads** (path + line + body +
+   resolution state), so the dev agent knows which file:line
+   each finding refers to.
+3. All **issue-style PR comments** (not tied to a line — `gh pr
+   comment` style messages) for general handoff text.
+4. Optionally, the **calling agent's own pending draft review**
+   (if any) — so it can be aware of in-flight work.
+
+Output is a structured chat report that the dev agent reads as
+a to-do list: address each unresolved thread, push fixes, loop.
+
+## When to invoke
+
+Run from the dev agent's session after `git pull` or after a
+review round has been requested. Typical scenarios:
+
+- Dev agent finished work, pushed, and a review agent posted
+  feedback. Dev agent restarts session, runs this skill.
+- Long-running dev session — periodically poll for new review
+  feedback during multi-round iteration.
+- Human reviewer left feedback on a PR; dev agent (or you, the
+  user) wants to see all findings at once instead of clicking
+  through GitHub.
+- After running `/pr-review <N>` on your own branch as a
+  self-check, this skill reads back any submitted reviews from
+  others.
+
+Do NOT use this skill to fetch the *diff* — `gh pr diff` is the
+right call for that. This skill is for **feedback on the diff**,
+not the diff itself.
+
+## Prerequisites
+
+| Requirement | Check |
+|---|---|
+| `gh` installed and on PATH | `gh --version` |
+| Authenticated for the right host | `gh auth status` — if it fails, stop and tell the user |
+| Read access to the PR | implicit; works for public repos or repos the gh user can read |
+
+## Invocation contract
+
+```
+github-pr-review-fetch <PR-number>
+github-pr-review-fetch                          # current branch's PR, resolved via `gh pr view --json number`
+github-pr-review-fetch <PR-number> --since <ISO-date>   # only feedback newer than this timestamp
+github-pr-review-fetch <PR-number> --unresolved-only    # filter to threads where isResolved=false
+```
+
+`<PR-number>` is optional when invoked from a branch with an open
+PR; resolved via `gh pr view --json number -q .number` from the
+current branch.
+
+## Phase 1 — Resolve PR number and identity
+
+```powershell
+# PR number (skip if user supplied one explicitly)
+$prNumber = gh pr view --json number -q .number
+
+# Current gh identity — used to filter "MY pending draft" vs "others' submitted reviews"
+$me = gh api user -q .login
+```
+
+If `gh pr view` fails ("no pull request found for branch"), the
+current branch doesn't have an open PR. Surface the error and
+exit — there's nothing to fetch.
+
+## Phase 2 — Parallel fetch (fire all four at once)
+
+Run these four `gh` calls **in parallel** (single message,
+multiple tool calls — they have no dependencies):
+
+### A. Submitted reviews + thread state (GraphQL)
+
+```bash
+gh api graphql -f query='
+query {
+  repository(owner: "OWNER", name: "REPO") {
+    pullRequest(number: <N>) {
+      reviews(first: 50) {
+        nodes {
+          id
+          databaseId
+          state            # PENDING / COMMENTED / CHANGES_REQUESTED / APPROVED / DISMISSED
+          author { login }
+          body
+          submittedAt
+          commit { oid }
+          comments(first: 100) {
+            nodes {
+              id
+              databaseId
+              path
+              line
+              originalLine
+              body
+              author { login }
+              createdAt
+            }
+          }
+        }
+      }
+      reviewThreads(first: 100) {
+        nodes {
+          id
+          isResolved
+          isOutdated
+          path
+          line
+          comments(first: 50) {
+            nodes { databaseId author { login } body createdAt }
+          }
+        }
+      }
+    }
+  }
+}'
+```
+
+`reviewThreads` and `reviews.comments` overlap — both describe
+the same line-anchored comments, but `reviewThreads` includes
+`isResolved` / `isOutdated` while `reviews` includes the
+review-level `state` and `body`. Use `reviewThreads` for
+resolution filtering, `reviews` for the review-level context.
+
+### B. Issue-style PR comments (REST)
+
+```bash
+gh api --paginate "repos/OWNER/REPO/issues/<N>/comments"
+```
+
+These are the `gh pr comment <N> --body ...` messages — NOT
+line-anchored, attached to the PR conversation tab. Useful for
+handoff messages between agents ("review agent: round 2 complete,
+3 ⚠ remaining"; "dev agent: addressed thread #4, please re-review").
+
+### C. PR metadata + head SHA
+
+```powershell
+gh pr view <N> --json title,body,state,isDraft,mergeable,headRefOid,baseRefName,headRefName,reviewDecision,closingIssuesReferences
+```
+
+`reviewDecision` is `APPROVED` / `REVIEW_REQUIRED` /
+`CHANGES_REQUESTED` — useful as a one-line status. `headRefOid`
+lets the dev agent compare what was reviewed vs what's currently
+on the branch (have any commits landed since the last review?).
+
+### D. Recent check / CI runs (optional, GraphQL)
+
+Skip unless the user explicitly wants CI signal alongside review
+findings. When invoked:
+
+```bash
+gh pr checks <N>
+```
+
+## Phase 3 — Filter and structure
+
+Apply filters in this order:
+
+1. **Drop pending reviews authored by OTHER users.** Per GitHub's
+   visibility model, a pending review by user X is only visible to
+   X. If the GraphQL query returns pending reviews by users other
+   than `$me`, that's a GitHub bug or a permission anomaly — skip
+   them and log a `note:`.
+
+2. **Keep the current user's own pending review** (if any) as a
+   separate `## My in-flight pending draft` section — surface it
+   so the dev agent doesn't forget about its own un-submitted
+   feedback (rare in agent-driven flows, but possible).
+
+3. **Apply `--since <ISO-date>` filter** if supplied: drop
+   reviews and threads with `submittedAt` / `createdAt` older
+   than the cutoff.
+
+4. **Apply `--unresolved-only` filter** if supplied: drop
+   threads where `isResolved == true`.
+
+5. **Sort threads** by file path, then line number. Sort reviews
+   by `submittedAt` descending (newest first).
+
+## Phase 4 — Emit structured report
+
+The output is **the entire point** of this skill — it must be
+structured so the dev agent can iterate over findings without
+re-querying. Use this template:
+
+```
+PR review feedback — #<N> (<PR title>)
+Status: <reviewDecision>   |   Reviewers: <comma-separated unique authors>
+Head: <headRefOid>   |   Last review: <submittedAt of newest>
+
+## Review-level summary
+
+### <reviewer-login> — <state>, submitted <submittedAt>
+> <review.body, quoted, first 5 lines>
+
+### <reviewer-login-2> — <state>, submitted <submittedAt>
+> <review.body, quoted, first 5 lines>
+
+## Unresolved threads (<count>)
+
+### 1. <path>:<line> — by <author>, <createdAt>
+**State:** unresolved <isOutdated ? "(outdated)" : "">
+**Body:**
+> <body, quoted in full>
+
+**Replies (<N>):**
+- <author>, <createdAt>: <body summary>
+
+### 2. <path>:<line> — by <author>, <createdAt>
+...
+
+## Resolved threads (<count>)
+
+(Listed in same format but compressed — one line per thread:
+`<path>:<line> — <author>: <body first 80 chars> [resolved]`)
+
+## Issue-style PR comments (<count>)
+
+- <author>, <createdAt>: <body summary>
+- <author>, <createdAt>: <body summary>
+
+## My in-flight pending draft (if any)
+
+(If `$me` has a pending review, name it here so the agent knows
+it has un-submitted work.)
+
+## Suggested next steps
+
+For each unresolved thread, the dev agent should:
+1. Read the cited file:line in full.
+2. Decide: address (commit a fix) / disagree (reply with rationale) / defer (mark for follow-up).
+3. After commit, mark the thread resolved via GraphQL `resolveReviewThread`.
+
+For `CHANGES_REQUESTED` reviews: address every unresolved thread before requesting re-review.
+For `COMMENTED` reviews: dev agent's call — non-blocking findings can be deferred or noted.
+```
+
+**Omit empty sections** (same convention as `pr-review/SKILL.md`).
+
+## What this skill does NOT do
+
+- **Does not address** the findings. It only fetches and
+  structures. The dev agent reads the output and decides what to
+  fix.
+- **Does not resolve threads.** Resolution is a separate action —
+  after the dev agent addresses a thread, it (or the calling
+  user) calls GraphQL `resolveReviewThread` with the thread's
+  node `id`. This skill surfaces the IDs but doesn't mutate.
+- **Does not reply** to threads or post any comment. Replying is
+  a write action; this skill is read-only.
+- **Does not re-request review.** That's `gh pr review --request
+  <user>` — separate action, user's call.
+- **Does not fetch the diff.** Use `gh pr diff <N>` for that. This
+  skill is for **feedback on the diff**.
+
+## Resolving threads after fixing (related — separate action)
+
+When the dev agent has addressed a thread, mark it resolved:
+
+```bash
+gh api graphql -f query='
+mutation {
+  resolveReviewThread(input: { threadId: "<thread node id from Phase 2 A>" }) {
+    thread { id isResolved }
+  }
+}'
+```
+
+This call is the responsibility of the dev agent's *fix-and-push*
+flow, not this skill. Mention the thread `id`s in the report
+output so the calling agent has them ready.
+
+## See also
+
+- `github-pr-review-pending/SKILL.md` — outbound, human-in-loop case.
+- `github-pr-review-submitted/SKILL.md` — outbound, agent-to-agent case;
+  what this skill reads back when the upstream review agent used
+  it to post.
+- `pr-review/SKILL.md` — produces the findings the upstream agent
+  posts.
+- `conventional-comments/SKILL.md` — the format the bodies are
+  written in; this skill parses them but doesn't re-format.
+- GitHub GraphQL — [PullRequest review APIs](https://docs.github.com/en/graphql/reference/objects#pullrequest)
+- GitHub REST — [Pull request review comments](https://docs.github.com/en/rest/pulls/comments)

--- a/.claude/skills/github-pr-review-pending/SKILL.md
+++ b/.claude/skills/github-pr-review-pending/SKILL.md
@@ -1,38 +1,53 @@
 ---
 name: github-pr-review-pending
-description: Post pr-review findings to a GitHub PR as a **pending (draft) review** — created with `gh api` against the `/reviews` endpoint with `event` omitted, leaving the human to click "Submit review" in the GitHub UI. Use only when invoked by pr-review's "Optional post-back" step after explicit user yes. The pending-draft POST itself is gated under CLAUDE.md "Opening PRs or pushing to a remote".
+description: Post pr-review findings to a GitHub PR as a **pending (draft) review** — created with `gh api` against the `/reviews` endpoint with `event` omitted, leaving the human to click "Submit review" in the GitHub UI. Invoked by pr-review's "Optional post-back" step in human-in-loop mode (Mode A). The POST fires on invocation — no per-POST confirmation gate; the surrounding context (autonomous vs human, dry-run framing) decides whether to invoke. Pending reviews are reversible via `DELETE .../reviews/{id}` and visible only to the author's gh identity until submitted, so the action is low-stakes.
 origin: local
 ---
 
 # GitHub PR review — pending draft (mechanics)
 
-photo-manager's `pr-review` skill emits findings in chat. When the user
-asks to publish those findings to the PR, this skill is the **mechanic**
-— it posts the findings as a **pending (draft)** GitHub review, never
-submitted, so the human can read them in the GitHub UI and click
-**Submit review** themselves (or discard).
+photo-manager's `pr-review` skill emits findings in chat. When the
+Optional post-back step is invoked in **Mode A (human-in-loop)** —
+the user wants to see findings in the GitHub UI before publishing,
+or wants a draft they can selectively edit/discard — this skill is
+the mechanic. It posts a **pending (draft)** GitHub review: never
+submitted, no notifications, no shared-state mutation. The human
+clicks **Submit review** in the GitHub UI when ready (or **Discard
+pending review** to throw it away).
 
-This is the right behaviour for photo-manager because CLAUDE.md
-explicitly gates **"Opening PRs or pushing to a remote"** — submitting
-a review is a remote mutation that fires notifications. Creating a
-pending draft leaves the user in control of when (or whether) it goes
-out.
+For the **agent-driven** case (no human to click Submit), use the
+sibling `github-pr-review-submitted/` skill instead. The two skills
+have parallel mechanics; only `event` (omitted here vs set there)
+distinguishes them.
 
-## Gate first — surface before POST
+## Invocation contract
 
-The pending-draft POST is itself a gated action under CLAUDE.md.
-Before calling `gh api --method POST .../reviews`:
+This skill **posts on invocation** — the calling code (typically
+`pr-review`'s Optional post-back step) decides whether to invoke
+it. Don't add an extra confirmation gate inside this skill; the
+surrounding context (autonomous loop vs human session, "preview
+only" framing) is what gates the POST.
 
-1. Confirm the PR number explicitly. If pr-review was invoked without a
-   number (current branch), ask for it now.
-2. Show the exact JSON body that will be POSTed (the `comments[]`
-   array built from pr-review's chat findings).
-3. Ask: "Create pending draft review on PR #N? You will submit it
-   yourself in the GitHub UI. (yes/no)"
-4. Only after explicit "yes": run the command.
+What this skill does on invocation:
 
-If the user says no, stop. Don't propose a different mechanic — the
-chat report is the deliverable, the PR post-back is an optional extra.
+1. Confirm the PR number is known. If pr-review handed off without
+   one, look it up via `gh pr view --json number`. Stop and surface
+   to the caller only if no PR exists for the branch.
+2. Build the pending-review JSON per Phase 2 below.
+3. POST it via `gh api` per Phase 3.
+4. Output the "review is pending" status per Phase 4.
+
+**The pending POST is reversible** (`DELETE .../reviews/{id}`)
+and the draft is visible only to the author's `gh` identity until
+submitted. Those two properties are why no per-POST gate exists
+inside this skill — the action is low-stakes and the caller has
+already decided to invoke. CLAUDE.md's "Opening PRs or pushing to
+a remote" gate doesn't apply: pending reviews aren't published,
+aren't visible to others, and can be deleted in one call.
+
+If the calling code wants a dry-run, it should construct the JSON
+and emit it to chat instead of calling this skill — same Phase 2
+shape, no Phase 3 POST.
 
 ## Prerequisites
 

--- a/.claude/skills/github-pr-review-submitted/SKILL.md
+++ b/.claude/skills/github-pr-review-submitted/SKILL.md
@@ -1,0 +1,202 @@
+---
+name: github-pr-review-submitted
+description: Post pr-review findings to a GitHub PR as a **submitted** review in one call — created with `gh api` against the `/reviews` endpoint WITH `event` set (COMMENT / REQUEST_CHANGES). Use in agent-driven workflows where there's no human to click Submit — the review goes live immediately, fires notifications, and is visible to other agents reading the PR. Sibling of `github-pr-review-pending` (which leaves the review pending for a human to submit).
+origin: local
+---
+
+# GitHub PR review — submitted (mechanics)
+
+photo-manager's `/pr-review` skill emits findings in chat. When the
+user (or a calling agent) asks to publish those findings to the PR
+**in agent-driven mode** — i.e. there is no human in the loop to
+click "Submit review" in the GitHub UI — this skill is the
+mechanic. It posts a **submitted** review in one call:
+notifications fire, the review is immediately visible to anyone
+with PR read access (including a downstream dev agent reading
+their own PR), and there's no separate Submit step.
+
+This is the sibling of `github-pr-review-pending` (which leaves
+the review pending for a human to submit in the UI). Use this one
+in agent-to-agent workflows; use the pending sibling when a human
+is in the loop.
+
+## When to invoke vs. the pending sibling
+
+| Scenario | Use this skill (-submitted) | Use the pending sibling (-pending) |
+|---|---|---|
+| Solo human runs `/pr-review` and wants to read before publishing | — | ✓ |
+| Dev agent pushes PR, separate review agent posts feedback for the dev agent to read back | ✓ | — |
+| Scheduled / cron review agent | ✓ | — |
+| Human reviewing on someone else's repo | — | ✓ (safer default) |
+| Bot reviewing on its own org repo where notifications are expected | ✓ | — |
+
+The `/pr-review` Optional post-back step picks which sibling to
+invoke based on the user's framing ("submit this review" vs "post
+as pending for me to submit") or based on an explicit mode hint.
+
+## Severity → event mapping
+
+This skill maps `/pr-review`'s verdict / per-gate findings to the
+GitHub review `event` value:
+
+| /pr-review state | `event` value | Reasoning |
+|---|---|---|
+| Any ✗ in findings (severe — blocking) | **`REQUEST_CHANGES`** | Tells the dev agent "address these before merge" |
+| Only ⚠ / `note:` / `ℹ️` | **`COMMENT`** | Non-blocking feedback |
+| All gates CLEAN, no findings | **DO NOT post a review** | An agent should never auto-`APPROVE` — leave the PR un-reviewed and end the session |
+
+**Never use `event: APPROVE` from an agent.** Approvals are a
+trust signal that should come from a human, even in agent-driven
+workflows. If `/pr-review` returns CLEAN and the calling agent
+wants to record that signal somewhere, write it to a regular PR
+comment ("review agent: no findings, CLEAN") via
+`gh pr comment <N> --body "..."`, not as an APPROVE review.
+
+## Prerequisites
+
+| Requirement | Check |
+|---|---|
+| `gh` installed and on PATH | `gh --version` |
+| Authenticated for the right host | `gh auth status` — if it fails, stop and surface to the calling agent; do not fall back to `curl` |
+| Repo accessible to current `gh` user | implicit in the `gh pr view` step pr-review already ran |
+| **Distinct `gh` identity is OK** | Unlike pending reviews (which are visible only to the author), submitted reviews are visible to anyone with PR read access — so the dev agent and review agent can use different gh identities |
+
+## Phase 1 — Re-fetch head SHA
+
+`/pr-review` already has the diff and findings. One extra read
+before posting:
+
+```powershell
+gh pr view <N> --json headRefOid -q .headRefOid
+```
+
+**Unlike the pending sibling, do NOT check for existing pending
+reviews by the current user.** Submitted reviews don't have the
+"one pending per user" limitation — each submitted review is
+independent. If the review agent has already submitted a previous
+round of feedback, a new round goes in as a separate review.
+
+## Phase 2 — Build the submitted-review JSON
+
+For each `/pr-review` finding worth threading on a specific line:
+
+- Resolve the **path** from the file the finding names.
+- Resolve the **line** — the new-file line number at `headRefOid`.
+- Format the **body** per `conventional-comments/SKILL.md`. **Apply
+  the dual-format rule** — even though this is the agent-to-agent
+  path, use the full label format (not chat icons), since the body
+  is destined for a PR thread.
+- Set **side** to `"RIGHT"` (comment on the new version of the
+  file).
+
+Determine the **event** value from the severity-to-event mapping
+above (any ✗ → `REQUEST_CHANGES`, else `COMMENT`).
+
+Write the body to a JSON file:
+
+```json
+{
+  "commit_id": "<headRefOid from Phase 1>",
+  "event": "COMMENT",
+  "body": "Review summary: 3 ⚠, 0 ✗. Verdict: ship-able after Gate 9 fix.",
+  "comments": [
+    {
+      "path": "app/views/dialogs/save_changes_dialog.py",
+      "line": 142,
+      "side": "RIGHT",
+      "body": "**suggestion (non-blocking):** Extract `_should_show_save_dialog(...)` ..."
+    }
+  ]
+}
+```
+
+**Critical:** `event` MUST be present and set to one of
+`"COMMENT"` / `"REQUEST_CHANGES"` (never `"APPROVE"` from an
+agent, never `"PENDING"` — that's not a valid enum value). If
+`event` is omitted, the API creates a PENDING review (which is
+what `github-pr-review-pending` is for) — that's the wrong
+mechanic for agent-to-agent.
+
+## Phase 3 — POST the submitted review
+
+```powershell
+gh api --method POST `
+  repos/OWNER/REPO/pulls/<N>/reviews `
+  --input submitted-review.json
+```
+
+Save the `id` from the response as `REVIEW_ID` (numeric). Save the
+`html_url` so the calling agent can include it in any handoff
+message.
+
+**This call is irreversible.** Once submitted, the review fires
+notifications and cannot be "un-submitted". You can:
+
+- Edit individual thread bodies via REST PATCH (works for REST-created
+  comments) or GraphQL `updatePullRequestReviewComment` (works for
+  all) — see `github-pr-review-pending/references/REFERENCE.md` for
+  the path/id rules.
+- Add a **dismiss** message via `PUT .../reviews/{id}/dismissals`,
+  but only an org admin can dismiss reviews on protected branches.
+- Add follow-up comments to existing threads.
+- Reply with another submitted review (new round of feedback).
+
+You **cannot** delete a submitted review. The pending sibling has
+a `DELETE .../reviews/{id}` for un-submitted drafts; submitted
+reviews don't.
+
+## Phase 4 — Tell the calling agent / user what's next
+
+After the POST succeeds, output verbatim:
+
+> Submitted review posted on PR #N (review id: <REVIEW_ID>, event: <COMMENT|REQUEST_CHANGES>).
+>
+> Notifications have fired. The review is now visible to anyone
+> with PR read access — the dev agent can read it via
+> `github-pr-review-fetch/SKILL.md` (run from a separate session
+> on the PR branch).
+>
+> URL: <html_url>
+>
+> This review cannot be un-submitted. To follow up: either reply
+> with another submitted review (new round), or edit individual
+> thread bodies via `updatePullRequestReviewComment`.
+
+Then stop. Do NOT try to APPROVE the PR later (per the severity
+mapping rule). Do NOT call `gh pr merge` — merging is the human's
+decision even in agent-driven flows.
+
+## What this skill does NOT do
+
+- **Never** use `event: "APPROVE"` from an agent. Use a regular
+  `gh pr comment <N>` with text like "review agent: no findings,
+  CLEAN" if you need to signal a clean outcome.
+- **Never** call `gh pr merge` — merging is not a review action.
+- **Never** dismiss someone else's submitted review.
+- **Never** include secrets or PII in the review body or thread
+  text (per CLAUDE.md "Never log, echo, or commit secrets"). The
+  review body and thread text are visible to anyone with PR read
+  access.
+
+## Platform note — PowerShell vs zsh/bash
+
+Same as `github-pr-review-pending`: PowerShell on Windows doesn't
+need the `?` glob-escape that zsh does. For HEREDOC-style JSON
+bodies, prefer the `--input <file>` pattern over inline `-f` or
+`-F`.
+
+## See also
+
+- `pr-review/SKILL.md` — emits the findings this skill posts; its
+  Optional post-back step picks between this skill and
+  `github-pr-review-pending` based on whether a human is in the
+  loop.
+- `github-pr-review-pending/SKILL.md` — sibling for the
+  human-in-the-loop case (creates pending draft, human submits).
+- `github-pr-review-fetch/SKILL.md` — the **incoming** side:
+  used by the dev agent to read back this skill's submitted
+  reviews.
+- `conventional-comments/SKILL.md` — body shape for each
+  `comments[].body` and for the review-level `body`.
+- GitHub REST — [Create a review for a pull request](https://docs.github.com/en/rest/pulls/reviews#create-a-review-for-a-pull-request)
+- GitHub REST — [Pull request reviews](https://docs.github.com/en/rest/pulls/reviews)

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: pr-review
-description: Use after `git push` (or against an existing PR number) to catch semantic drift between code, docs/features.md, and qa/scenarios/sNN_*.py that the file-touch hooks (docs_guard, qa_scenario_guard) cannot see. Acts as a **manager** that dispatches to per-gate sub-skills based on what the diff touches. Reports findings in chat; optionally posts to the PR after explicit user approval.
+description: Use after `git push` (or against an existing PR number) to catch semantic drift between code, docs/features.md, and qa/scenarios/sNN_*.py that the file-touch hooks (docs_guard, qa_scenario_guard) cannot see. Acts as a **manager** that dispatches to per-gate sub-skills based on what the diff touches. Reports findings in chat; defaults to posting them to the PR (pending draft for human-in-loop, submitted review for agent-driven flows) unless the user said "preview only" or there are no thread-worthy findings.
 origin: local
 ---
 
@@ -39,9 +39,12 @@ Skill tool when their conditions match.
 - During code review of someone else's PR — `/pr-review <PR-number>`
   pulls the diff via `gh pr diff <N>` and applies the same rubric.
 
-Do NOT auto-invoke. Do NOT post to the PR without explicit user
-"yes" — the optional post-back step has its own gate (see "Optional
-post-back" below).
+Do NOT auto-invoke `/pr-review` itself — the user (or a calling
+agent) decides when to run it. Once running, **the post-back to
+the PR fires by default** in whichever mode the context picks
+(see "Post-back to the PR" below). The user can opt out per
+invocation by saying "preview only" / "dry run" / "don't post"
+before or during the chat report.
 
 ## Invocation contract
 
@@ -99,8 +102,8 @@ logic) that handles it:
 | **9** — scanner / threading perf | diff touches `scanner/**.py`, `app/views/workers/**.py`, or adds a `QThread` / `QRunnable` / `ThreadPoolExecutor` | → `scanner-perf-patterns/` (project skill) → composes `photo-scanner-patterns` (global lens) |
 | **10** — test padding patterns | diff adds or modifies `tests/test_*.py` or `tests/integration/test_*.py` | → `test-padding-patterns/` (project skill) → composes `python-testing` (global lens) |
 | **11** — PII audit on project skills | diff adds or modifies files under `.claude/skills/<name>/` (NOT `.claude/skills/personal/`) | → `skill-pii-audit/` (project skill) |
-| **Optional post-back (human-in-loop)** | user explicitly says "post to PR" for self-review before submit | → `github-pr-review-pending/` (project skill) → composes `conventional-comments` |
-| **Optional post-back (agent-driven)** | calling agent or `/pr-review` user says "submit this review" / no human will click Submit | → `github-pr-review-submitted/` (project skill) → composes `conventional-comments` |
+| **Post-back, Mode A** (human-in-loop) | default in human session AND user didn't say "preview only" | → `github-pr-review-pending/` (project skill) → composes `conventional-comments` |
+| **Post-back, Mode B** (agent-driven) | default in autonomous context (`/loop`, `/schedule`, `$CI`, agent-to-agent), OR user says "submit / publish / send to PR" | → `github-pr-review-submitted/` (project skill) → composes `conventional-comments` |
 | **Reading back feedback** | dev agent resumes work on a PR that has reviews posted on it | → `github-pr-review-fetch/` (project skill) — inbound counterpart |
 
 Composition depth = 2 at most. If a gate's condition does NOT
@@ -227,7 +230,11 @@ When the user runs `/pr-review` (with or without a PR number):
 7. **Emit the report** in the output template (below) and end
    with the Verdict line.
 
-8. **Stop.** Do NOT post anything to the PR. Wait for the user.
+8. **Post-back to the PR.** Per "Post-back to the PR" below, pick
+   Mode A (pending) or Mode B (submitted) from context and invoke
+   the corresponding sub-skill. Skip the post-back when the user
+   said "preview only" / "dry run" / "don't post", or when the
+   verdict is CLEAN with no thread-worthy findings.
 
 ## Output template
 
@@ -327,77 +334,91 @@ ignored):
   Skill cross-references belong in the sub-skill's "See also"
   section, not in pr-review's output.
 
-## Optional post-back to the PR
+## Post-back to the PR (default on)
 
-After the chat report, findings may be published to the PR. Pick
-the right mechanic based on **whether there's a human in the
-loop**:
+After the chat report, `/pr-review` **posts findings to the PR by
+default**. The mode (pending draft vs submitted review) is picked
+from context, not from an extra confirmation question:
 
-### Mode A — human-in-loop (pending draft)
+- **Mode A (pending draft)** — when a human is in the loop and
+  will click Submit themselves. Reversible (`DELETE` works), no
+  notifications fire, visible only to the author's `gh` identity.
+  Default for solo / human sessions.
+- **Mode B (submitted review)** — when no human will click Submit.
+  Goes live in one call, fires notifications, visible to anyone
+  with PR read access. Default for scheduled / `/loop` / multi-agent
+  contexts.
 
-When a human runs `/pr-review` to self-check before opening PR
-discussion, OR when reviewing in a context where a draft-for-review
-is the right ergonomic (the user wants to read findings in the
-GitHub UI before deciding to publish):
+### Pick the mode
 
-1. Show the exact thread bodies that will be posted, one per
-   line-anchored finding. **Apply the dual-format rule:** chat
-   findings keep `⚠` / `✗` / `ℹ️` icons; PR thread bodies get
-   rewritten into full `conventional-comments` shape using the
-   icon-to-label mapping. Trim Gate 5 drive-by observations to
+Use these signals in order; first match wins:
+
+1. **User says "preview only"** / "don't post" / "show me first" /
+   "dry run" → **skip both modes**. Emit only the chat report,
+   stop. Don't ask "are you sure".
+2. **User says "submit this review"** / "publish" / "send to PR" /
+   "post as final" → **Mode B**.
+3. **Calling context is autonomous** — `/loop`, `/schedule`,
+   `$CI` env, agent-to-agent pipeline (e.g. invoked by a sibling
+   agent who said something like "review and post") → **Mode B**.
+4. **There's a `git` user attached to this session who matches
+   the project owner** AND no autonomous signal in step 3 →
+   **Mode A**.
+5. **Otherwise** (genuinely ambiguous — first time running on a
+   shared repo, mixed signals) → **Mode A**. Pending is reversible;
+   submitted isn't. When in doubt, take the reversible action.
+
+### Mode A — handoff to `github-pr-review-pending`
+
+1. Prep: rewrite findings into `conventional-comments` shape per
+   the dual-format mapping. Trim Gate 5 drive-by observations to
    the top three.
-2. Hand off to `github-pr-review-pending/SKILL.md` Phase 2 (build
-   the JSON) and Phase 3 (POST). That skill creates a **pending
-   (draft) review** — no notifications fire; the user submits in
-   the GitHub UI when ready.
-3. Per `github-pr-review-pending` Phase 4, tell the user the
-   review is pending and they need to click **Submit review** (or
-   **Discard pending review**) in the GitHub UI.
+2. Invoke `github-pr-review-pending/SKILL.md` — it builds the
+   JSON, POSTs to `/reviews` without `event`, and prints the
+   "review is pending; click Submit in the UI" instruction. No
+   per-POST confirmation gate inside that skill.
+3. End.
 
-### Mode B — agent-driven (submitted in one call)
+### Mode B — handoff to `github-pr-review-submitted`
 
-When `/pr-review` runs in an autonomous / agent-driven context
-(scheduled review agent, bot reviewing a peer agent's PR, no
-human will click Submit):
-
-1. Same Phase-2 prep — rewrite findings into
-   `conventional-comments` shape.
+1. Same prep as Mode A (`conventional-comments` shape).
 2. Compute the `event` value per the severity-to-event mapping in
    `github-pr-review-submitted/SKILL.md`:
    - Any ✗ finding → `event: "REQUEST_CHANGES"`
    - Only ⚠ / `note:` / `ℹ️` → `event: "COMMENT"`
    - All CLEAN → **do not post a review at all** (an agent must
-     never auto-`APPROVE`). End the session, or `gh pr comment <N>`
-     a one-liner if a status signal is needed.
-3. Hand off to `github-pr-review-submitted/SKILL.md` Phase 2-3.
-   The review goes live immediately, notifications fire, and the
-   dev agent (in a separate session) can read it via
+     never auto-`APPROVE`). End the session, or
+     `gh pr comment <N> --body "review agent: no findings, CLEAN"`
+     if a status signal is needed for the dev agent to read.
+3. Invoke `github-pr-review-submitted/SKILL.md` — it POSTs to
+   `/reviews` with the chosen `event`, the review goes live in
+   one call. No per-POST confirmation gate.
+4. End. The dev agent (in a separate session) reads it back via
    `github-pr-review-fetch/SKILL.md`.
 
-### How to choose the mode
+### When findings are sparse / non-thread-worthy
 
-- If the user's request was "review my PR" and they're sitting in
-  this session → **Mode A** (pending).
-- If the calling context is clearly an agent loop (scheduled
-  task, multi-agent pipeline, sibling agent), or the user's
-  request used words like "submit", "publish", "send review",
-  "ship feedback" → **Mode B** (submitted).
-- If ambiguous, **ask once** which mode. Defaulting wrong is
-  reversible for Mode A (delete pending), irreversible for Mode B
-  (submitted reviews can't be un-submitted) — so when in doubt,
-  Mode A is safer.
+Skip the post-back entirely (both modes) when:
+
+- The verdict is CLEAN (no findings) — there's nothing to thread.
+  In Mode B context, optionally `gh pr comment` a one-liner.
+- All findings are Gate 5 drive-by observations only — those go
+  in the chat report but are too low-stakes to clutter the PR.
+- The diff is doc-only / hooks-only / translation-only and Gate 1
+  short-circuited to CLEAN at the start.
 
 ### Never
 
-- Auto-`APPROVE` from an agent. Even if all gates pass clean,
-  approve is a trust signal that should come from a human. A
-  `gh pr comment <N> --body "review agent: no findings, CLEAN"`
-  is fine for autonomous flows that need to record the clean
-  outcome.
-- Use `gh pr review --comment / --approve / --request-changes` —
+- **Auto-`APPROVE` from an agent.** Even if every gate passes
+  clean. Approve is a trust signal that should come from a human.
+  A `gh pr comment` works fine to record the CLEAN outcome.
+- **Use `gh pr review --comment / --approve / --request-changes`** —
   those all submit immediately and bypass both mechanics above.
-- Auto-merge after a clean review. `gh pr merge` is not part of
-  this skill or its sub-skills.
+  The composition graph points at the `-pending` / `-submitted`
+  skills for a reason: they pass `--input <file>` so multi-line
+  thread bodies survive shell quoting.
+- **Auto-merge after a clean review.** `gh pr merge` is not part
+  of this skill or any of its sub-skills.
 
 ## Reading review feedback back into a session
 

--- a/.claude/skills/pr-review/SKILL.md
+++ b/.claude/skills/pr-review/SKILL.md
@@ -99,7 +99,9 @@ logic) that handles it:
 | **9** — scanner / threading perf | diff touches `scanner/**.py`, `app/views/workers/**.py`, or adds a `QThread` / `QRunnable` / `ThreadPoolExecutor` | → `scanner-perf-patterns/` (project skill) → composes `photo-scanner-patterns` (global lens) |
 | **10** — test padding patterns | diff adds or modifies `tests/test_*.py` or `tests/integration/test_*.py` | → `test-padding-patterns/` (project skill) → composes `python-testing` (global lens) |
 | **11** — PII audit on project skills | diff adds or modifies files under `.claude/skills/<name>/` (NOT `.claude/skills/personal/`) | → `skill-pii-audit/` (project skill) |
-| **Optional post-back** | user explicitly says "post to PR" after the chat report | → `github-pr-review-pending/` (project skill) → composes `conventional-comments` (format spec) |
+| **Optional post-back (human-in-loop)** | user explicitly says "post to PR" for self-review before submit | → `github-pr-review-pending/` (project skill) → composes `conventional-comments` |
+| **Optional post-back (agent-driven)** | calling agent or `/pr-review` user says "submit this review" / no human will click Submit | → `github-pr-review-submitted/` (project skill) → composes `conventional-comments` |
+| **Reading back feedback** | dev agent resumes work on a PR that has reviews posted on it | → `github-pr-review-fetch/` (project skill) — inbound counterpart |
 
 Composition depth = 2 at most. If a gate's condition does NOT
 fire, skip its handler entirely — don't load the sub-skill, don't
@@ -325,38 +327,103 @@ ignored):
   Skill cross-references belong in the sub-skill's "See also"
   section, not in pr-review's output.
 
-## Optional post-back to the PR (explicitly gated)
+## Optional post-back to the PR
 
-After the user has read the chat report, they may want to publish
-findings as PR review comments. This is a **separate, explicit
-step** — and it routes through the `github-pr-review-pending`
-skill, NOT through `gh pr review --comment` (which would submit
-immediately and bypass the project's "never publish without a
-yes" gate).
+After the chat report, findings may be published to the PR. Pick
+the right mechanic based on **whether there's a human in the
+loop**:
 
-When the user says "post that to the PR" or similar:
+### Mode A — human-in-loop (pending draft)
 
-1. Confirm the PR number explicitly. If the skill was invoked
-   without a number (current branch), ask for the PR number first.
-2. Show the exact thread bodies that will be posted, one per
+When a human runs `/pr-review` to self-check before opening PR
+discussion, OR when reviewing in a context where a draft-for-review
+is the right ergonomic (the user wants to read findings in the
+GitHub UI before deciding to publish):
+
+1. Show the exact thread bodies that will be posted, one per
    line-anchored finding. **Apply the dual-format rule:** chat
    findings keep `⚠` / `✗` / `ℹ️` icons; PR thread bodies get
-   rewritten into full `conventional-comments` shape (`**suggestion
-   (non-blocking):** ...`) using the icon-to-label mapping in
-   `conventional-comments/SKILL.md`. Trim Gate 5 drive-by
-   observations to the top three.
-3. Hand off to `github-pr-review-pending/SKILL.md` Phase 2 (build
+   rewritten into full `conventional-comments` shape using the
+   icon-to-label mapping. Trim Gate 5 drive-by observations to
+   the top three.
+2. Hand off to `github-pr-review-pending/SKILL.md` Phase 2 (build
    the JSON) and Phase 3 (POST). That skill creates a **pending
    (draft) review** — no notifications fire; the user submits in
    the GitHub UI when ready.
-4. Per `github-pr-review-pending` Phase 4, tell the user the
+3. Per `github-pr-review-pending` Phase 4, tell the user the
    review is pending and they need to click **Submit review** (or
    **Discard pending review**) in the GitHub UI.
 
-Do NOT auto-post under any circumstances. Do NOT use
-`gh pr review --comment / --approve / --request-changes` — those
-all submit immediately. The skill's job is to surface findings;
-the user decides what reaches the PR and when.
+### Mode B — agent-driven (submitted in one call)
+
+When `/pr-review` runs in an autonomous / agent-driven context
+(scheduled review agent, bot reviewing a peer agent's PR, no
+human will click Submit):
+
+1. Same Phase-2 prep — rewrite findings into
+   `conventional-comments` shape.
+2. Compute the `event` value per the severity-to-event mapping in
+   `github-pr-review-submitted/SKILL.md`:
+   - Any ✗ finding → `event: "REQUEST_CHANGES"`
+   - Only ⚠ / `note:` / `ℹ️` → `event: "COMMENT"`
+   - All CLEAN → **do not post a review at all** (an agent must
+     never auto-`APPROVE`). End the session, or `gh pr comment <N>`
+     a one-liner if a status signal is needed.
+3. Hand off to `github-pr-review-submitted/SKILL.md` Phase 2-3.
+   The review goes live immediately, notifications fire, and the
+   dev agent (in a separate session) can read it via
+   `github-pr-review-fetch/SKILL.md`.
+
+### How to choose the mode
+
+- If the user's request was "review my PR" and they're sitting in
+  this session → **Mode A** (pending).
+- If the calling context is clearly an agent loop (scheduled
+  task, multi-agent pipeline, sibling agent), or the user's
+  request used words like "submit", "publish", "send review",
+  "ship feedback" → **Mode B** (submitted).
+- If ambiguous, **ask once** which mode. Defaulting wrong is
+  reversible for Mode A (delete pending), irreversible for Mode B
+  (submitted reviews can't be un-submitted) — so when in doubt,
+  Mode A is safer.
+
+### Never
+
+- Auto-`APPROVE` from an agent. Even if all gates pass clean,
+  approve is a trust signal that should come from a human. A
+  `gh pr comment <N> --body "review agent: no findings, CLEAN"`
+  is fine for autonomous flows that need to record the clean
+  outcome.
+- Use `gh pr review --comment / --approve / --request-changes` —
+  those all submit immediately and bypass both mechanics above.
+- Auto-merge after a clean review. `gh pr merge` is not part of
+  this skill or its sub-skills.
+
+## Reading review feedback back into a session
+
+When a dev agent resumes work on a PR after a review agent has
+posted findings (Mode B above, or a human reviewer), the dev
+agent needs to **read** the feedback into its session context.
+That's the job of `github-pr-review-fetch/SKILL.md` — the
+inbound counterpart to the two outbound posting skills.
+
+Typical agent-driven loop:
+
+```
+Agent A (dev)   →   /pr-review (Mode B post-back)   →   PR has submitted review
+                                                          │
+Agent B (dev again, new session)   ←   github-pr-review-fetch   ←   reads reviews
+   │
+   addresses findings, pushes new commits
+   │
+   loop until verdict is CLEAN
+```
+
+Invoke `github-pr-review-fetch <PR-number>` (or no arg to use the
+current branch's PR) at the start of a fix-and-iterate session.
+The skill emits a structured chat report of all submitted
+reviews, all line-anchored threads, and all issue-style PR
+comments — ready for the agent to walk through as a to-do list.
 
 ## Why this exists
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -186,7 +186,8 @@ Skills live in two homes, split by trust level:
   shared across all contributors. Generic to the codebase: workflow,
   conventions, test scaffolding, QA drivers. Today this includes
   `app-security-patterns/`, `conventional-comments/`,
-  `docs-features-drift/`, `github-pr-review-pending/`,
+  `docs-features-drift/`, `github-pr-review-fetch/`,
+  `github-pr-review-pending/`, `github-pr-review-submitted/`,
   `impact-map/`, `parallel-brief-generator/`, `pr-review/`,
   `qa-explore/`, `qa-scenario-drift/`, `scanner-perf-patterns/`,
   `skill-pii-audit/`, `sqlite-migration-safety/`,
@@ -219,11 +220,29 @@ Skills live in two homes, split by trust level:
   formats.
 
   `github-pr-review-pending/` is the optional post-back mechanic
-  invoked from `/pr-review` — it creates a **pending (draft)**
-  GitHub review via `gh api` (no `event` key, so nothing is
-  submitted) and stops, leaving the human to click "Submit review"
-  in the GitHub UI. The pending-draft POST itself is gated under
-  this file's "Opening PRs or pushing to a remote" rule.
+  invoked from `/pr-review` in **human-in-loop mode** — it creates
+  a **pending (draft)** GitHub review via `gh api` (no `event`
+  key, so nothing is submitted) and stops, leaving the human to
+  click "Submit review" in the GitHub UI.
+
+  `github-pr-review-submitted/` is the sibling mechanic for
+  **agent-driven mode** — when the review is being posted by an
+  agent (scheduled, peer agent in a multi-agent pipeline) with no
+  human to click Submit. It POSTs with `event` set to `COMMENT`
+  (or `REQUEST_CHANGES` if findings are blocking) so the review
+  goes live in one call. Agents never use `APPROVE` — that's a
+  human-only trust signal.
+
+  `github-pr-review-fetch/` is the **inbound** counterpart to the
+  two outbound siblings. When a dev agent resumes work on a PR
+  after a separate review agent (or human reviewer) posted
+  findings, this skill fetches all submitted reviews, line-anchored
+  threads, and issue-style PR comments via `gh api` + GraphQL,
+  then emits a structured chat report ready for the dev agent to
+  walk through as a to-do list. Inbound + outbound + manager
+  together form the agent-to-agent review loop:
+  dev → push → review agent (`/pr-review` + `-submitted`) → PR has feedback →
+  dev agent (`-fetch` to ingest) → fix + push → loop.
 - **Personal skills** — `.claude/skills/personal/<name>/` (gitignored)
   or `~/.claude/skills/<name>/` (user-level, never in any repo). For
   ad-hoc skills with machine-specific paths, Synology IPs, NAS


### PR DESCRIPTION
## Summary

Closes the agent-to-agent PR review loop. The previous PRs gave us `/pr-review` (manager) + `github-pr-review-pending/` (outbound, human-in-loop). This PR adds the two missing pieces for agent-driven workflows:

- **`github-pr-review-submitted/`** — outbound, **agent-driven**. POSTs to `/reviews` with `event` set (`COMMENT` or `REQUEST_CHANGES`); the review goes live in one call, fires notifications, becomes visible to other agents reading the PR. Sibling of `-pending`.
- **`github-pr-review-fetch/`** — **inbound**. Fetches all submitted reviews + line-anchored threads (with `isResolved` / `isOutdated`) + issue-style PR comments. Emits a structured to-do report the dev agent walks through.

Stacked on [#307](https://github.com/jackal998/photo-manager/pull/307) (manager-composition refactor). Base = `chore/pr-review-as-manager-composition`. After #307 merges, retargets to master.

## The four-way family

| Skill | Direction | When |
|---|---|---|
| `/pr-review` (manager) | produces findings | always — the reviewer |
| `github-pr-review-pending` | outbound | human-in-loop, self-check before publish |
| `github-pr-review-submitted` | outbound | agent-driven; no human to click Submit |
| `github-pr-review-fetch` | inbound | dev agent reads what reviewer posted |

Agent-to-agent loop:

```
Agent A (dev session)
├── implement + push
└── gh pr create

Agent B (review session, cold start)
├── /pr-review <PR#>
└── github-pr-review-submitted  → review live on PR

Agent A (resumed, new session)
├── github-pr-review-fetch  → structured to-do list
├── fix each unresolved thread, push
└── loop until verdict is CLEAN
```

## Design rules embedded in the new skills

- **Agents NEVER use `event: APPROVE`.** Approval is a human-only trust signal. If `/pr-review` returns CLEAN, the agent posts a regular `gh pr comment` ("review agent: no findings, CLEAN") or just ends the session.
- **Severity → event mapping** (in `-submitted`): any `✗` → `REQUEST_CHANGES`; only `⚠ / ℹ️ / note:` → `COMMENT`; all CLEAN → no review at all.
- **Pending visibility quirk**: pending reviews are visible only to the author's `gh` identity. So pending can't be a cross-agent comm channel if the two agents use distinct `gh` users. Submitted reviews are visible to anyone with PR read access — that's what agent-to-agent needs.
- **`-submitted` reviews are irreversible.** Documented in the skill — no `DELETE .../reviews/{id}` exists for submitted reviews; dismissal requires admin on protected branches.
- **`-fetch` is read-only.** It surfaces thread node IDs but doesn't call `resolveReviewThread`; that mutation is the dev agent's separate fix-and-push action.

## Edits to existing files

- `pr-review/SKILL.md` — Optional post-back section rewritten with **Mode A (pending) + Mode B (submitted) + How-to-choose** guide. Composition graph table gains rows for both outbound modes + the inbound fetch. New \"Reading review feedback back into a session\" section.
- `CLAUDE.md` — project-skills list gains the two new entries; descriptive prose block documents the four-way family and the agent-to-agent loop pattern.

## Test plan

- [ ] **Skills register on disk.** Available-skills list should include `github-pr-review-submitted` and `github-pr-review-fetch`. **Verified during implementation.**
- [ ] **End-to-end agent-to-agent loop** (would need a real sandbox PR + two sessions):
  1. Session A: small no-op commit on a test branch, push, `gh pr create`.
  2. Session B (cold start): `/pr-review <PR#>` → Mode B post-back → `github-pr-review-submitted` POSTs with `event: COMMENT`.
  3. Session A (resumed): `github-pr-review-fetch <PR#>` → see the structured report listing session B's findings.
- [ ] **No `event: APPROVE` codepath.** Grep the new skills for `APPROVE` — should only appear in \"never use\" / \"do not use\" contexts. **Verified during implementation.**
- [ ] **Mode selection logic in pr-review.** Read the Optional post-back section; confirm \"how to choose\" guide is unambiguous (Mode A safer default when ambiguous).
- [ ] **PII grep + bundle-leak grep.** **Ran during implementation: zero matches** on `C:\Users\J\` / `/Users/` / IPv4 / `ghp_` / `AKIA` and `easyship | stripe | jira | acli | confluence | Rails | RSpec | RuboCop | Sidekiq | ActiveRecord | Supabase | Vercel`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)