### PR TITLE
fix(parallel-brief-generator): validate PR vs issue refs in briefs

### DIFF
--- a/.claude/skills/parallel-brief-generator/SKILL.md
+++ b/.claude/skills/parallel-brief-generator/SKILL.md
@@ -114,6 +114,15 @@ For each issue mentioned (or implied by bundle name):
    history of the project (if available) is the next-best source.
 4. If two open issues plausibly match the user's description, ask
    ONE clarifying question. Otherwise don't outsource research.
+5. **Whenever you write `#N` in a brief or in your own output,
+   prefix it with the object kind: `[PR #N]` or `[issue #N]`.**
+   Bare `#N` is ambiguous — a number in the user's intent might
+   be either, and the cold session reading the brief cannot
+   re-derive which. (Filed via
+   [#292](https://github.com/jackal998/photo-manager/issues/292)
+   after a brief named `#245` as a PR when it was the issue
+   closed by PR #256.) The matching `gh` check that validates
+   each label lives in Step 2.
 
 You also need (these are usually trivial to infer):
 
@@ -142,6 +151,28 @@ the likely rebase cost. Don't silently fan out overlapping work.
 Pre-assign slot numbers: if bundles A, B, C each need a new
 `qa/scenarios/sNN_*.py`, hand out `sNN`, `sNN+1`, `sNN+2` from the
 first free slot.
+
+**Validate every `#N` reference before emitting briefs.** For each
+number you've decided to put in a brief — sample sets ("run
+`/pr-review` against PRs #A, #B, #C"), `Closes #N` trailers, "see
+PR #N for prior art", "this depends on issue #N" — run the check
+that matches the kind you've labelled it (Step 1 bullet 5):
+
+```
+# If you wrote [PR #N]:
+gh pr view <N> --json number,state,title >/dev/null \
+  || echo "MISMATCH: #N is not a PR — check gh issue view <N>"
+
+# If you wrote [issue #N]:
+gh issue view <N> --json number,title >/dev/null \
+  || echo "MISMATCH: #N is not an issue — check gh pr view <N>"
+```
+
+On mismatch, do NOT emit the brief — either swap for the correct
+object (e.g. the PR that closed the issue, or vice versa) or
+surface to the user. Do not pass-through a labelled `#N` that
+doesn't resolve to that kind. (See [#292](https://github.com/jackal998/photo-manager/issues/292)
+for the recurrence the check defends against.)
 
 ### Step 3 — Generate one brief per task
 
@@ -355,6 +386,15 @@ from here; they own their work end-to-end.
   backtick are different fence chars, so inner ``` is unambiguously
   content. This was caught mid-session on 2026-05-15 (briefs for
   #230 and #212 rendered invisible).
+- **Emitting bare `#N` references in a brief, or labelling one as
+  `[PR #N]` / `[issue #N]` without running the matching `gh pr
+  view` / `gh issue view` check first.** The two fixes are
+  redundant on purpose — the prefix is for the human reader and the
+  cold session, the validation is for the orchestrator. Filed as
+  [#292](https://github.com/jackal998/photo-manager/issues/292)
+  after a brief listed issue #245 as a PR in a "5 recent clean PRs"
+  sample set; the executing session caught the mismatch in-band
+  and substituted PR #255, but burned context doing it.
 
 ## Photo-manager-specific reminders to bake into every brief
 

--- a/news/309.misc
+++ b/news/309.misc
@@ -1,0 +1,1 @@
+Validate PR vs issue refs in parallel-brief-generator output to prevent mismatched `#N` in briefs (#292).


### PR DESCRIPTION
## Summary

Closes #292.

Belt-and-suspenders fix for the bug seen during the brief for #272,
where the orchestrator listed issue #245 in a "5 recent clean PRs"
sample set. The executing session caught the mismatch and substituted
PR #255 in-band, but only after burning context on the detect-and-correct.

Three additions to [`.claude/skills/parallel-brief-generator/SKILL.md`](.claude/skills/parallel-brief-generator/SKILL.md):

1. **Step 1 — new bullet 5:** require `[PR #N]` / `[issue #N]` prefixes
   on every numeric reference the orchestrator emits. Bare `#N` is
   ambiguous to the cold session reading the brief.
2. **Step 2 — validation block:** run `gh pr view <N>` / `gh issue view <N>`
   matching the kind labelled in Step 1. Mismatch → swap (e.g. PR that
   closed the issue) or surface to user. Do not pass through.
3. **Anti-patterns list — new bullet:** "emitting bare `#N` or labelling
   without the matching `gh` check first" goes alongside the existing
   emit-time foot-guns (backtick-fence wrap, etc.).

Either fix alone leaves a gap: the prefix catches drift from future
human hand-edits; the validation catches the orchestrator's own slip
before any brief leaves.

## Verification

- [x] Diff is skill-only (`.claude/skills/parallel-brief-generator/SKILL.md`).
      No code or test files touched. No behaviour change.
- [x] `/pr-review` semantic gate run pre-PR — CLEAN (Gate 0 aligned,
      Gate 11 PII audit zero matches, no behaviour-bearing surface).
- [x] Spot-read confirms all three insertions read coherently in
      context (new bullet flows from the previous four; validation
      block sits cleanly after the existing pre-flight; anti-pattern
      bullet matches the tone of its neighbours).

## Test plan

- [ ] On next use of `parallel-brief-generator` (next `/parallel-brief-generator`
      invocation or "fan out X, Y, Z" intent), confirm the orchestrator
      writes `[PR #N]` / `[issue #N]` prefixes and runs the matching
      `gh` validation before emitting briefs.
- [ ] Mental dry-run against the #292 scenario: if a brief author wrote
      `[PR #245]`, `gh pr view 245` returns non-zero (it's an issue) →
      mismatch caught, swap or surface required before emit.