### PR TITLE
chore(scanner): localise manifest summary row labels

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -51,6 +51,7 @@ for the chore plan.
 | [Scan dialog — collapse Advanced Settings](#scan-dialog--collapse-advanced-settings) | Scan |
 | [Scan dialog — folder list (no priority arrows)](#scan-dialog--folder-list-no-priority-arrows) | Scan |
 | [Scan dialog — multi-source scan](#scan-dialog--multi-source-scan) | Scan |
+| [Scan flow — manifest summary in progress log](#scan-flow--manifest-summary-in-progress-log) | Scan |
 | [Scan flow — rescan confirm](#scan-flow--rescan-confirm) | Scan |
 | [Scan flow — visual selection of KEEP rows after scan](#scan-flow--visual-selection-of-keep-rows-after-scan) | Scan |
 | [Set Action dialog — Beginner / Regex mode toggle](#set-action-dialog--beginner--regex-mode-toggle) | Set Action dialog |
@@ -387,6 +388,17 @@ for the chore plan.
 - **Conditions / variants:** Source paths persist to `settings.json` (`sources.list`) between sessions. The Scan dialog accepts invalid / missing paths but surfaces a validation toast on Start Scan ([`qa/scenarios/s38_scan_dialog_invalid_path.py`](../qa/scenarios/s38_scan_dialog_invalid_path.py)).
 - **Related:** [PR #17](https://github.com/jackal998/photo-manager/pull/17) (dynamic multi-source scan); [PR #160](https://github.com/jackal998/photo-manager/pull/160) (two-column layout); QA scenarios [`qa/scenarios/s10_multi_source.py`](../qa/scenarios/s10_multi_source.py), [`qa/scenarios/s17_scan_dialog_widgets.py`](../qa/scenarios/s17_scan_dialog_widgets.py).
 - **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Scan flow — manifest summary in progress log
+
+- **Entry point:** [scanner/manifest.py:92](../scanner/manifest.py#L92) `print_summary()` — output captured by [app/views/workers/scan_worker.py](../app/views/workers/scan_worker.py) `_emit` and routed to the scan-dialog progress log.
+- **Trigger:** Scan finishes and the worker emits the summary block.
+- **Behaviour:** The progress log prints a "Migration Manifest Summary" table with one row per action bucket (kept, to be moved, exact duplicates, near-duplicates (review), no shot date), each row showing the count and percentage. The headline `Indexed in manifest` line counts manifest rows; `Skipped (unreadable)` reconciles the headline against the per-step "Hashed N/M" log line earlier. A second "Group Summary" block follows with group count, files-in-groups, and isolated-file counts.
+- **Conditions / variants:** Action-bucket row labels are localised via [`translations/en.yml`](../translations/en.yml) / [`translations/zh_TW.yml`](../translations/zh_TW.yml) `manifest_summary:` keys — raw internal action strings (`KEEP` / `MOVE` / `EXACT` / `REVIEW_DUPLICATE` / `UNDATED`) no longer leak into the log. The `Skipped (unreadable)` row is omitted when the count is zero.
+- **Related:** [PR #310](https://github.com/jackal998/photo-manager/pull/310) (fix for [#242](https://github.com/jackal998/photo-manager/issues/242)); also [#87](https://github.com/jackal998/photo-manager/issues/87) (headline-label + skipped reconciliation).
+- **Last verified:** 2026-05-19 (PR for [#242](https://github.com/jackal998/photo-manager/issues/242))
 
 ---
 

--- a/news/242.misc
+++ b/news/242.misc
@@ -1,0 +1,1 @@
+Localise the action-bucket row labels in the scan-dialog progress log so raw internal action strings (`KEEP` / `MOVE` / `EXACT` / `REVIEW_DUPLICATE` / `UNDATED`) stop leaking into user-visible output; internal values stay unchanged (#242).

--- a/scanner/manifest.py
+++ b/scanner/manifest.py
@@ -106,20 +106,33 @@ def print_summary(rows: list[ManifestRow], skipped: int = 0) -> None:
     every file was decode-skipped (#87).
     """
     from collections import Counter
+    from infrastructure.i18n import t
     counts: Counter = Counter(r.action for r in rows)
     total = len(rows)
+
+    # Internal action strings stay as dict keys (they drive sort order
+    # and tree rendering); only the row labels are localised. See #242.
+    action_label_keys = (
+        ("KEEP", "manifest_summary.keep"),
+        ("MOVE", "manifest_summary.move"),
+        ("EXACT", "manifest_summary.exact"),
+        ("REVIEW_DUPLICATE", "manifest_summary.review_duplicate"),
+        ("UNDATED", "manifest_summary.undated"),
+    )
 
     print("\n── Migration Manifest Summary ──────────────────────")
     print(f"  Indexed in manifest : {total:>7,}")
     if skipped:
         print(f"  Skipped (unreadable): {skipped:>7,}")
-    for action in ("KEEP", "MOVE", "EXACT", "REVIEW_DUPLICATE", "UNDATED"):
+    for action, key in action_label_keys:
+        label = t(key)
         n = counts.get(action, 0)
         pct = 100 * n / total if total else 0
-        print(f"  {action:<20}: {n:>7,}  ({pct:.1f}%)")
-    other = total - sum(counts[a] for a in ("KEEP", "MOVE", "EXACT", "REVIEW_DUPLICATE", "UNDATED"))
+        print(f"  {label:<26}: {n:>7,}  ({pct:.1f}%)")
+    other = total - sum(counts[a] for a, _ in action_label_keys)
     if other:
-        print(f"  {'other':<20}: {other:>7,}")
+        other_label = t("manifest_summary.other")
+        print(f"  {other_label:<26}: {other:>7,}")
     print("────────────────────────────────────────────────────")
 
     n_groups = len({r.group_id for r in rows if r.group_id})

--- a/tests/test_scanner_manifest.py
+++ b/tests/test_scanner_manifest.py
@@ -153,9 +153,15 @@ class TestPrintSummary:
         )
         print_summary(rows)
         out = capsys.readouterr().out
-        assert "MOVE" in out
-        assert "EXACT" in out
-        assert "REVIEW_DUPLICATE" in out
+        # Friendly labels render instead of raw internal action names
+        # (#242 — internal MOVE/EXACT/REVIEW_DUPLICATE must not leak
+        # into the user-visible scan-dialog log).
+        assert "to be moved" in out
+        assert "exact duplicates" in out
+        assert "near-duplicates (review)" in out
+        assert "MOVE" not in out
+        assert "EXACT" not in out
+        assert "REVIEW_DUPLICATE" not in out
 
     def test_empty_rows_no_crash(self, capsys):
         print_summary([])

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -98,6 +98,19 @@ decision:
   lock: "lock"
   unlock: "unlock"
 
+# Friendly row labels for the scan-dialog progress log's action-count
+# summary table (scanner.manifest.print_summary). The raw action
+# strings ("KEEP", "MOVE", "EXACT", "REVIEW_DUPLICATE", "UNDATED")
+# stay internal — they drive sort order and tree rendering — but the
+# user only sees these labels.
+manifest_summary:
+  keep: "kept (no action)"
+  move: "to be moved"
+  exact: "exact duplicates"
+  review_duplicate: "near-duplicates (review)"
+  undated: "no shot date"
+  other: "other"
+
 # ScanDialog and its inner panels.
 scan_dialog:
   title: "Scan Sources"

--- a/translations/zh_TW.yml
+++ b/translations/zh_TW.yml
@@ -78,6 +78,14 @@ decision:
   lock: "鎖定"
   unlock: "解除鎖定"
 
+manifest_summary:
+  keep: "已保留 (無動作)"
+  move: "待搬移"
+  exact: "完全重複"
+  review_duplicate: "近似重複 (待檢閱)"
+  undated: "無拍攝日期"
+  other: "其他"
+
 scan_dialog:
   title: "掃描來源"
   notice: "唯讀掃描 — 不會搬移或刪除任何檔案。"


### PR DESCRIPTION
## Summary
- `scanner.manifest.print_summary()` row labels now route through `infrastructure.i18n.t()` instead of printing the raw internal action strings (`KEEP` / `MOVE` / `EXACT` / `REVIEW_DUPLICATE` / `UNDATED`). Those names were captured by `scan_worker._emit` and surfaced in the scan-dialog progress log — i.e. user-visible.
- Internal action values are untouched — they still drive sort order and tree rendering. Only the rendered row label changed.
- New `manifest_summary:` key group added to `translations/en.yml` and `translations/zh_TW.yml`.
- `tests/test_scanner_manifest.py::test_counts_each_action` now asserts the friendly labels render AND raw names are absent.

Closes #242.

## Test plan
- [x] `pytest` — 1417 passed, 2 skipped
- [x] `scripts/check_coverage_per_file.py` — 70% per-file floor holds; `scanner/manifest.py` at 94%
- [x] Eyeballed `print_summary` output locally — friendly labels render, no raw `MOVE`/`EXACT`/`REVIEW_DUPLICATE` strings
- [ ] L3 scan-dialog scenario (s17) — leave for manual confirm post-merge if useful

## Out of scope (per #242 verification)
- `translations/en.yml` / `translations/zh_TW.yml` scan-dialog notices — already cleaned up before this branch.
- `app/views/workers/scan_worker.py:78` historic MOVE/SKIP/REVIEW notice — already removed; only an internal source comment at line 249 remains (not user-visible).
- Legacy `scan.py` / `review.py` CLI — files no longer exist; the CLI sub-task in #242 is a no-op.
- Renaming the internal action strings in `core/models.py` / `scanner/dedup.py` / `_ACTION_SORT` — separate, much larger refactor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)