### PR TITLE
feat(tree): render Similarity % against displayed Ref, not scanner anchor

### DIFF
--- a/app/views/tree_model_builder.py
+++ b/app/views/tree_model_builder.py
@@ -25,6 +25,7 @@ from app.views.constants import (
     headers,
 )
 from infrastructure.i18n import t
+from scanner.phash_distance import hamming_distance as _phash_hamming
 
 
 _LOCK_GLYPH = "\U0001F512"  # 🔒
@@ -89,11 +90,23 @@ def _hamming_to_pct(hamming: int | None) -> str:
 
 
 def _file_similarity(
-    action: str, record: object, is_ref_winner: bool = True
+    action: str,
+    record: object,
+    is_ref_winner: bool = True,
+    ref_phash: str | None = None,
 ) -> str:
     """Return similarity label for a file row.
 
-    EXACT → "100%"; REVIEW_DUPLICATE → percentage from hamming_distance.
+    EXACT → "100%"; REVIEW_DUPLICATE → percentage from pHash Hamming
+    distance against the *displayed* Ref winner (#253). The render-time
+    recomputation preserves #241's score-aware Ref pick: when the
+    scanner anchored on a different Ref-tier file than ``_pick_ref_winner``
+    selects, the stored ``hamming_distance`` would read "X% similar to
+    *what?*" — so we re-measure against the row the user actually sees
+    as the group's Ref. Falls back to the scanner's stored
+    ``hamming_distance`` when either pHash is missing (old manifests
+    pre-phash, video rows, or imagehash unavailable).
+
     For Ref-tier actions (KEEP / MOVE / UNDATED / ""): when
     ``is_ref_winner`` is True the row carries the "Ref" label; when
     False it falls back to the neutral passenger sentinel "—". Within
@@ -102,23 +115,28 @@ def _file_similarity(
     duplicates union-find collapsed into one group, etc. all used to
     render two or three "Ref" labels in the same group.
 
-    Default ``is_ref_winner=True`` keeps the legacy behaviour for
-    callers that don't track within-group winners (notably the unit
-    tests in ``tests/test_tree_model_builder.py::TestFileSimilarity``,
-    which exercise the helper in isolation).
+    Default ``is_ref_winner=True`` and ``ref_phash=None`` keep the
+    legacy behaviour for callers that don't track within-group winners
+    (notably the unit tests in
+    ``tests/test_tree_model_builder.py::TestFileSimilarity``, which
+    exercise the helper in isolation).
     """
     if action == "EXACT":
         return "100%"
     if action == "REVIEW_DUPLICATE":
+        record_phash = getattr(record, "phash", None)
+        recomputed = _phash_hamming(ref_phash, record_phash)
+        if recomputed is not None:
+            return _hamming_to_pct(recomputed)
         return _hamming_to_pct(getattr(record, "hamming_distance", None))
     if is_ref_winner:
         return t("tree.similarity_ref")
     return t("tree.similarity_passenger")
 
 
-def _pick_ref_winner_id(items_list: Iterable[object]) -> int | None:
-    """Return ``id()`` of the items_list element that should carry the
-    "Ref" label within its group, or ``None`` if no item is Ref-tier.
+def _pick_ref_winner(items_list: Iterable[object]) -> object | None:
+    """Return the items_list element that should carry the "Ref" label
+    within its group, or ``None`` if no item is Ref-tier.
 
     Tie-break (ascending — smallest tuple wins):
       1. ``_ACTION_SORT`` priority (Ref-tier == 1 always beats
@@ -128,10 +146,14 @@ def _pick_ref_winner_id(items_list: Iterable[object]) -> int | None:
          canonical case)
       3. ``file_path`` lexicographic (deterministic when score ties)
 
-    Only returns an id when the candidate is genuinely Ref-tier
+    Only returns an item when the candidate is genuinely Ref-tier
     (priority 1). A group of only EXACT/REVIEW_DUPLICATE rows has no
     Ref winner — those rows render their own similarity labels and
     no "Ref" should appear.
+
+    Returning the item itself (not just its ``id()``) lets the caller
+    read the winner's pHash to drive #253's render-time Similarity %
+    recomputation.
     """
     best_item: object | None = None
     best_key: tuple | None = None
@@ -152,7 +174,7 @@ def _pick_ref_winner_id(items_list: Iterable[object]) -> int | None:
         if best_key is None or key < best_key:
             best_key = key
             best_item = it
-    return id(best_item) if best_item is not None else None
+    return best_item
 
 
 # Sentinel SORT_ROLE value for unscored rows (Live Photo MOV passengers,
@@ -322,7 +344,15 @@ def build_model(
         # once per group instead of tracking ref_seen in the loop so
         # the source-model iteration order stays untouched (sort happens
         # downstream through QSortFilterProxyModel).
-        ref_winner_id = _pick_ref_winner_id(items_list)
+        #
+        # #253 — also grab the winner's pHash so REVIEW_DUPLICATE rows
+        # can render % against the *displayed* Ref rather than the
+        # scanner's anchor (which may differ when #241's score-aware
+        # tie-break picks a different Ref-tier row).
+        ref_winner = _pick_ref_winner(items_list)
+        ref_winner_phash = (
+            getattr(ref_winner, "phash", None) if ref_winner is not None else None
+        )
 
         for p in items_list:
             name = Path(getattr(p, "file_path", "")).name
@@ -343,7 +373,10 @@ def build_model(
             # the per-group winner, "—" for sibling Ref-tier rows (#241).
             file_action = getattr(p, "action", "") or ""
             file_match = _file_similarity(
-                file_action, p, is_ref_winner=(id(p) == ref_winner_id),
+                file_action,
+                p,
+                is_ref_winner=(p is ref_winner),
+                ref_phash=ref_winner_phash,
             )
 
             # Col 1: user's decision (delete / keep / "" / remove_from_list).

--- a/core/models.py
+++ b/core/models.py
@@ -33,6 +33,12 @@ class PhotoRecord:
     # User's planned file operation (delete | keep | "" = undecided)
     user_decision: str = ""
     hamming_distance: int | None = None
+    # Perceptual hash hex string (16 chars / 64 bits via imagehash). Used
+    # at render time (#253) to recompute the Similarity % against the
+    # *displayed* Ref winner, which can diverge from the scanner's anchor
+    # after #241's score-aware Ref pick. None for videos, RAW-only rows,
+    # and rows from manifests that pre-date the phash column.
+    phash: str | None = None
     # Keep-worthiness score in [0.0, 1.0] (#187). None for isolated rows
     # (no peers to score against) and Live Photo MOV passengers (inherit
     # their HEIC's decision). Computed at scan time by scanner.scoring;

--- a/docs/features.md
+++ b/docs/features.md
@@ -57,6 +57,7 @@ for the chore plan.
 | [Set Action dialog — live preview + validation](#set-action-dialog--live-preview--validation) | Set Action dialog |
 | [Set Action dialog — numeric comparison panel](#set-action-dialog--numeric-comparison-panel) | Set Action dialog |
 | [Set Action dialog — Score / Lock / Resolution fields](#set-action-dialog--score--lock--resolution-fields) | Set Action dialog |
+| [Similarity column](#similarity-column) | Review |
 
 ---
 
@@ -453,6 +454,17 @@ for the chore plan.
 - **Conditions / variants:** All three labels go through `t()` so they translate correctly. Without this addition, picking Score from the combo would have rendered untranslated; Lock would have been picker-visible but raw-English; Resolution wasn't there at all.
 - **Related:** [PR #250](https://github.com/jackal998/photo-manager/pull/250) (closes [#238](https://github.com/jackal998/photo-manager/issues/238)); QA scenario [`qa/scenarios/s50_select_numeric_panel_from_main_window.py`](../qa/scenarios/s50_select_numeric_panel_from_main_window.py).
 - **Last verified:** 2026-05-17 (PR for [#262](https://github.com/jackal998/photo-manager/issues/262))
+
+---
+
+### Similarity column
+
+- **Entry point:** First column of the main result tree (COL_GROUP at index 0) — [app/views/tree_model_builder.py](../app/views/tree_model_builder.py). On the group header row it shows the localised "Group N" label; on each file row it shows one of: `Ref`, `100%`, an `N%` similarity, `—`, or `~dup`.
+- **Trigger:** Populated automatically when a manifest is loaded; no user action.
+- **Behaviour:** Per file row, the cell renders one of five values: (a) `Ref` — exactly one row per group, picked via the score-aware tie-break (highest score among Ref-tier action rows, lex name as final tiebreaker); (b) `100%` — `action='EXACT'` (SHA / format duplicate); (c) `N%` — `action='REVIEW_DUPLICATE'`, computed at render time as `round((64 - hamming) / 64 * 100)` where `hamming` is the pHash Hamming distance between the row's pHash and **the displayed Ref's pHash**, not the scanner's anchor's pHash; (d) `—` — Ref-tier sibling row (e.g. Live Photo MOV passenger sitting alongside the HEIC primary) that did not win the Ref pick; (e) `~dup` — fallback placeholder when neither pHash can be read.
+- **Conditions / variants:** The render-time recomputation requires both the displayed Ref's pHash and the row's pHash to be populated. When either is missing (old manifests pre-phash column, video rows, or imagehash not installed), the cell falls back to the scanner's stored `hamming_distance` so old manifests degrade gracefully. The manifest's `hamming_distance` column is still written by the scanner but is no longer the source of truth for the rendered % when phashes are available — the rendered value is always relative to the row the user sees as `Ref`.
+- **Related:** [#253](https://github.com/jackal998/photo-manager/issues/253) (render against displayed Ref); [#241](https://github.com/jackal998/photo-manager/issues/241) (score-aware Ref tie-break); QA scenarios [`qa/scenarios/s52_similarity_against_displayed_ref.py`](../qa/scenarios/s52_similarity_against_displayed_ref.py); helper module [`scanner/phash_distance.py`](../scanner/phash_distance.py).
+- **Last verified:** 2026-05-19 (PR for [#253](https://github.com/jackal998/photo-manager/issues/253))
 
 ---
 

--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -54,6 +54,7 @@ SELECT id, source_path, source_label, group_id, hamming_distance, reason,
        action, executed, user_decision, is_locked,
        file_size_bytes, shot_date, creation_date, mtime,
        pixel_width, pixel_height,
+       phash,
        score
 FROM   migration_manifest
 WHERE  executed = 0
@@ -129,6 +130,7 @@ def _photo_record(
     hamming_distance: "int | None" = None,
     db_pixel_width: "int | None" = None,
     db_pixel_height: "int | None" = None,
+    db_phash: "str | None" = None,
     db_score: "float | None" = None,
 ) -> PhotoRecord:
     """Build a PhotoRecord, preferring cached DB metadata over filesystem reads.
@@ -193,6 +195,7 @@ def _photo_record(
         hamming_distance=hamming_distance,
         pixel_width=db_pixel_width,
         pixel_height=db_pixel_height,
+        phash=db_phash,
         score=db_score,
     )
 
@@ -276,6 +279,7 @@ class ManifestRepository:
                         hamming_distance=row["hamming_distance"],
                         db_pixel_width=row["pixel_width"],
                         db_pixel_height=row["pixel_height"],
+                        db_phash=row["phash"],
                         db_score=row["score"],
                     )
                 except Exception as exc:  # pylint: disable=broad-exception-caught

--- a/news/311.feature
+++ b/news/311.feature
@@ -1,0 +1,1 @@
+Render Similarity column % against the displayed Ref winner (recomputed at render time from each row's pHash), preserving #241's score-aware Ref pick and removing the "X% similar to *what?*" ambiguity that surfaced when the scanner's anchor diverged from the displayed Ref (#253).

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -197,6 +197,15 @@ ALL_SCENARIOS = [
     # contains both a tree and a preview pane visible to UIA, then
     # cancels without executing.
     "s51_execute_dialog_preview",
+    # s52 (#253) — REVIEW_DUPLICATE rows' Similarity % is recomputed at
+    # render time against the *displayed* Ref winner (which can diverge
+    # from the scanner's anchor after #241's score-aware tie-break).
+    # Scans the near-duplicates fixture, reads back the manifest, and
+    # verifies that for every REVIEW_DUPLICATE row the (Ref-winner pHash,
+    # row pHash) Hamming distance reaches the renderer — phash column
+    # has to be wired through PhotoRecord for the new render path to
+    # work. Read-only on the manifest.
+    "s52_similarity_against_displayed_ref",
 ]
 
 

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -195,6 +195,12 @@ SCENARIO_SOURCES: dict[str, list[str] | None] = {
     # preview surface mounted. Non-destructive — cancels without
     # executing.
     "s51_execute_dialog_preview": ["qa/sandbox/near-duplicates"],
+    # s52 (#253) — pHash recomputation against displayed Ref. The
+    # near-duplicates fixture (5 JPEG re-saves at qualities 95/88/80/72/65)
+    # gives one Ref-tier MOVE row + four REVIEW_DUPLICATE rows with
+    # populated pHash strings — the minimal end-to-end shape the new
+    # render path needs.
+    "s52_similarity_against_displayed_ref": ["qa/sandbox/near-duplicates"],
 }
 
 

--- a/qa/scenarios/s52_similarity_against_displayed_ref.py
+++ b/qa/scenarios/s52_similarity_against_displayed_ref.py
@@ -1,0 +1,212 @@
+"""Scenario 52 — Similarity % measured against the *displayed* Ref (#253).
+
+Required source: qa/sandbox/near-duplicates (5 JPEGs neardup_NN_qXX.jpg).
+
+After #241's score-aware Ref tie-break, the row that carries the "Ref"
+label in the tree can diverge from the row the scanner anchored on
+when computing each REVIEW_DUPLICATE's stored ``hamming_distance``.
+The Similarity column used to render the stored distance directly,
+making the % read "X% similar to *what?*" once the displayed Ref had
+shifted. #253 fixes this by recomputing pHash Hamming distance at
+render time against the *displayed* Ref's pHash, which requires:
+
+  1. The scanner writes ``phash`` for every grouped row (already true
+     pre-#253; see ``scanner/manifest.py`` schema).
+  2. ManifestRepository loads ``phash`` into PhotoRecord — added in
+     this change.
+  3. The tree builder reads the Ref winner's pHash and passes it into
+     ``_file_similarity`` for each REVIEW_DUPLICATE sibling.
+
+This scenario pins the wiring (1)+(2)+(3) by replicating, on the
+manifest side, the exact arithmetic the renderer performs and checking
+that the data the renderer needs is actually present and produces
+the expected percentages.
+
+The full divergence case (scanner anchor != score-winner with two
+Ref-tier rows in one group) is exercised at layer 1 in
+``tests/test_tree_model_builder.py::TestBuildModelSimilarityAgainstDisplayedRef``
+— the near-duplicates fixture has only one Ref-tier row so anchor
+and displayed Ref happen to coincide here, but the data path being
+verified is the same.
+
+Per CLAUDE.md, this driver uses sqlite-read for tree-content assertions
+because ``read_result_rows`` filters rows below y=600 on CI's smaller
+render — same pattern as s14, s32, s35.
+
+PRE: PHOTO_MANAGER_HOME=qa QT_ACCESSIBILITY=1 .venv/Scripts/python.exe main.py
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+from qa.scenarios import _uia
+
+REPO = Path(__file__).resolve().parents[2]
+MANIFEST_PATH = REPO / "qa" / "run-manifest.sqlite"
+FIXTURE_NAME_GLOB = "neardup_"
+
+REF_TIER_ACTIONS = {"KEEP", "MOVE", "UNDATED", ""}
+
+
+def _hamming_to_pct(hamming: int) -> str:
+    """Mirror of ``app/views/tree_model_builder._hamming_to_pct`` —
+    duplicated here so the scenario doesn't depend on the renderer's
+    private helper while still computing the *exact* % the user sees.
+    """
+    return f"{round((64 - hamming) / 64 * 100)}%"
+
+
+def _read_rows() -> list[dict]:
+    """Return every fixture row as a dict with the columns this
+    scenario inspects."""
+    if not MANIFEST_PATH.exists():
+        raise RuntimeError(f"manifest not found at {MANIFEST_PATH}")
+    conn = sqlite3.connect(str(MANIFEST_PATH))
+    try:
+        rows = conn.execute(
+            "SELECT source_path, action, phash, hamming_distance, score "
+            "FROM migration_manifest WHERE source_path LIKE ?",
+            (f"%{FIXTURE_NAME_GLOB}%",),
+        ).fetchall()
+    finally:
+        conn.close()
+    return [
+        {
+            "name": Path(p).name,
+            "action": a or "",
+            "phash": ph,
+            "hamming_distance": hd,
+            "score": s,
+        }
+        for p, a, ph, hd, s in rows
+    ]
+
+
+def _pick_displayed_ref(rows: list[dict]) -> dict | None:
+    """Replicate ``_pick_ref_winner`` from app/views/tree_model_builder.
+
+    Same tie-break: Ref-tier only, then highest score, then lex file
+    name. Inlined so a future refactor that splits or renames the
+    helper doesn't silently fall out of sync with this scenario.
+    """
+    candidates = [r for r in rows if r["action"] in REF_TIER_ACTIONS]
+    if not candidates:
+        return None
+    return min(
+        candidates,
+        # negate score so highest wins; unscored rows (None) collapse
+        # to +inf and sort last among Ref-tier candidates.
+        key=lambda r: (
+            -(r["score"] if r["score"] is not None else float("-inf")),
+            r["name"],
+        ),
+    )
+
+
+def main() -> int:
+    print("scenario: s52_similarity_against_displayed_ref")
+    app, win = _uia.connect_main()
+    print(f"connected: pid={win.process_id()} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, _ = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=30)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    for line in _uia.extract_summary(log):
+        if line:
+            print(f"  log: {line}")
+
+    print("step: close_dialog")
+    _uia.close_and_load_manifest(dlg)
+    _, win = _uia.connect_main()
+
+    print("step: read_rows")
+    rows = _read_rows()
+    if not rows:
+        print("FAIL: no fixture rows found in manifest after scan")
+        return 1
+    for r in rows:
+        print(
+            f"  row: name={r['name']} action={r['action']!r} "
+            f"phash={r['phash']!r} hamming={r['hamming_distance']} "
+            f"score={r['score']}"
+        )
+
+    # ── Invariant 1: phash populated everywhere (renderer needs it) ──────
+    print("step: assert_phash_populated")
+    missing_phash = [r["name"] for r in rows if not r["phash"]]
+    if missing_phash:
+        print(
+            f"FAIL: phash column empty for {missing_phash} — the new render "
+            f"path falls back to stored hamming_distance, defeating #253"
+        )
+        return 1
+
+    # ── Invariant 2: a displayed Ref exists ──────────────────────────────
+    print("step: assert_displayed_ref_exists")
+    displayed_ref = _pick_displayed_ref(rows)
+    if displayed_ref is None:
+        print("FAIL: no Ref-tier row in fixture group — fixture changed?")
+        return 1
+    print(
+        f"  displayed_ref name={displayed_ref['name']!r} "
+        f"action={displayed_ref['action']!r} score={displayed_ref['score']}"
+    )
+
+    # ── Invariant 3: every REVIEW_DUPLICATE row's recomputed % is the
+    # value the user sees in the Similarity column. Imports imagehash
+    # here (not at module top) so the scenario file remains parseable
+    # even on a CI image without the optional dep, and fails fast with
+    # a clear message if it's missing locally. ────────────────────────
+    print("step: assert_recomputed_pct_for_each_dup")
+    try:
+        import imagehash
+    except ImportError:
+        print("FAIL: imagehash not installed — required to verify #253 wiring")
+        return 1
+
+    ref_hash = imagehash.hex_to_hash(displayed_ref["phash"])
+    failures: list[str] = []
+    review_dup_rows = [r for r in rows if r["action"] == "REVIEW_DUPLICATE"]
+    if not review_dup_rows:
+        print(
+            "FAIL: no REVIEW_DUPLICATE rows in fixture group — "
+            "near-duplicates classifier may have changed"
+        )
+        return 1
+
+    for r in review_dup_rows:
+        row_hash = imagehash.hex_to_hash(r["phash"])
+        distance = ref_hash - row_hash
+        expected_pct = _hamming_to_pct(distance)
+        legacy_pct = _hamming_to_pct(r["hamming_distance"])
+        marker = "≡" if expected_pct == legacy_pct else "≠"
+        print(
+            f"  {r['name']}: ref_dist={distance} → {expected_pct}  "
+            f"{marker}  stored hamming={r['hamming_distance']} → {legacy_pct}"
+        )
+        # Sanity check on the math itself: every recomputed % must
+        # fall inside [0%, 100%]. A negative or >100 would mean
+        # _hamming_to_pct was passed something other than 0..64.
+        n = int(expected_pct.rstrip("%"))
+        if not (0 <= n <= 100):
+            failures.append(
+                f"{r['name']}: recomputed pct {expected_pct} out of range"
+            )
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    print("scenario: s52_similarity_against_displayed_ref DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scanner/phash_distance.py
+++ b/scanner/phash_distance.py
@@ -1,0 +1,32 @@
+"""Pure pHash Hamming-distance helper.
+
+Extracted so the tree renderer can recompute distances at render time
+(#253) without importing scanner internals like ``scanner.dedup``.
+Scanner-side near-duplicate classification still uses its own inline
+``imagehash.hex_to_hash`` calls — sharing this helper would force
+``dedup`` to import a sibling for one call.
+"""
+from __future__ import annotations
+
+try:
+    import imagehash
+    _IMAGEHASH_AVAILABLE = True
+except ImportError:
+    _IMAGEHASH_AVAILABLE = False
+
+
+def hamming_distance(phash_a: str | None, phash_b: str | None) -> int | None:
+    """Return pHash Hamming distance between two hex strings.
+
+    Returns ``None`` when either input is missing/empty, when imagehash
+    is not installed (CI without optional deps), or when a hex string is
+    malformed. ``None`` signals "fall back to whatever the caller stored
+    elsewhere" rather than raising — the renderer must never crash on a
+    bad row.
+    """
+    if not phash_a or not phash_b or not _IMAGEHASH_AVAILABLE:
+        return None
+    try:
+        return imagehash.hex_to_hash(phash_a) - imagehash.hex_to_hash(phash_b)
+    except (ValueError, TypeError):
+        return None

--- a/tests/test_phash_distance.py
+++ b/tests/test_phash_distance.py
@@ -1,0 +1,57 @@
+"""Tests for scanner/phash_distance — the render-time Hamming helper.
+
+This is the pure function the tree renderer calls (#253) to compute
+distances against the *displayed* Ref winner without importing scanner
+internals. The helper must:
+
+  1. Return an integer Hamming distance when both phashes are valid.
+  2. Return None on missing inputs (so callers fall back gracefully).
+  3. Never raise — the renderer must never crash on a bad row.
+"""
+from __future__ import annotations
+
+import pytest
+
+from scanner.phash_distance import hamming_distance
+
+
+class TestHammingDistanceBasics:
+    def test_zero_distance_when_phashes_match(self):
+        assert hamming_distance("0000000000000000", "0000000000000000") == 0
+
+    def test_one_bit_difference(self):
+        """Last hex char 0 → 1 flips a single bit; this anchors the
+        #253 test fixture which uses these exact strings to drive a
+        divergence-vs-anchor case in the renderer.
+        """
+        assert hamming_distance("0000000000000000", "0000000000000001") == 1
+
+    def test_max_distance_for_64_bit_phash(self):
+        """All-zero vs all-ones is the upper bound for 64-bit pHashes
+        (16 hex chars). Pins the bit width — if a future change moves
+        to a larger hash size the renderer's ``_hamming_to_pct``
+        constants would need an update too.
+        """
+        assert hamming_distance("0000000000000000", "ffffffffffffffff") == 64
+
+
+class TestHammingDistanceFallbacks:
+    """Every fallback returns None so ``_file_similarity`` can drop back
+    to the scanner's stored hamming_distance instead of rendering a
+    placeholder. None is the contract — not 0, not 64, not raise."""
+
+    @pytest.mark.parametrize("a,b", [
+        (None, "0000000000000000"),
+        ("0000000000000000", None),
+        (None, None),
+        ("", "0000000000000000"),
+        ("0000000000000000", ""),
+    ])
+    def test_missing_inputs_return_none(self, a, b):
+        assert hamming_distance(a, b) is None
+
+    def test_malformed_hex_returns_none_not_raises(self):
+        """A row with a corrupt phash (caused by a bad manifest write
+        or hand-edit) must not crash the renderer. Caller falls back
+        to the stored hamming_distance."""
+        assert hamming_distance("not-hex-at-all", "0000000000000000") is None

--- a/tests/test_tree_model_builder.py
+++ b/tests/test_tree_model_builder.py
@@ -18,6 +18,7 @@ from app.views.tree_model_builder import (
     _action_display,
     _file_similarity,
     _hamming_to_pct,
+    _pick_ref_winner,
     build_model,
 )
 
@@ -87,6 +88,178 @@ class TestFileSimilarity:
     @pytest.mark.parametrize("action", ["KEEP", "MOVE", "UNDATED", "", "FOO_UNKNOWN"])
     def test_other_actions_render_as_ref(self, action):
         assert _file_similarity(action, _rec()) == "Ref"
+
+
+# ── #253: % against the displayed Ref, not the scanner's anchor ────────────
+
+
+class TestFileSimilarityAgainstDisplayedRef:
+    """#253 — REVIEW_DUPLICATE rows render % measured against the Ref
+    winner ``_pick_ref_winner`` selects, NOT the scanner's anchor whose
+    distance lives in ``record.hamming_distance``. After #241 the two
+    can diverge: scanner anchors on the lex-first MOVE row, but the
+    score-aware Ref pick may select a different Ref-tier sibling.
+    """
+
+    def test_render_time_recomputation_supersedes_stored_hamming(self):
+        """The stored hamming_distance (vs scanner anchor) should be
+        ignored when ref_phash is supplied — render-time recomputation
+        wins. Concrete divergence: stored=63 (would render "2%") vs
+        recomputed=1 (renders "98%"). If the fix walks back, the legacy
+        2% would resurface and this test would catch it.
+        """
+        dup = _rec(
+            action="REVIEW_DUPLICATE",
+            phash="0000000000000001",
+            hamming_distance=63,  # scanner measured this against a different anchor
+        )
+        result = _file_similarity(
+            "REVIEW_DUPLICATE", dup, ref_phash="0000000000000000",
+        )
+        # round((64-1)/64*100) == round(98.4375) == 98
+        assert result == "98%"
+
+    def test_falls_back_to_stored_hamming_when_ref_phash_missing(self):
+        """Old manifests pre-date the phash column wiring through
+        PhotoRecord; when ref_phash is None the renderer must still
+        produce a meaningful % from the legacy stored value rather
+        than blanking the cell.
+        """
+        dup = _rec(
+            action="REVIEW_DUPLICATE",
+            phash="0000000000000001",
+            hamming_distance=2,
+        )
+        result = _file_similarity(
+            "REVIEW_DUPLICATE", dup, ref_phash=None,
+        )
+        # round((64-2)/64*100) == 97
+        assert result == "97%"
+
+    def test_falls_back_to_stored_hamming_when_record_phash_missing(self):
+        """Symmetric to the previous case — a row whose own phash is
+        None (video / RAW with no thumbnail / hash failure) cannot
+        be re-measured, so the stored hamming_distance is the only
+        signal available.
+        """
+        dup = _rec(
+            action="REVIEW_DUPLICATE",
+            phash=None,
+            hamming_distance=4,
+        )
+        result = _file_similarity(
+            "REVIEW_DUPLICATE", dup, ref_phash="0000000000000000",
+        )
+        # round((64-4)/64*100) == round(93.75) == 94
+        assert result == "94%"
+
+    def test_recompute_path_handles_zero_distance(self):
+        """A REVIEW_DUPLICATE row whose pHash exactly matches the
+        Ref winner's renders 100% — same arithmetic as EXACT but
+        reached via the recomputation branch instead of the action
+        check, so this catches an off-by-one in the new code path.
+        """
+        dup = _rec(
+            action="REVIEW_DUPLICATE",
+            phash="abcdef0123456789",
+            hamming_distance=10,  # ignored
+        )
+        result = _file_similarity(
+            "REVIEW_DUPLICATE", dup, ref_phash="abcdef0123456789",
+        )
+        assert result == "100%"
+
+
+# ── _pick_ref_winner ───────────────────────────────────────────────────────
+
+
+class TestPickRefWinner:
+    """``_pick_ref_winner`` returns the items_list element that should
+    carry the "Ref" label. #253 changed the return type from id() to
+    the item itself so the caller can read ``winner.phash`` — the
+    score-aware tie-break itself must still match #241's behaviour.
+    """
+
+    def test_returns_none_when_no_ref_tier(self):
+        only_dups = [
+            _rec(file_path="/p/a.jpg", action="REVIEW_DUPLICATE"),
+            _rec(file_path="/p/b.jpg", action="EXACT"),
+        ]
+        assert _pick_ref_winner(only_dups) is None
+
+    def test_returns_the_winner_item_not_just_its_id(self):
+        """Regression guard for the API change: previous helper returned
+        ``id(item)``. Callers reading ``winner.phash`` would crash on an
+        int — this test pins that the returned value is the actual
+        record-shaped object.
+        """
+        ref_a = _rec(file_path="/p/a.jpg", action="MOVE", score=0.9, phash="aaaa")
+        ref_b = _rec(file_path="/p/b.jpg", action="MOVE", score=0.5, phash="bbbb")
+        winner = _pick_ref_winner([ref_a, ref_b])
+        assert winner is ref_a
+        assert getattr(winner, "phash") == "aaaa"
+
+    def test_score_winner_supersedes_lex_order(self):
+        """The #241 canonical case: two Ref-tier rows, the lex-first
+        (ref_b) loses to the higher-scored ref_a. With this in place,
+        ``build_model`` reads the higher-scored row's phash and that
+        becomes the basis for #253's render-time recomputation.
+        """
+        ref_a = _rec(file_path="/p/zzz.jpg", action="MOVE", score=0.9)
+        ref_b = _rec(file_path="/p/aaa.jpg", action="MOVE", score=0.5)
+        winner = _pick_ref_winner([ref_a, ref_b])
+        assert winner is ref_a
+
+
+# ── #253: build_model end-to-end against the displayed Ref ─────────────────
+
+
+class TestBuildModelSimilarityAgainstDisplayedRef:
+    """End-to-end through build_model: a group whose score-winner
+    differs from where the scanner would have anchored its
+    hamming_distance must render the REVIEW_DUPLICATE row's % against
+    the score-winner's phash. The stored hamming_distance is left in
+    place so old manifests still degrade gracefully, but it is NOT what
+    the user sees when phashes are available."""
+
+    def test_review_duplicate_pct_uses_score_winner_phash(self, qapp):
+        from app.views.constants import COL_GROUP, COL_NAME, PATH_ROLE
+        # Group: two Ref-tier rows (score-winner != lex-first) + one
+        # REVIEW_DUPLICATE whose stored hamming was measured against
+        # ref_low (the lex-first scanner anchor).
+        ref_high = _rec(
+            file_path="/p/ref_high.jpg",
+            action="MOVE",
+            score=0.9,
+            phash="0000000000000000",
+        )
+        ref_low = _rec(
+            file_path="/p/aaa_ref_low.jpg",  # lex-first
+            action="MOVE",
+            score=0.3,
+            phash="ffffffffffffffff",
+        )
+        # Stored hamming=63 vs ref_low (the scanner's anchor).
+        # Distance to the score-winner (ref_high) is 1 → should render 98%.
+        dup = _rec(
+            file_path="/p/dup.jpg",
+            action="REVIEW_DUPLICATE",
+            phash="0000000000000001",
+            hamming_distance=63,
+        )
+        model, _ = build_model([_group([ref_high, ref_low, dup])])
+        group_row = model.item(0, 0)
+        # Find the dup row by file path and read its similarity cell.
+        dup_sim = None
+        for r in range(group_row.rowCount()):
+            name_item = group_row.child(r, COL_NAME)
+            if name_item.data(PATH_ROLE) == "/p/dup.jpg":
+                dup_sim = group_row.child(r, COL_GROUP).text()
+        assert dup_sim == "98%", (
+            f"REVIEW_DUPLICATE row should render % against ref_high (score=0.9, "
+            f"distance=1 → 98%), not against ref_low (stored hamming=63 → 2%); "
+            f"got {dup_sim!r}"
+        )
 
 
 # ── _ACTION_SORT / _DECISION_SORT mappings ─────────────────────────────────


### PR DESCRIPTION
## Summary

- Recompute the REVIEW_DUPLICATE Similarity % at render time against the *displayed* Ref's pHash, not the scanner's anchor. After [#241](https://github.com/jackal998/photo-manager/issues/241) introduced score-aware tie-breaking, the two can diverge and "96% similar" became "similar to *what*?".
- New pure helper [`scanner/phash_distance.py`](../scanner/phash_distance.py) isolates `imagehash` so the renderer doesn't import scanner internals.
- `PhotoRecord` gains a `phash` field; `ManifestRepository.load` threads it from the existing `migration_manifest.phash` column.
- `_pick_ref_winner` now returns the winner item itself (was returning `id()`), so the caller can read its pHash.
- Old manifests pre-dating the phash column and rows without a pHash (video, RAW thumbnail failure) fall back to the scanner's stored `hamming_distance` so they degrade gracefully.

## Test plan

- [x] `pytest` — 1434 passed, 2 skipped, global coverage 88%.
- [x] `scripts/check_coverage_per_file.py` — 70% per-file floor clears on every touched file.
- [x] `python -m qa.scenarios._batch s52_similarity_against_displayed_ref` — passes locally.
- [x] Layer-1 divergence case (`TestBuildModelSimilarityAgainstDisplayedRef`) pins that a stored hamming=63 row renders 98% (vs displayed Ref distance=1), not the legacy 2%. Walking the fix back resurfaces the legacy value and the test catches it.
- [x] `TestPickRefWinner` pins the new return-type contract — callers reading `winner.phash` would crash on the previous `id()` return.

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)