### PR TITLE
docs(readme): list missing app/views helpers in project tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,12 +396,16 @@ photo-manager/
 │
 ├── app/                     # PySide6 GUI
 │   ├── views/
-│   │   ├── main_window.py         # Main window — wires all components
-│   │   ├── tree_model_builder.py  # Builds QStandardItemModel from groups
-│   │   ├── constants.py           # Column indices and header labels
-│   │   ├── preview_pane.py        # Image/video preview; grid + single-file modes
-│   │   ├── image_tasks.py         # Background image loading tasks
-│   │   ├── media_utils.py         # Media type helpers for the views layer
+│   │   ├── main_window.py             # Main window — wires all components
+│   │   ├── main_window_helpers.py     # Pure-logic helpers extracted from main_window (layer-1 testable)
+│   │   ├── tree_model_builder.py      # Builds QStandardItemModel from groups
+│   │   ├── constants.py               # Column indices and header labels
+│   │   ├── preview_pane.py            # Image/video preview; grid + single-file modes
+│   │   ├── preview_pane_helpers.py    # Pure-logic helpers extracted from preview_pane (layer-1 testable)
+│   │   ├── image_tasks.py             # Background image loading tasks
+│   │   ├── image_tasks_helpers.py     # Pure-logic token-format helpers extracted from image_tasks (layer-1 testable)
+│   │   ├── media_utils.py             # Media type helpers for the views layer
+│   │   ├── window_state.py            # Shared geometry persistence (MainWindow + dialogs)
 │   │   ├── components/
 │   │   │   ├── menu_controller.py      # Menu creation + "Set Action" submenu
 │   │   │   ├── status_messages.py      # Centralized status-bar copy formatter

--- a/news/315.doc
+++ b/news/315.doc
@@ -1,0 +1,1 @@
+List missing app/views helpers (main_window_helpers, preview_pane_helpers, image_tasks_helpers, window_state) in the README project tree.


### PR DESCRIPTION
## Summary

- Caught by `/update-docs` drift check during a whole-repo audit
- README's `## Project structure` block for `app/views/` was missing 4 files that exist in the codebase:
  - `main_window_helpers.py`, `preview_pane_helpers.py`, `image_tasks_helpers.py` (the layer-1-testable extraction pattern from #312 / #182 / #138 / #140 / #137)
  - `window_state.py` (shared geometry persistence from the #215 / #141 refactor)
- Surgical edit only — no other doc rewrites.

## Test plan

- [ ] Inspect rendered README on GitHub — verify the four files appear under `app/views/` at the right indentation
- [ ] No source / test changes → no pytest re-run needed; CI will still run anyway

🤖 Generated with [Claude Code](https://claude.com/claude-code)