### PR TITLE
chore(qa-explore): correct scenario count from 21 to 52

### DIFF
--- a/.claude/skills/qa-explore/SKILL.md
+++ b/.claude/skills/qa-explore/SKILL.md
@@ -133,11 +133,13 @@ If everything is already populated, skip the regen and move on.
 
 ## Phase 3 — Plan
 
-**Default behavior — invoked with no additional prompt:** run **all
-21 scenarios** in batch via `qa.scenarios._batch`. Don't print the
+**Default behavior — invoked with no additional prompt:** run **the
+full scenario batch** via `qa.scenarios._batch`. Don't print the
 menu, don't ask which to run. Get one `yes batch` approval up front
 (per the gate rule below) and proceed. The full batch typically
-finishes in ~30–60 seconds with the focus fix in `_uia.py`.
+finishes in a few minutes wall-clock (52 scenarios as of 2026-05-19
+— the canonical list lives at
+[`qa/scenarios/_batch.py:ALL_SCENARIOS`](../../../qa/scenarios/_batch.py)).
 
 **Invoked with hints** (e.g. `/qa-explore smoke`, `/qa-explore 1,2,9`,
 `/qa-explore failed 8`): respect the hint, run only the named subset,

--- a/.claude/skills/qa-explore/scenario-drivers.md
+++ b/.claude/skills/qa-explore/scenario-drivers.md
@@ -45,6 +45,12 @@ running.
 | 26 | Keyboard-only navigation: tree arrows, Alt+F mnemonic, scan dialog Tab cycle, Esc (#125) | `qa.scenarios.s26_keyboard_navigation` | ✓ ready |
 | 27 | Re-scan with pending decisions → confirmation prompt (#142) | `qa.scenarios.s27_rescan_confirm` | ✓ ready |
 
+The table above lists the original menu (s01–s27). The full set has
+grown well past it — see
+[`qa.scenarios._batch.ALL_SCENARIOS`](../../../qa/scenarios/_batch.py)
+or `Glob("qa/scenarios/s*.py")` for the canonical, always-current
+list. Don't trust this table for completeness; trust the directory.
+
 Several drivers also call cross-scenario invariant probes from
 `qa/scenarios/_invariants.py` — they assert that the status bar matches
 an expected shape after a manifest-changing action, that all
@@ -105,7 +111,7 @@ windows leak — document the residual in the driver header.
 in one go, use `qa.scenarios._batch`:
 
 ```
-.venv/Scripts/python.exe -m qa.scenarios._batch              # all 21 (s01–s21)
+.venv/Scripts/python.exe -m qa.scenarios._batch              # full sweep
 .venv/Scripts/python.exe -m qa.scenarios._batch s04_corrupted s09_walker_exclusions
 ```
 
@@ -113,11 +119,13 @@ For each scenario it: configures `qa/settings.json` → launches
 `main.py` → polls (ctypes `EnumWindows`) until the main window is
 visible (max 8 s; typically <2 s) → runs the driver → closes the
 window → waits for the subprocess to exit → moves to the next.
-Prints a final SUMMARY table with rc per scenario. The whole batch
-(21 scenarios) typically finishes in ~5–7 minutes (5m19s on
-`windows-latest` after the #133 poll change). Each app launch is
-still a real launch — get the user's "yes batch" once before
-starting.
+Prints a final SUMMARY table with rc per scenario. The full batch
+(52 scenarios as of 2026-05-19 — see
+[`qa.scenarios._batch.ALL_SCENARIOS`](../../../qa/scenarios/_batch.py)
+for the canonical list) typically finishes in a few minutes
+wall-clock locally and ~5 minutes per shard on CI's 5-way matrix.
+Each app launch is still a real launch — get the user's "yes batch"
+once before starting.
 
 **Optional optimization — skip the per-run Bash prompt.** Add this
 to `.allow` in `.claude/settings.json` so driver runs don't prompt:

--- a/news/319.doc
+++ b/news/319.doc
@@ -1,0 +1,1 @@
+Correct stale "21 scenarios / 30-60 seconds" claims in the qa-explore skill docs; point at qa.scenarios._batch.ALL_SCENARIOS as the canonical scenario list.


### PR DESCRIPTION
## Summary

Skill-doc drift caught by the whole-repo audit. `.claude/skills/qa-explore/SKILL.md` and `.claude/skills/qa-explore/scenario-drivers.md` both claimed the batch runs **21 scenarios** in **~30-60 seconds**. Reality:

- The canonical list in [`qa/scenarios/_batch.py:ALL_SCENARIOS`](qa/scenarios/_batch.py) has **52** entries.
- Local full-batch wall-clock is "a few minutes," not 30-60 seconds.
- The s01-s27 table in `scenario-drivers.md` was already stale; extending it to s52 is out of scope here.

## What changed

- Replace hard-coded "21" with "the full sweep" + a one-line "as of YYYY-MM-DD" qualifier
- Point readers at `qa.scenarios._batch.ALL_SCENARIOS` as the canonical source so the same drift can't silently recur
- Add an explicit "trust the directory, not this table" footer below the s01-s27 menu

## Why this matters

The skill is the prompt-injection surface every `/qa-explore` invocation reads. A stale "21 scenarios" claim teaches future agents the wrong default scope.

## Test plan

- [ ] Inspect rendered Markdown on GitHub
- [ ] No source / test changes — pure docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)