### PR TITLE
chore(qa-batch): label-based close-window selector (#325)

### DIFF
--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -45,6 +45,25 @@ from app.views.window_state import (
 from infrastructure.i18n import t
 
 
+# Button specs for the "Unsaved Changes" QMessageBox built in
+# :meth:`MainWindow.closeEvent`. Tuple order is the order buttons appear
+# in the dialog (left → right), which determines Tab traversal and is
+# load-bearing for the qa batch runner's close-window dance — see
+# :func:`qa.scenarios._close_window_helper.click_leave_button` and the
+# matching L1 test in tests/test_main_window.py.
+#
+# Each entry: (name, translation_key, ButtonRole). ``name`` is the
+# internal identifier closeEvent uses to look the button up after
+# constructing them; it intentionally does NOT depend on locale or
+# button text. ``"leave"`` is the only name external code (the qa
+# helper) needs to know about.
+EXIT_DIALOG_BUTTONS: tuple[tuple[str, str, QMessageBox.ButtonRole], ...] = (
+    ("save", "exit.button_save_leave", QMessageBox.AcceptRole),
+    ("leave", "exit.button_leave", QMessageBox.DestructiveRole),
+    ("back", "exit.button_back", QMessageBox.RejectRole),
+)
+
+
 class MainWindow(QMainWindow):
     """Main application window with refactored architecture.
 
@@ -705,9 +724,15 @@ class MainWindow(QMainWindow):
         box.setIcon(QMessageBox.Warning)
         box.setWindowTitle(t("exit.confirm_title"))
         box.setText(t("exit.confirm_body"))
-        btn_save = box.addButton(t("exit.button_save_leave"), QMessageBox.AcceptRole)
-        btn_leave = box.addButton(t("exit.button_leave"), QMessageBox.DestructiveRole)
-        btn_back = box.addButton(t("exit.button_back"), QMessageBox.RejectRole)
+        # Iterate over the module-level spec so the qa helper and the
+        # closeEvent body cannot disagree about button order/roles.
+        buttons_by_name = {
+            name: box.addButton(t(key), role)
+            for name, key, role in EXIT_DIALOG_BUTTONS
+        }
+        btn_save = buttons_by_name["save"]
+        btn_leave = buttons_by_name["leave"]
+        btn_back = buttons_by_name["back"]
         # Default to Back so an accidental Enter/Esc keeps the user in the app.
         box.setDefaultButton(btn_back)
         box.exec()

--- a/news/338.misc
+++ b/news/338.misc
@@ -1,0 +1,1 @@
+Replace the qa batch runner's Tab+Tab+Enter positional close with a UIA label-based selector, and extract `MainWindow.closeEvent`'s "Unsaved Changes" button list into a module-level spec pinned by L1 tests so a future button-order reorder fails fast instead of silently leaking "app did not exit cleanly, terminating" (#325).

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -248,6 +248,33 @@ def select_shard(
     return [name for unit in selected_units for name in unit]
 
 
+def _resolve_exit_button_labels() -> tuple[str, str]:
+    """Resolve the localised ``("Leave" button, "Unsaved Changes" title)``
+    pair for the locale currently persisted in ``qa/settings.json``.
+
+    Reading the locale at parent-process time (here) keeps the
+    subprocess helper free of YAML/Qt imports at startup, and means
+    locale switches by previous scenarios (e.g. s22_language_switch
+    runs but doesn't fully restore) don't make the close-window dance
+    look for "Leave" when the running app actually shows "離開". On any
+    failure we fall back to the English strings — that matches the
+    pre-#325 behaviour exactly, so the worst case is "no worse than
+    before" rather than "broken differently".
+    """
+    try:
+        from infrastructure.i18n import init_translator
+        from infrastructure.settings import JsonSettings
+
+        home_env = os.environ.get("PHOTO_MANAGER_HOME") or ""
+        config_home = (REPO / home_env).resolve() if home_env else REPO
+        settings = JsonSettings(config_home / "settings.json")
+        locale = settings.get("ui.locale", "en") or "en"
+        translator = init_translator(locale, REPO / "translations")
+        return translator.t("exit.button_leave"), translator.t("exit.confirm_title")
+    except Exception:
+        return "Leave", "Unsaved Changes"
+
+
 def _close_window() -> None:
     """Close the Photo Manager top window; dismiss the dirty prompt if it fires.
 
@@ -266,69 +293,31 @@ def _close_window() -> None:
     is "save first if you want a SEPARATE manifest file" — irrelevant
     in batch mode.
 
-    Implementation note: we use ``PostMessage(WM_CLOSE)`` via ctypes
-    instead of pywinauto's ``top_window().close()``. The pywinauto call
-    drives the UIA Window pattern's Close, which is synchronous and
-    blocks while the modal QMessageBox runs — leaving us no chance to
-    click Leave. PostMessage is fire-and-forget, so the close request
-    queues, Qt fires closeEvent, the dialog opens, and we get a window
-    of time to dismiss it.
-
-    The Leave click is done via ``PostMessage(WM_KEYDOWN, VK_TAB)`` +
-    ``VK_RETURN`` rather than via pywinauto's UIA selectors because the
-    QMessageBox dialog doesn't surface in UIA's top-level window list
-    until after some refresh — pywinauto's ``connect(title='Unsaved
-    Changes')`` empirically times out even when ``EnumWindows`` sees
-    the dialog. The Tab+Tab+Enter sequence relies on the button-add
-    order in :meth:`MainWindow.closeEvent` — Save & leave (AcceptRole),
-    Leave (DestructiveRole), Back (RejectRole, default focus). Tab
-    twice from Back lands on Leave; Enter clicks it.
+    Implementation moved to :mod:`qa.scenarios._close_window_helper`
+    (#325). The helper uses pywinauto's UIA backend with
+    ``connect(handle=...)`` to look up the Leave button by its display
+    text rather than by Tab-traversal position, which was load-bearing
+    on ``MainWindow.closeEvent`` button order — a future reorder used
+    to silently route Enter to the wrong button. ``EnumWindows`` +
+    ``WM_CLOSE`` are kept (in the helper) because pywinauto's
+    ``top_window().close()`` is synchronous and blocks while the modal
+    runs, leaving no chance to click Leave.
     """
-    code = (
-        "import sys, time, ctypes\n"
-        "from ctypes import wintypes\n"
-        "user32 = ctypes.windll.user32\n"
-        "WM_CLOSE = 0x0010\n"
-        "WM_KEYDOWN = 0x0100\n"
-        "WM_KEYUP = 0x0101\n"
-        "VK_TAB = 0x09\n"
-        "VK_RETURN = 0x0D\n"
-        "WNDENUMPROC = ctypes.WINFUNCTYPE("
-        "ctypes.c_int, wintypes.HWND, wintypes.LPARAM)\n"
-        "found = []\n"
-        "def cb(hwnd, _):\n"
-        "    if not user32.IsWindowVisible(hwnd):\n"
-        "        return True\n"
-        "    title = ctypes.create_unicode_buffer(256)\n"
-        "    user32.GetWindowTextW(hwnd, title, 256)\n"
-        "    if 'Photo Manager' in title.value:\n"
-        "        found.append(hwnd)\n"
-        "    return True\n"
-        "user32.EnumWindows(WNDENUMPROC(cb), 0)\n"
-        "for hwnd in found:\n"
-        "    user32.PostMessageW(hwnd, WM_CLOSE, 0, 0)\n"
-        "time.sleep(0.7)\n"
-        "dlg_hwnds = []\n"
-        "def cb2(hwnd, _):\n"
-        "    if not user32.IsWindowVisible(hwnd):\n"
-        "        return True\n"
-        "    title = ctypes.create_unicode_buffer(256)\n"
-        "    user32.GetWindowTextW(hwnd, title, 256)\n"
-        "    if title.value == 'Unsaved Changes':\n"
-        "        dlg_hwnds.append(hwnd)\n"
-        "    return True\n"
-        "user32.EnumWindows(WNDENUMPROC(cb2), 0)\n"
-        "for dlg in dlg_hwnds:\n"
-        "    user32.SetForegroundWindow(dlg)\n"
-        "    time.sleep(0.15)\n"
-        "    for _ in range(2):\n"
-        "        user32.PostMessageW(dlg, WM_KEYDOWN, VK_TAB, 0)\n"
-        "        user32.PostMessageW(dlg, WM_KEYUP, VK_TAB, 0)\n"
-        "        time.sleep(0.05)\n"
-        "    user32.PostMessageW(dlg, WM_KEYDOWN, VK_RETURN, 0)\n"
-        "    user32.PostMessageW(dlg, WM_KEYUP, VK_RETURN, 0)\n"
+    leave_label, dialog_title = _resolve_exit_button_labels()
+    subprocess.run(
+        [
+            PY,
+            "-m",
+            "qa.scenarios._close_window_helper",
+            "--leave-label",
+            leave_label,
+            "--dialog-title",
+            dialog_title,
+        ],
+        cwd=REPO,
+        capture_output=True,
+        timeout=15,
     )
-    subprocess.run([PY, "-c", code], cwd=REPO, capture_output=True, timeout=15)
 
 
 _user32 = ctypes.windll.user32
@@ -502,7 +491,7 @@ def run_one(name: str) -> tuple[int, str]:
             driver_err = "non-zero exit"
     except subprocess.TimeoutExpired as exc:
         driver_err = "driver timeout"
-        print(f"DRIVER TIMEOUT after 180s", flush=True)
+        print("DRIVER TIMEOUT after 180s", flush=True)
         # Surface whatever the driver printed before hanging — by default
         # TimeoutExpired drops it on the floor, which makes hangs
         # essentially undebuggable from CI logs.
@@ -526,7 +515,7 @@ def run_one(name: str) -> tuple[int, str]:
     try:
         proc.wait(timeout=8)
     except subprocess.TimeoutExpired:
-        print(f"app did not exit cleanly, terminating", flush=True)
+        print("app did not exit cleanly, terminating", flush=True)
         proc.terminate()
         try:
             proc.wait(timeout=5)

--- a/qa/scenarios/_close_window_helper.py
+++ b/qa/scenarios/_close_window_helper.py
@@ -1,0 +1,219 @@
+"""Subprocess entry point that closes the running photo-manager window.
+
+Invoked by :func:`qa.scenarios._batch._close_window` at the tail end of
+every scenario run. Lives in its own module (not embedded as a code
+string) so it can be lint-checked, type-checked, and unit-tested
+directly — the previous implementation was a ~40-line string passed
+to ``python -c`` which silently rotted when ``MainWindow.closeEvent``
+reordered its buttons (see #325).
+
+The subprocess shape is preserved (rather than calling the helper
+in-process from ``_batch.py``) because pywinauto state has historically
+been touchy across re-uses inside a single Python session — isolating
+each close-window invocation in its own process is the cheapest way to
+keep the batch runner deterministic.
+
+Usage::
+
+    python -m qa.scenarios._close_window_helper --leave-label "Leave"
+
+The ``--leave-label`` is the *display text* of the "Leave" button as
+rendered in the running app's current locale (``"Leave"`` for ``en``,
+``"離開"`` for ``zh_TW``). The batch runner resolves it once via the
+i18n catalog against the persisted ``ui.locale`` and passes it in
+verbatim — the subprocess does no translation work itself, which keeps
+it free of YAML / Qt imports at startup.
+
+Failure mode is deliberately silent (no non-zero exit code) because
+``_close_window`` is best-effort cleanup. If we cannot find the dialog
+or the button, the batch runner will fall through to ``proc.wait()``,
+time out, and force-terminate the child — same as the legacy
+"Tab+Tab+Enter then maybe kill" path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import ctypes
+import ctypes.wintypes
+import sys
+import time
+
+_user32 = ctypes.windll.user32
+
+WM_CLOSE = 0x0010
+WM_KEYDOWN = 0x0100
+WM_KEYUP = 0x0101
+VK_TAB = 0x09
+VK_RETURN = 0x0D
+
+_WNDENUMPROC = ctypes.WINFUNCTYPE(
+    ctypes.c_int, ctypes.wintypes.HWND, ctypes.wintypes.LPARAM
+)
+
+
+def _enum_visible_windows() -> list[tuple[int, str]]:
+    """Return (hwnd, window_text) pairs for every visible top-level window."""
+    out: list[tuple[int, str]] = []
+
+    def cb(hwnd, _):
+        if not _user32.IsWindowVisible(hwnd):
+            return True
+        buf = ctypes.create_unicode_buffer(256)
+        _user32.GetWindowTextW(hwnd, buf, 256)
+        out.append((hwnd, buf.value))
+        return True
+
+    _user32.EnumWindows(_WNDENUMPROC(cb), 0)
+    return out
+
+
+def _find_window_containing(needle: str) -> list[int]:
+    return [h for h, title in _enum_visible_windows() if needle in title]
+
+
+def _find_window_exact(title: str) -> list[int]:
+    return [h for h, t in _enum_visible_windows() if t == title]
+
+
+def close_main_window() -> None:
+    """Send WM_CLOSE to every visible 'Photo Manager' top-level window.
+
+    Fire-and-forget. Qt translates WM_CLOSE into ``closeEvent``, which
+    either accepts (if the manifest is clean) or pops the "Unsaved
+    Changes" QMessageBox.
+    """
+    for hwnd in _find_window_containing("Photo Manager"):
+        _user32.PostMessageW(hwnd, WM_CLOSE, 0, 0)
+
+
+def _wait_for_dialog(title: str, timeout: float) -> int | None:
+    """Poll EnumWindows until a window with exactly ``title`` appears."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        hwnds = _find_window_exact(title)
+        if hwnds:
+            return hwnds[0]
+        time.sleep(0.1)
+    return None
+
+
+def click_leave_button(dlg_hwnd: int, leave_label: str) -> bool:
+    """Click the "Leave" button on the Unsaved Changes dialog by label.
+
+    Uses pywinauto's UIA backend via ``connect(handle=...)`` (NOT
+    ``connect(title=...)`` — the title-based connect empirically times
+    out on QMessageBox even when EnumWindows already sees the dialog).
+    Once connected, enumerate every descendant control and click the
+    first ``Button`` whose visible text equals ``leave_label``.
+
+    Returns ``True`` on a successful click, ``False`` if no matching
+    button was found or pywinauto errored.
+
+    Note on Qt + Win32: QMessageBox child buttons are not real Win32
+    HWND children — Qt composite widgets share their parent's HWND. So
+    ``EnumChildWindows(dlg_hwnd, …)`` returns empty here. UIA sees them
+    fine because Qt exposes them through the UI Automation provider.
+    """
+    try:
+        from pywinauto import Application
+    except ImportError:
+        return False
+
+    try:
+        app = Application(backend="uia").connect(handle=dlg_hwnd, timeout=3)
+        dlg = app.window(handle=dlg_hwnd)
+        # ``descendants(control_type="Button")`` finds the buttons even
+        # though they aren't HWND children, because UIA flattens the
+        # tree across the Qt accessibility bridge.
+        for btn in dlg.descendants(control_type="Button"):
+            try:
+                if btn.window_text() == leave_label:
+                    btn.click_input()
+                    return True
+            except Exception:
+                continue
+    except Exception:
+        return False
+    return False
+
+
+def fallback_tab_enter(dlg_hwnd: int) -> None:
+    """Legacy Tab+Tab+Enter sequence used when label-based click fails.
+
+    Preserved as a last resort so transient pywinauto/UIA failures
+    don't regress us below the previous behaviour. Relies on the
+    button order in ``EXIT_DIALOG_BUTTONS`` (save / leave / back) with
+    Back focused by default — Tab Tab from Back lands on Leave; Enter
+    clicks it. If that order ever changes, the L1 test in
+    ``tests/test_main_window.py::TestExitDialogButtonsConstant`` fires
+    and this fallback should be updated alongside.
+    """
+    _user32.SetForegroundWindow(dlg_hwnd)
+    time.sleep(0.15)
+    for _ in range(2):
+        _user32.PostMessageW(dlg_hwnd, WM_KEYDOWN, VK_TAB, 0)
+        _user32.PostMessageW(dlg_hwnd, WM_KEYUP, VK_TAB, 0)
+        time.sleep(0.05)
+    _user32.PostMessageW(dlg_hwnd, WM_KEYDOWN, VK_RETURN, 0)
+    _user32.PostMessageW(dlg_hwnd, WM_KEYUP, VK_RETURN, 0)
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        prog="python -m qa.scenarios._close_window_helper",
+        description=(
+            "Close the running photo-manager window and dismiss the "
+            "'Unsaved Changes' dialog by clicking the Leave button."
+        ),
+    )
+    parser.add_argument(
+        "--leave-label",
+        required=True,
+        help=(
+            "Display text of the Leave button in the running app's locale "
+            "(e.g. 'Leave' for en, '離開' for zh_TW)."
+        ),
+    )
+    parser.add_argument(
+        "--dialog-title",
+        default="Unsaved Changes",
+        help=(
+            "Win32 window title of the dirty-state dialog. Defaults to "
+            "the en string; pass the localised title (e.g. '尚未儲存的變更') "
+            "when running under non-en locales."
+        ),
+    )
+    parser.add_argument(
+        "--settle",
+        type=float,
+        default=2.5,
+        help=(
+            "Seconds to wait for the dialog to appear after WM_CLOSE. "
+            "The original 1.0s wasn't enough on slower runners — 2-3s "
+            "is the sweet spot per the issue notes (#325)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    close_main_window()
+    dlg_hwnd = _wait_for_dialog(args.dialog_title, timeout=args.settle)
+    if dlg_hwnd is None:
+        # No dirty prompt fired (manifest was clean, or app already
+        # exited). Nothing to dismiss; let the batch runner's
+        # proc.wait() see a clean exit.
+        return 0
+
+    if click_leave_button(dlg_hwnd, args.leave_label):
+        return 0
+
+    # UIA click didn't work — fall back to the positional sequence
+    # rather than leaking the process. This is the legacy behaviour
+    # and is documented as a known-fragile path that will be flagged
+    # by the L1 button-order test if it ever silently breaks.
+    fallback_tab_enter(dlg_hwnd)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1157,3 +1157,113 @@ def test_on_tree_selection_changed_uses_proxy_mapping_when_proxy_present():
 
     fake_proxy.mapToSource.assert_called_once_with(view_idx)
     fake_preview.show_single.assert_called_once()
+
+
+class TestExitDialogButtonsConstant:
+    """Pin the ``EXIT_DIALOG_BUTTONS`` spec used by ``MainWindow.closeEvent``.
+
+    The qa batch runner (``qa/scenarios/_close_window_helper.py``)
+    looks up the "Leave" button by its display text. If a future PR
+    reorders / renames / removes entries in ``EXIT_DIALOG_BUTTONS``
+    the runner's label-based click can break silently — the symptom
+    is qa scenarios printing "app did not exit cleanly, terminating"
+    again, exactly the regression #325 fixed.
+
+    These tests cost ~0ms — they import a tuple and check its shape,
+    no Qt event loop, no QMessageBox instance. The metric-gaming
+    rejection in CLAUDE.md applies to *defensive branches* not to
+    real-bug probes; this one catches a documented past regression
+    class, so it earns its keep.
+    """
+
+    def test_constant_lists_exactly_three_buttons_in_dialog_order(self) -> None:
+        """save → leave → back is the order ``MainWindow.closeEvent``
+        adds buttons and the order Qt renders them left-to-right. The
+        qa helper's positional ``fallback_tab_enter`` (Tab Tab Enter
+        from default-focused Back) only works if Leave sits at index 1.
+        """
+        from app.views.main_window import EXIT_DIALOG_BUTTONS
+
+        names = [name for name, _key, _role in EXIT_DIALOG_BUTTONS]
+        assert names == ["save", "leave", "back"], (
+            f"EXIT_DIALOG_BUTTONS order changed: got {names!r} — update "
+            "qa/scenarios/_close_window_helper.py::fallback_tab_enter "
+            "to match, then update this test."
+        )
+
+    def test_leave_button_carries_destructive_role(self) -> None:
+        """``DestructiveRole`` is what tells QMessageBox to render the
+        button with the "irreversible action" affordance (different
+        styling on some platforms). The qa helper doesn't read role
+        directly, but a reviewer eyeballing the dialog should see
+        save=accept, leave=destructive, back=reject — losing
+        DestructiveRole on Leave would change the visible UI without
+        any other test catching it.
+        """
+        from PySide6.QtWidgets import QMessageBox
+
+        from app.views.main_window import EXIT_DIALOG_BUTTONS
+
+        leave_entry = next(
+            entry for entry in EXIT_DIALOG_BUTTONS if entry[0] == "leave"
+        )
+        assert leave_entry[1] == "exit.button_leave"
+        assert leave_entry[2] == QMessageBox.DestructiveRole
+
+    def test_translation_keys_resolve_to_non_empty_strings_in_both_locales(self) -> None:
+        """Every translation key in the spec must resolve to a non-
+        empty display string in both ``en`` and ``zh_TW`` — otherwise
+        the qa runner would look up an empty-string button label and
+        match nothing. This is the regression class #325 is *prevent-
+        ing*: silent label drift between the constant and translations.
+        """
+        from pathlib import Path
+
+        from app.views.main_window import EXIT_DIALOG_BUTTONS
+        from infrastructure.i18n import Translator
+
+        translations_dir = Path(__file__).resolve().parents[1] / "translations"
+        for locale in ("en", "zh_TW"):
+            translator = Translator(locale, translations_dir)
+            for name, key, _role in EXIT_DIALOG_BUTTONS:
+                resolved = translator.t(key)
+                assert resolved and resolved != key, (
+                    f"{key!r} (button {name!r}) didn't resolve in {locale!r}: "
+                    f"got {resolved!r} — translations/{locale}.yml may be "
+                    "missing the key."
+                )
+
+    def test_close_event_body_uses_the_constant_not_inline_addbutton_calls(self) -> None:
+        """The whole point of extracting ``EXIT_DIALOG_BUTTONS`` is
+        that ``closeEvent`` reads from it. If a future PR inlines
+        ``box.addButton(t("exit.button_leave"), ...)`` again, the
+        constant becomes a lie. Catch that by parsing the source.
+
+        This is a source-level check, not a behaviour check, but the
+        behaviour version (real QMessageBox, real exec()) would cost
+        ~25s per run and need a qapp fixture — far above the value of
+        what's being asserted.
+        """
+        import inspect
+
+        from app.views.main_window import MainWindow
+
+        source = inspect.getsource(MainWindow.closeEvent)
+        # The pre-#325 body called addButton(t("exit.button_leave"), ...)
+        # inline three times. Forbid that exact pattern as a regression
+        # tripwire — closeEvent should iterate over the constant.
+        assert "EXIT_DIALOG_BUTTONS" in source, (
+            "closeEvent no longer references EXIT_DIALOG_BUTTONS — if you "
+            "removed the constant on purpose, also remove this test and "
+            "update qa/scenarios/_close_window_helper.py's docstring."
+        )
+        # An explicit inline 't(\"exit.button_' call inside closeEvent
+        # (beyond the dialog title/body) would mean someone added a
+        # button outside the constant — that's the drift we want to
+        # block.
+        for forbidden_key in ("exit.button_save_leave", "exit.button_leave", "exit.button_back"):
+            assert forbidden_key not in source, (
+                f"closeEvent contains a hard-coded reference to "
+                f"{forbidden_key!r}. Move it into EXIT_DIALOG_BUTTONS so "
+                "the qa helper's label-based selector stays in sync."
+            )


### PR DESCRIPTION
## Summary
- Replace Tab+Tab+Enter positional close in `qa/scenarios/_batch.py` with a UIA label-based lookup ("Leave" button by display text, resolved from the persisted locale so zh_TW works too).
- Extract `MainWindow.closeEvent`'s three `QMessageBox` buttons into a module-level `EXIT_DIALOG_BUTTONS` tuple and pin order + roles with fast L1 tests.
- Move the subprocess close-window logic from an inline `python -c` string into a real module (`qa/scenarios/_close_window_helper.py`) so it can be lint/type-checked.

`QMessageBox` child buttons aren't real Win32 `HWND` children, so the issue's `EnumChildWindows` suggestion would have returned empty here — the helper's docstring explains why and the implementation goes straight to UIA via `connect(handle=…)`. Tab+Tab+Enter is preserved as a documented fallback if UIA fails transiently.

Closes #325.

## Test plan
- [x] `pytest tests/` — all 45 tests in `test_main_window.py` pass; full suite green (88% coverage, per-file floor 70% clear).
- [x] `ruff check` — clean on the four files touched (one pre-existing `B023` in `qa/_batch.py` from #320 left alone).
- [x] `docs_guard.py` + `qa_scenario_guard.py` — no findings.
- [x] `/pr-review` (preview) — CLEAN, 0 ✗ 0 ⚠ 0 ℹ. No behaviour-bearing files (refactor + qa infra + tests).
- [ ] qa-batch workflow on this PR — to be verified by CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)