### PR TITLE
chore(skill): add Phase 5 post-PR completion to /work

### DIFF
--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -34,6 +34,15 @@ to grep-only resolution" and treat the input as free-text instead.
 If multiple issues: fan-out to one researcher-agent invocation per
 issue (parallel), merge briefs before planning.
 
+**File-overlap check (multi-issue only).** Before recommending the
+multi-issue parallel-sessions path in Phase 2, scan each researcher
+brief's `affected_files` list. If any two issues touch the same file,
+**force sequential-in-single-session** instead of parallel fan-out —
+parallel sessions on overlapping files cause merge conflicts that
+cost more than the parallelism saves. The Phase 3 plan should call
+this out explicitly: "issues #N and #M both touch `<file>` →
+sequencing in this session in order: #X → #Y → #Z."
+
 ## Phase 1 — spawn researcher-agent
 
 Invoke `researcher-agent` as a subagent. Pass the resolved task spec
@@ -170,13 +179,146 @@ Execute the approved workflow. Route based on complexity score:
 5. Run `/pr-review team` if diff qualifies (> 5 behaviour-bearing files
    or > 300 lines); otherwise `/pr-review` single-session.
 
-### multi-issue — fan out
+### multi-issue — fan out OR sequence
+
+If Phase 2's file-overlap check found **no overlap**: parallel fan-out.
 
 1. Run `/parallel-brief-generator` with the list of issue numbers.
 2. Each generated brief becomes a self-contained prompt for a separate
    Desktop session.
 3. Emit the briefs and stop — parallel Desktop sessions are
    human-initiated.
+
+If overlap **was** found: sequence in this session.
+
+1. Pick an order (smallest blast-radius first usually wins —
+   reduces rebase pain on the larger PRs).
+2. Run Phase 4's simple/medium or complex path for the first issue
+   end-to-end, including Phase 5 (Post-PR completion). Don't start
+   the next issue until the previous PR's CI is green or the human
+   explicitly says to proceed.
+3. Repeat for each remaining issue. The branch base for issue #2 is
+   the **merged** main branch, not the open PR — wait for human
+   merge before starting #2.
+
+## Phase 5 — Post-PR completion
+
+Phase 5 starts the moment `gh pr create` returns a PR URL — i.e.
+right after the human approves the `gh pr create` gate that flows
+out of Phase 4's `/pr-review` step. The simple, medium, and complex
+paths all funnel through Phase 5. Multi-issue fan-out skips Phase 5
+(each parallel session runs its own).
+
+Phase 5's exit condition is **CI green on the open PR**, not "PR
+opened" — the leak this section closes is the post-`gh pr create`
+tail that today gets improvised into ad-hoc follow-up commits
+(news fragment, CI-failure fix-up, etc.).
+
+### 5.1 — Capture PR number
+
+`gh pr create`'s stdout is the PR URL. Parse the trailing integer:
+`https://github.com/<owner>/<repo>/pull/<N>` → N. Store as `$PR`.
+
+### 5.2 — Write news fragment inline
+
+The repo's CI requires `news/<PR>.<type>` matching the type table in
+`news/README.md`. Steps:
+
+1. Read the head commit's conventional-commits type:
+   ```bash
+   git log -1 --format=%s | grep -oE '^(feat|fix|docs|chore|test|refactor|perf|ci|build|revert)'
+   ```
+2. Map conventional-commits type → news fragment suffix
+   (canonical table in [`news/README.md`](../../../news/README.md)):
+   `feat → feature`, `fix → bugfix`, `docs → doc`,
+   `chore → misc`, `refactor → misc`, `test → misc`,
+   `perf → misc`, `ci → misc`, `build → misc`,
+   `revert → misc`. Breaking schema changes or removed features
+   that don't fit any cc type → `removal` (judge by content, not
+   commit prefix).
+3. Write `news/<PR>.<type>` with a one-line imperative-mood
+   description ending in `(#<issue>)`. The text should be derived
+   from the PR title / commit message — not invented fresh.
+4. Don't ask the human to confirm the fragment text unless the
+   PR title is ambiguous (single-issue, well-titled PR → just write
+   it).
+5. **Skip-news bypass.** If the PR body or title contains the
+   literal token `[skip-news: <reason>]`, the news-gate CI check
+   passes without a fragment. Don't write one in that case — Phase
+   5.2 is a no-op and Phase 5.3's commit/push is skipped.
+
+### 5.3 — Commit and push the fragment
+
+```bash
+git add news/<PR>.<type>
+git commit -m "docs(news): add fragment for #<issue>"
+```
+
+Then surface the push gate per CLAUDE.md (mandatory; news-fragment
+push is still a `git push`):
+
+> **Gated action — `git push` (news fragment)**
+> - What: push the news-fragment commit to `origin/<branch>`.
+> - Risk: single-line text file, no secrets, additive.
+> - Verdict: safe.
+
+After "yes": `git push`.
+
+### 5.4 — Watch CI with timeout
+
+```bash
+gh pr checks <PR> --watch --interval 30
+```
+
+Wrap in a Bash call with `timeout: 1200000` (20 minutes). Known
+flakiness: the `--watch` listener can stall silently. If Bash
+returns from the timeout instead of from the `gh` exit, fall through
+to step 5.5's **timeout** branch and surface the current state from
+a one-shot `gh pr checks <PR>`.
+
+The user may also interrupt the watch manually (Ctrl-C / "stop").
+Treat that the same as the timeout branch — re-fetch state and
+surface, don't loop on watch.
+
+### 5.5 — Branch on CI result
+
+**Green** — `gh pr checks --watch` exits 0:
+> Emit one line: `PR #<N> CI green — ready for human review.`
+> EXIT Phase 5. /work is done.
+
+**Red** — `gh pr checks --watch` exits non-zero:
+1. Run `gh pr checks <PR> --output json` to enumerate failed checks
+   with their names and conclusions.
+2. Classify the failure: lint? unit test? `require-news-fragment`?
+   integration? Each class has a known fix recipe.
+3. **One auto-iteration** only — fetch the relevant log
+   (`gh run view <run-id> --log-failed`), implement the fix, commit,
+   surface push gate, push.
+4. After the iteration's push: loop back to step 5.4 ONCE. If the
+   second `--watch` returns red again, EXIT Phase 5 with:
+   > `CI failed after 1 auto-iteration on PR #<N>. Failing checks:
+   > <list>. Surfacing for human review — fix manually or say
+   > "retry" to attempt another auto-iteration.`
+5. Hard limit: never auto-iterate more than once per Phase 5 entry.
+   The 4-cycle dev↔QA limit in the complex path is independent.
+
+**Timeout / interrupt** — Bash killed the watch:
+1. One-shot `gh pr checks <PR>` to get current state.
+2. Surface:
+   > `Watch timed out at 20min on PR #<N>. Current checks: <state>.
+   > Resume the watch ("/work watch #<N>") or surface now.`
+3. EXIT Phase 5 — don't loop. The user decides whether to wait.
+
+### 5.6 — `/work watch <N>` resume mode (Phase 0 extension)
+
+To support the timeout/interrupt case, Phase 0 also accepts:
+
+| Input shape | How to resolve |
+|---|---|
+| `watch #N` or `watch <N>` | **Skip Phases 1–4 entirely.** Re-enter Phase 5 at step 5.4 for PR `<N>`. No researcher, no plan, no implementation. |
+
+This is the "I had to step away mid-watch" affordance the listener
+flakiness makes necessary.
 
 ## Self-management rules
 
@@ -210,13 +352,25 @@ them unless the human says to.
   auto-declines anyway, but don't waste the spawn attempt.
 - ✗ Don't fan out to parallel Desktop sessions for a single issue —
   that's only for truly independent multi-issue work.
+- ✗ Don't declare /work done at "PR opened" — Phase 5's exit condition
+  is CI green or a surfaced failure after one auto-iteration. PR-open-
+  and-hope is the leak this skill is built to close.
+- ✗ Don't loop on `--watch` after a timeout. The listener is known
+  flaky; loop guard is one watch + one one-shot status read, then
+  exit with the resume hint.
+- ✗ Don't fan out multi-issue tasks in parallel sessions when the
+  briefs show file overlap — sequence them in a single session
+  instead. Parallel sessions on shared files cost more in merge
+  conflicts than they save in latency.
 
 ## Invocation examples
 
 ```
 /work #257                     → simple: 2 doc edits, LEAD handles directly
-/work #326                     → complex: 35 features.md entries to verify
+/work #326                     → medium: ~30 features.md entries to verify
 /work "add dark mode"          → medium: researcher maps affected files first
-/work #323 #324 #325           → multi-issue: fan out to 3 parallel sessions
+/work #323 #324 #325           → multi-issue, no overlap: fan out to 3 parallel sessions
+/work #324 #325 #326           → multi-issue, file overlap on _batch.py: sequence in this session
 /work feature/my-branch        → review only: skip research, go to /pr-review
+/work watch #342               → resume Phase 5 watch on PR #342 (timeout/interrupt recovery)
 ```

--- a/news/343.misc
+++ b/news/343.misc
@@ -1,0 +1,1 @@
+Add Phase 5 (post-PR completion) to the `/work` skill — inline news-fragment write, `gh pr checks --watch` with 20-min timeout, one auto-iteration on red, `/work watch <N>` resume mode for listener-flakiness recovery, plus a Phase 2 file-overlap check that forces multi-issue tasks with shared files to sequence in a single session (#343).


### PR DESCRIPTION
## Summary

Close the post-`gh pr create` leak surfaced in this session's `/work` retro (three PRs in a row hit the same chicken-and-egg news-fragment dance + ad-hoc CI fix-ups). New **Phase 5 — Post-PR completion** runs from the moment `gh pr create` returns until CI is green or one auto-iteration has surfaced a failure for human review.

Also adds a Phase 2 file-overlap check so multi-issue tasks like this session's `#324 #325 #326` (all touching `qa/scenarios/_batch.py`) sequence in a single session by spec, instead of by improvisation.

## What's new in Phase 5

| Step | Action |
|---|---|
| 5.1 | Parse PR number from `gh pr create` URL |
| 5.2 | Write `news/<N>.<type>` inline (cc-type → suffix table; respects `[skip-news: ...]`) |
| 5.3 | Commit + push the fragment through the standard CLAUDE.md push gate |
| 5.4 | `gh pr checks --watch` with **20-min hard timeout** (documented listener flakiness) |
| 5.5 | Green → exit; red → ONE auto-iteration then surface; timeout → re-fetch state, surface, exit |
| 5.6 | `/work watch <N>` resume mode for the "I had to step away mid-watch" case |

## Decisions documented in the skill

- **No `/goal` dependency.** Most-documented Anthropic pattern for CI waits, but block-and-iterate was picked instead so `/work` stays self-contained (per [goal.md](https://code.claude.com/docs/en/goal.md) research).
- **No PostToolUse hook for news fragments.** Feasible per [hooks.md](https://code.claude.com/docs/en/hooks.md), but inline-step is simpler and survives without per-machine hook wiring. Hook approach can be re-evaluated after a few PRs of inline experience.
- **One auto-iteration cap.** Zero defeats the purpose; unlimited risks the runaway pattern the existing 4-cycle dev↔QA guard already addresses elsewhere.

## File sizes

- Before: 223 lines
- After: 376 lines
- Anthropic soft cap: 500 lines (per [skills.md](https://code.claude.com/docs/en/skills.md))

## Test plan

- [ ] Skill is self-documenting — no code execution to verify. Next `/work` invocation that opens a PR will exercise Phase 5 in production.
- [ ] `require-news-fragment` CI gate passes (`news/<N>.misc` added in follow-up commit per Phase 5.2 of the new spec — yes, this PR dogfoods itself).
- [ ] No `docs_guard` / `qa_scenario_guard` triggers — skill-only, no behaviour-bearing files touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)