### PR TITLE
fix(main-window): batch post-scan keeper selection to one .select() call (#344)

### DIFF
--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -549,7 +549,7 @@ class MainWindow(QMainWindow):
         post-scan highlight (#239). Generalises :meth:`_reselect_by_path`
         from single- to multi-target selection.
         """
-        from PySide6.QtCore import QItemSelectionModel
+        from PySide6.QtCore import QItemSelection, QItemSelectionModel
 
         from app.views.main_window_helpers import find_paths_in_model
 
@@ -560,12 +560,18 @@ class MainWindow(QMainWindow):
         if sel_model is None:
             return
 
-        sel_model.clearSelection()
+        # Batch the selection into one .select() call. The per-index loop this
+        # replaces emitted selectionChanged once per match, and the wired
+        # handler (on_tree_selection_changed → _preview.show_single) is a
+        # heavy image/video load on the UI thread — N=hundreds of keepers
+        # froze the window after Close & Load. See #344.
+        selection = QItemSelection()
         for name_idx in matches:
-            sel_model.select(
-                name_idx,
-                QItemSelectionModel.Select | QItemSelectionModel.Rows,
-            )
+            selection.select(name_idx, name_idx)
+        sel_model.select(
+            selection,
+            QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows,
+        )
         self.tree.scrollTo(matches[0])
 
     def on_open_manifest(self) -> None:

--- a/news/344.bugfix
+++ b/news/344.bugfix
@@ -1,0 +1,1 @@
+Fix UI freeze after scan + Close & Load when auto-select produced many keepers — selection is now applied in one batched QItemSelection.select() call instead of per-keeper, so selectionChanged + preview load fires once regardless of N (#344).

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -341,32 +341,64 @@ def test_reselect_by_path_does_nothing_when_helper_returns_none():
     fake_tree.selectionModel.assert_not_called()
 
 
-def test_select_rows_by_paths_clears_then_selects_each_match():
-    """Multi-target version: clear existing selection, then ``select``
-    each returned index, then ``scrollTo`` the first.
+def test_select_rows_by_paths_applies_selection_in_one_call():
+    """Multi-target version: build a single QItemSelection, apply it
+    in one ``select(...)`` call with ClearAndSelect | Rows, then
+    ``scrollTo`` the first match.
 
-    Failure mode: the loop drops the clearSelection() call and the
-    new selection ADDS to the old one — user sees the wrong subset
-    highlighted after a scan-complete auto-select.
+    Failure mode: regressing to a per-index loop over ``sel_model.select(idx, ...)``
+    emits ``selectionChanged`` once per match. The wired handler
+    (``on_tree_selection_changed`` → ``_preview.show_single``) is a
+    heavy image/video load on the UI thread — N=hundreds of keepers
+    freezes the window after Close & Load (see #344). Test pins the
+    contract: select() must be called exactly once regardless of N.
     """
-    idx_a = object()
-    idx_b = object()
+    from PySide6.QtCore import QItemSelectionModel
+    from PySide6.QtGui import QStandardItem, QStandardItemModel
+
+    # Real QModelIndex objects — QItemSelection.select is type-checked
+    # PySide6 code and rejects bare object() mocks.
+    real_model = QStandardItemModel()
+    for name in ("a.jpg", "b.jpg", "c.jpg"):
+        real_model.appendRow(QStandardItem(name))
+    idx_a = real_model.index(0, 0)
+    idx_b = real_model.index(1, 0)
+    idx_c = real_model.index(2, 0)
+
     fake_tree = MagicMock()
-    fake_tree.model.return_value = MagicMock()
+    fake_tree.model.return_value = real_model
     fake_sel = MagicMock()
     fake_tree.selectionModel.return_value = fake_sel
     fake_self = SimpleNamespace(tree=fake_tree)
 
     import app.views.main_window_helpers as helpers
     real = helpers.find_paths_in_model
-    helpers.find_paths_in_model = lambda model, targets: [idx_a, idx_b]
+    helpers.find_paths_in_model = lambda model, targets: [idx_a, idx_b, idx_c]
     try:
-        MainWindow._select_rows_by_paths(fake_self, {"/a.jpg", "/b.jpg"})
+        MainWindow._select_rows_by_paths(fake_self, {"/a.jpg", "/b.jpg", "/c.jpg"})
     finally:
         helpers.find_paths_in_model = real
 
-    fake_sel.clearSelection.assert_called_once_with()
-    assert fake_sel.select.call_count == 2
+    # The freeze regression check: exactly one .select() call no matter
+    # how many keepers the auto-select produces.
+    assert fake_sel.select.call_count == 1, (
+        f"sel_model.select() called {fake_sel.select.call_count}x — "
+        f"regressed to per-index loop; will refreeze on real scans (see #344)"
+    )
+
+    # Verify the single call uses ClearAndSelect | Rows (replaces the
+    # previous clearSelection() + Select-each pair atomically).
+    args, _ = fake_sel.select.call_args
+    flags = args[1]
+    assert flags & QItemSelectionModel.ClearAndSelect, (
+        "select() flags must include ClearAndSelect — otherwise stale "
+        "selection from before the scan is kept"
+    )
+    assert flags & QItemSelectionModel.Rows, (
+        "select() flags must include Rows — single-cell selection "
+        "doesn't highlight the full row"
+    )
+
     fake_tree.scrollTo.assert_called_once_with(idx_a)
 
 


### PR DESCRIPTION
## Summary

- Fixes [#344](https://github.com/jackal998/photo-manager/issues/344) — UI freeze after scan + **Close & Load** when auto-select produced many keeper rows.
- Replaces the per-keeper `sel_model.select(idx, Select|Rows)` loop with a single batched `QItemSelection` + `ClearAndSelect|Rows` call.
- Regression test pins `sel_model.select.call_count == 1` so re-introducing a per-index loop fails CI with a message pointing at #344.

## Why

`QItemSelectionModel.select(idx, ...)` emits `selectionChanged` on every call. That signal is wired to `MainWindow.on_tree_selection_changed` → `_preview.show_single(path)` — image decode / video-player setup on the UI thread. With auto-select ON the scan worker stamps `action="KEEP"` on the top row of **every group**, so a real library with hundreds/thousands of groups produced the same number of rapid `show_single` calls back-to-back. App became unresponsive, CPU pinned at 100%.

[`qa/scenarios/s49_scan_auto_select.py`](qa/scenarios/s49_scan_auto_select.py) only ever exercised a single 5-row group → exactly one `.select()` call, so the N=many regression was invisible to CI and the qa-batch.

## The fix

```python
selection = QItemSelection()
for name_idx in matches:
    selection.select(name_idx, name_idx)
sel_model.select(
    selection,
    QItemSelectionModel.ClearAndSelect | QItemSelectionModel.Rows,
)
self.tree.scrollTo(matches[0])
```

Idiomatic Qt for atomic multi-row selection; `ClearAndSelect` preserves the previous `clearSelection()` + `Select` semantics in one shot.

## Companion audit

A loop-IO audit was run across the codebase in the same session — no other instances of this anti-pattern class were found. Findings inventory in #344. Scanner / SQLite / exiftool boundaries were already disciplined (executemany + transactions, -stay_open batching, batched progress emission every 100 files).

## Test plan

- [x] `pytest tests/test_main_window.py` — 45 / 45 pass
- [x] `pytest tests/test_main_window_helpers.py tests/test_scan_dialog.py` — 87 / 87 pass
- [x] Regression test fails with a clear message when the per-index loop is reintroduced
- [ ] Manual: rerun a real scan with auto-select ON, click Close & Load, confirm window stays responsive and the first keeper row is scrolled into view

🤖 Generated with [Claude Code](https://claude.com/claude-code)