### PR TITLE
test(qa): add Apply-gate probe blocks to s14 + s31 (#354)

### DIFF
--- a/news/357.misc
+++ b/news/357.misc
@@ -1,0 +1,1 @@
+Add Apply-gate live-UIA probe blocks to qa scenarios s14 + s31 (#357).

--- a/qa/scenarios/s14_action_by_regex.py
+++ b/qa/scenarios/s14_action_by_regex.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import re
 import sqlite3
 import sys
+import time
 from pathlib import Path
 
 from qa.scenarios import _invariants, _uia
@@ -105,6 +106,45 @@ def main() -> int:
     print(f"  pre_total={len(pre)}")
     print(f"  pre_delete={sum(1 for v in pre.values() if v == 'delete')}")
     print(f"  pre_empty={sum(1 for v in pre.values() if v == '')}")
+
+    # #354 — Apply-button gating probe. Layer-1 tests in
+    # tests/test_select_dialog.py::TestApplyGate pin _validate_regex +
+    # _compute_apply_enabled (no-emit on empty / invalid), but no
+    # layer-3 driver asserts that the *button itself* honors
+    # setEnabled(False). If a future PR rewires _btn_set_action to a
+    # control that ignores setEnabled, or drops the setEnabled(False)
+    # calls in _validate_regex, layer-1 still passes while the UI
+    # silently regresses. The probe opens the dialog, exercises both
+    # gated cases, prints the live enabled state, then closes — the
+    # main flow below reopens the dialog and proceeds unchanged.
+    print("step: probe_apply_gate")
+    probe_dlg, _ = _uia.open_action_by_regex_dialog(win)
+    regex_radio = _uia._find_descendant_by_aid_suffix(
+        probe_dlg, "RadioButton", ".regexModeRegex"
+    )
+    if regex_radio is not None:
+        try:
+            if not regex_radio.is_selected():
+                regex_radio.click_input()
+                time.sleep(0.2)
+        except Exception:
+            pass
+    probe_apply = _uia._find_dialog_button(probe_dlg, _uia.ACTION_DIALOG_BTN_APPLY)
+    probe_regex = _uia._find_descendant_by_aid_suffix(
+        probe_dlg, "Edit", ".regexLineEdit"
+    )
+    if probe_regex is not None:
+        probe_regex.iface_value.SetValue("")
+        # Past the 150 ms live-preview debounce so _validate_regex has
+        # run before we read the button state.
+        time.sleep(0.3)
+    print(f"  probe_status: apply_enabled_empty={probe_apply.is_enabled()}")
+    if probe_regex is not None:
+        probe_regex.iface_value.SetValue("(unclosed")
+        time.sleep(0.3)
+    print(f"  probe_status: apply_enabled_invalid={probe_apply.is_enabled()}")
+    _uia.close_action_dialog(probe_dlg)
+    _, win = _uia.connect_main()
 
     print("step: apply_regex_via_menu")
     rx = re.compile(REGEX, re.IGNORECASE)

--- a/qa/scenarios/s31_simple_mode_regex.py
+++ b/qa/scenarios/s31_simple_mode_regex.py
@@ -151,6 +151,47 @@ def main() -> int:
         print("FAIL: Simple mode is not the default")
         return 1
 
+    # #354 — Apply-button gating probe (Simple-mode variant).
+    # Layer-1 tests in tests/test_select_dialog.py::TestApplyGate cover
+    # the no-emit rule on _emit_set_action when the pattern is empty or
+    # invalid, but they don't observe the live button's enabled state.
+    # This probe reads dlg._btn_set_action.isEnabled() through UIA for
+    # both gate paths so a future PR that rewires the button (e.g. a
+    # QToolButton swap, or dropping the setEnabled(False) calls in
+    # _validate_regex) trips a visible regression here. Probe state is
+    # restored before the existing happy-path flow continues.
+    print("step: probe_apply_gate")
+    probe_apply = _uia._find_dialog_button(
+        action_dlg, _uia.ACTION_DIALOG_BTN_APPLY
+    )
+    # Empty-text case — Simple text is empty by default on dialog open.
+    # The 150 ms live-preview debounce has already elapsed by the time
+    # we get here (the assert_simple_mode_is_default block above takes
+    # well over 150 ms), so the gate has settled.
+    print(f"  probe_status: apply_enabled_empty={probe_apply.is_enabled()}")
+    # Invalid-pattern case — Simple mode synthesises via re.escape so
+    # no Simple input is ever syntactically invalid; the gate path that
+    # disables Apply on re.error lives behind the Regex-mode line edit
+    # (select_dialog.py line 1266). Toggle into Regex mode to exercise
+    # it, then restore Simple state so the existing happy path runs
+    # unchanged.
+    regex_radio.click_input()
+    time.sleep(0.3)
+    probe_regex_edit = _uia._find_descendant_by_aid_suffix(
+        action_dlg, "Edit", ".regexLineEdit"
+    )
+    if probe_regex_edit is not None:
+        probe_regex_edit.iface_value.SetValue("(unclosed")
+        time.sleep(0.3)
+    print(f"  probe_status: apply_enabled_invalid={probe_apply.is_enabled()}")
+    # Clear the line edit before toggling back so Simple's reverse-parse
+    # doesn't see the malformed "(unclosed" pattern.
+    if probe_regex_edit is not None:
+        probe_regex_edit.iface_value.SetValue("")
+        time.sleep(0.2)
+    simple_radio.click_input()
+    time.sleep(0.3)
+
     print("step: select_field")
     field_combo = _uia._find_descendant_by_aid_suffix(
         action_dlg, "ComboBox", ".regexFieldCombo"


### PR DESCRIPTION
## Summary
- Layer-1 `tests/test_select_dialog.py::TestApplyGate` pins `_validate_regex` + `_compute_apply_enabled` (no-emit on empty/invalid), but no layer-3 driver asserts the live Apply button honors `setEnabled(False)`. A future rewire (e.g. QToolButton swap) or a dropped `setEnabled(False)` call would pass layer-1 while the UI silently regresses.
- Adds probe blocks to `s14_action_by_regex.py` (Regex mode, menu route) and `s31_simple_mode_regex.py` (Simple mode default, toggling into Regex for the invalid-pattern path). Each emits two `probe_status:` lines (`apply_enabled_empty`, `apply_enabled_invalid`), both expected `False`.
- Probe state is restored before the existing happy path runs, so neither scenario's pass/fail outcome changes.

## Test plan
- [x] `tests/test_select_dialog.py::TestApplyGate` still passes (4 tests)
- [x] `python -m qa.scenarios._batch s14_action_by_regex` — PASS; probe output `apply_enabled_empty=False`, `apply_enabled_invalid=False`
- [x] `python -m qa.scenarios._batch s31_simple_mode_regex` — PASS; same probe output
- [x] No source-code changes; no `select_dialog.py` touched

[docs-not-needed: probe blocks are observational only — they don't change which scenario covers what; the docs/testing.md per-module table for s14/s31 is unchanged. No new module, no new omit entry, no shifted coverage claim.]

Closes #354