### PR TITLE
docs(skills): name Generator-Verifier; cite Google + MAST in /work

### DIFF
--- a/.claude/agents/app-security-reviewer.md
+++ b/.claude/agents/app-security-reviewer.md
@@ -7,6 +7,10 @@ model: sonnet
 
 # app-security-reviewer — Gate 7 teammate
 
+You are the **verifier** half of a Generator-Verifier pair (Anthropic
+Multi-Agent Coordination Patterns, 2026/4): you find faults, you do
+not execute fixes.
+
 You are a teammate spawned by the LEAD session running `/pr-review` in
 team mode. Your job is to apply Gate 7 of the pr-review composition
 graph to the PR's diff and report findings back to LEAD.

--- a/.claude/agents/docs-reviewer.md
+++ b/.claude/agents/docs-reviewer.md
@@ -7,6 +7,10 @@ model: sonnet
 
 # docs-reviewer — DOCS gate teammate
 
+You are the **verifier** half of a Generator-Verifier pair (Anthropic
+Multi-Agent Coordination Patterns, 2026/4): you find faults, you do
+not execute fixes.
+
 You are a teammate spawned by the LEAD session running `/pr-review` in
 team mode. Your job is to apply Gates 2 and 3 of the pr-review
 composition graph to the PR's diff and report findings back to LEAD.

--- a/.claude/agents/qa-agent.md
+++ b/.claude/agents/qa-agent.md
@@ -7,9 +7,12 @@ model: sonnet
 
 # qa-agent — post-implementation validator
 
-You are a quality-assurance agent. You do not write code. You run
-tests, check acceptance criteria, and report honestly — including
-passing when things actually pass.
+You are the **verifier** half of a Generator-Verifier pair (Anthropic
+Multi-Agent Coordination Patterns, 2026/4): you find faults, you do
+not execute fixes.
+
+You do not write code. You run tests, check acceptance criteria, and
+report honestly — including passing when things actually pass.
 
 ## What you receive
 

--- a/.claude/agents/quality-reviewer.md
+++ b/.claude/agents/quality-reviewer.md
@@ -7,6 +7,10 @@ model: sonnet
 
 # quality-reviewer — Gates 8+9+10 teammate
 
+You are the **verifier** half of a Generator-Verifier pair (Anthropic
+Multi-Agent Coordination Patterns, 2026/4): you find faults, you do
+not execute fixes.
+
 You are a teammate spawned by the LEAD session running `/pr-review` in
 team mode. Your job is to apply Gates 8, 9, and 10 of the pr-review
 composition graph to the PR's diff and report findings back to LEAD.

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -368,6 +368,18 @@ them unless the human says to.
   agents degrades performance up to 70% on sequential tasks. The
   complexity table is the gate.
 
+**MAST failure-category coverage** (arxiv 2503.13657, 14 modes in 3
+categories — Multi-Agent System Failure Taxonomy):
+(i) system design issues → addressed by Phase 2 complexity gate +
+Phase 3 human plan-approval. /pr-review's gate decomposition is the
+same pattern at the manager level (narrow trigger conditions, sub-skills
+independently editable).
+(ii) inter-agent misalignment → addressed by single-direction brief
+passing (researcher → developer → qa, no loops) and central LEAD
+ownership of merges and remote writes.
+(iii) task verification → addressed by qa-agent (Generator-Verifier)
+and the 4-cycle dev↔QA loop cap.
+
 ## Invocation examples
 
 ```

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -362,6 +362,11 @@ them unless the human says to.
   briefs show file overlap — sequence them in a single session
   instead. Parallel sessions on shared files cost more in merge
   conflicts than they save in latency.
+- ✗ Don't add subagents to a "medium" task to "be thorough". Google
+  Research (arxiv 2512.08296, 2026) shows independent agents amplify
+  errors 17.2× vs 4.4× for centrally-coordinated ones, and adding
+  agents degrades performance up to 70% on sequential tasks. The
+  complexity table is the gate.
 
 ## Invocation examples
 


### PR DESCRIPTION
## Summary

Implements 3 of 5 proposals from the multi-agent skill audit (#368):

- **P1** — Name the Generator-Verifier pattern in all four read-only verifier agents (qa-agent, docs-reviewer, app-security-reviewer, quality-reviewer). One-line annotation per agent connects the existing read-only discipline to durable literature terminology (Anthropic Multi-Agent Coordination Patterns, 2026/4).
- **P4** — Cite Google scaling study ([arxiv 2512.08296](https://arxiv.org/abs/2512.08296), 2026) in /work's anti-patterns list: 17.2× independent vs 4.4× centrally-coordinated error amplification; up to 70% degradation when scaling on sequential tasks.
- **P5** — Cross-link MAST's 3 failure-mode categories ([arxiv 2503.13657](https://arxiv.org/abs/2503.13657)) to existing /work guards: (i) system design / (ii) inter-agent misalignment / (iii) task verification.

**Zero behaviour change.** All edits are descriptive — naming patterns, citing sources, cross-linking taxonomies. The routing decisions (Phase 2 complexity table, 4-cycle dev↔QA cap, etc.) remain identical.

## Diff stat

| File | Lines |
|---|---|
| `.claude/agents/qa-agent.md` | +6 / -3 |
| `.claude/agents/docs-reviewer.md` | +4 |
| `.claude/agents/app-security-reviewer.md` | +4 |
| `.claude/agents/quality-reviewer.md` | +4 |
| `.claude/skills/work/SKILL.md` | +17 |
| **Total** | **+35 / -3** |

## Test plan

- [x] No source code, tests, or hooks touched — nothing to test.
- [x] All edited files under `.claude/agents/` and `.claude/skills/` — meta/tooling, not behaviour-bearing (per pr-review SKILL.md Gate 1).
- [x] `docs_guard` and `qa_scenario_guard` predicates not tripped.

## Companion PRs

- #368 — audit doc (research artefact behind these changes)
- Follow-up PR — P2 (`<N>×` cost-coverage clarification) + P6 (researcher-agent blast-radius input to complexity score)

[skip-news: skill/agent documentation — naming + citations, no user-recordable app behaviour change]

🤖 Generated with [Claude Code](https://claude.com/claude-code)