### PR TITLE
fix(skills): plumb blast-radius into researcher complexity score; clarify cost coverage

### DIFF
--- a/.claude/agents/researcher-agent.md
+++ b/.claude/agents/researcher-agent.md
@@ -59,6 +59,15 @@ After all three angles return, classify the task:
 | **complex** | > 10 files, cross-cutting, coverage gaps, multiple independent lanes | Full `/work` pipeline: subagents + `/pr-review team` |
 | **multi-issue** | Touches unrelated areas or multiple acceptance criteria | Consider `/parallel-brief-generator` for fan-out |
 
+**Blast-radius override.** If any affected file has `blast-radius: high`
+from Angle A — e.g. SQLite migrations (`_MIGRATIONS` list, `CREATE TABLE`),
+`settings.json` keys, background workers, or anything matching the
+[impact-map activation list](../skills/impact-map/SKILL.md) — upgrade the
+score by one tier (simple → medium, medium → complex). Rationale: a 2-file
+migration touch would otherwise score `simple` by file count and skip the
+dev↔QA Generator-Verifier loop entirely, despite being a Gate 8 high-risk
+area for `/pr-review`.
+
 ## Output format — send to LEAD via SendMessage
 
 ```

--- a/.claude/skills/work/SKILL.md
+++ b/.claude/skills/work/SKILL.md
@@ -79,6 +79,12 @@ Map complexity → execution workflow:
 | **complex** | Dev subagent (`isolation: "worktree"`) → QA subagent loop → `/pr-review team`. |
 | **multi-issue** | `/parallel-brief-generator` to fan out; each issue → its own session. |
 
+**The complexity score IS the auto-decline gate for subagent spawn.**
+`simple` and `medium` stay in LEAD; `complex` and `multi-issue` spawn
+subagents at roughly 4× single-session cost. Same shape as `/pr-review`
+team mode's auto-decline at ≤5 files / ≤300 diff lines — don't pay the
+overhead unless the score justifies it.
+
 ## Phase 3 — present to human for approval
 
 Print the plan in this format before doing anything else:
@@ -99,6 +105,8 @@ Workflow:
   …
 
 Cost estimate: ~<N>× single-session
+  (covers: researcher + dev iterations + qa iterations; excludes
+  LEAD overhead and Phase-5 /pr-review-team multiplier)
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Say "go" to execute, or adjust: "go but skip QA", "go with team review", etc.
 ```

--- a/news/370.bugfix
+++ b/news/370.bugfix
@@ -1,0 +1,1 @@
+`/work` now routes high-blast-radius small changes (migrations, settings keys, workers) through dev↔QA validation instead of skipping them as "simple" (#370).


### PR DESCRIPTION
## Summary

Implements the remaining 2 of 5 proposals from the multi-agent skill audit (#368):

- **P6 (routing fix)** — `.claude/agents/researcher-agent.md`: add a blast-radius override to the complexity-scoring rubric. If any affected file has `blast-radius: high` (SQLite migrations, settings keys, background workers, anything matching impact-map's activation list), upgrade the score by one tier (simple → medium, medium → complex). **This is the only behaviour-change PR in the set.**
- **P2 (clarification)** — `.claude/skills/work/SKILL.md`: two surgical edits clarifying (a) the complexity score IS the auto-decline gate for subagent spawn, mirroring `/pr-review`'s ≤5-files-/-≤300-lines auto-decline at the appropriate granularity, and (b) what `<N>×` covers in the cost estimate (researcher + dev iterations + qa iterations; excludes LEAD overhead and Phase-5 /pr-review-team multiplier).

## Behaviour change (P6)

**Before:** A 2-file change to `infrastructure/manifest_repository.py` migrations would score `simple` (≤3 files, no cross-cutting deps, full coverage, <1h) and route to LEAD-direct, **skipping the dev↔QA Generator-Verifier loop** — despite SQLite migrations being a Gate 8 high-risk area per `/pr-review`'s composition graph.

**After:** Angle A already collects per-file blast-radius; the rubric now references it. The same 2-file migration touch bumps to `medium` minimum, ensuring the Generator-Verifier loop fires.

This is the Challenge-3 issue surfaced during the audit's independent-review reconciliation pass — a real miss in the original audit, conceded and added as Proposal 6.

## Diff stat

| File | Lines |
|---|---|
| `.claude/agents/researcher-agent.md` | +9 |
| `.claude/skills/work/SKILL.md` | +8 |
| **Total** | **+17** |

## Test plan

- [x] No Python source, tests, or hooks touched — pytest doesn't exercise agent/skill markdown definitions.
- [x] All edited files under `.claude/agents/` and `.claude/skills/` — meta/tooling, not behaviour-bearing per pr-review SKILL.md Gate 1.
- [x] `docs_guard` and `qa_scenario_guard` predicates not tripped.
- [x] First test of the new routing is the next `/work` invocation that names a high-blast-radius file. Worst case if the override is wrong: a `medium`-scored task gets the dev↔QA loop unnecessarily — that's strictly safer than the bug it fixes.

## Companion PRs

- #368 — audit doc (research artefact)
- #369 — descriptive PR (P1 + P4 + P5)

News fragment: `news/370.bugfix` (added in follow-up commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)