### PR TITLE
docs(news): tighten skip-news criterion to "no diff worth a one-line record"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -303,10 +303,10 @@ Add Execute Action preview pane (#165).
 
 ### Bypass — `[skip-news: <reason>]`
 
-A PR that genuinely has no entry worth recording (e.g. a typo fix in
-a code comment, a transitive-dep bump with no behaviour change) can
-skip the gate by including the literal token `[skip-news: <reason>]`
-in the PR title or body. The reason is for the reviewer — keep it
+A PR with no diff worth a one-line record (e.g. a typo fix in a code
+comment, a transitive-dep bump with no behaviour change) can skip
+the gate by including the literal token `[skip-news: <reason>]` in
+the PR title or body. The reason is for the reviewer — keep it
 specific (`[skip-news: comment typo]`, not `[skip-news: trivial]`).
 
 This is the same convention as `[docs-not-needed]` for the docs-guard

--- a/news/375.doc
+++ b/news/375.doc
@@ -1,0 +1,1 @@
+Replace the skip-news classification criterion ("user-visible or contributor-visible change worth noting") with a capability test ("no diff worth a one-line record") so authors can apply it without judging visibility boundaries (#375).

--- a/news/README.md
+++ b/news/README.md
@@ -35,8 +35,8 @@ Add Execute Action preview pane (#165).
 
 ## Bypass
 
-A PR that genuinely has no user-visible or contributor-visible change
-worth noting (e.g. fixing a typo in a comment, bumping a transitive
-dep with no behaviour change) can skip the fragment by including the
-literal token `[skip-news: <reason>]` in the PR title or body. CI
-enforces this; reviewers see the reason inline.
+A PR with no diff worth a one-line record (e.g. fixing a typo in a
+comment, bumping a transitive dep with no behaviour change) can skip
+the fragment by including the literal token `[skip-news: <reason>]`
+in the PR title or body. CI enforces this; reviewers see the reason
+inline.


### PR DESCRIPTION
## Summary

Replaces the user/contributor-visibility classification phrasing in `news/README.md` and `CONTRIBUTING.md`'s skip-news bypass guidance with a capability test: **"can you write a useful one-line record for this PR?"**.

## Why

The previous wording asked authors to classify a PR as "user-visible / contributor-visible / worth noting" before deciding to bypass. That's a fuzzy classification boundary, and the boundary is hard to apply correctly — see #370, which originally shipped with a wrong `[skip-news: skill/agent routing-rubric edit]` token because the framing anchored on "no `app/` source touched" rather than the actual criterion. The user-vs-contributor visibility split for tooling-as-code (skills, agents, hooks) is exactly where the classification breaks.

Capability tests are easier to apply correctly than classification tests. If you can write a useful one-line record, write the fragment; if you literally cannot, use the bypass.

## What's NOT changing

- The bypass mechanism (`[skip-news: <reason>]` token) — still functional.
- The `news-gate` CI workflow — unchanged.
- Skill files (`.claude/skills/work/`, `parallel-brief-generator/`) — they describe the bypass mechanism only and don't carry the classification criterion, so no edit needed.
- The fragment type vocabulary (`feature` / `bugfix` / `doc` / `removal` / `misc`) — unchanged.

## Diff

| File | Lines |
|---|---|
| `news/README.md` | +5 / -5 (`## Bypass` section wording) |
| `CONTRIBUTING.md` | +4 / -4 (`### Bypass` section wording) |
| **Total** | **+9 / -9** |

## Test plan

- [x] No source code, tests, hooks, or CI workflows touched.
- [x] `docs_guard` and `qa_scenario_guard` predicates not tripped (docs-only diff).
- [x] News fragment for this PR will be added in a follow-up commit per the new criterion (this PR has a one-line record worth writing — a criterion change is exactly the kind of meta-change worth recording).

🤖 Generated with [Claude Code](https://claude.com/claude-code)