### PR TITLE
fix(qa): raise connect_main default timeout to absorb GH Actions cold-start variance

### DIFF
--- a/news/383.bugfix
+++ b/news/383.bugfix
@@ -1,0 +1,1 @@
+Raise the qa-batch UIA connect default timeout from 5s to 20s so the launch-to-UIA-ready window absorbs GitHub Actions Windows-runner cold-start variance, eliminating the intermittent `ElementNotFoundError: '.*Photo Manager.*'` flake that surfaced on random shards (matches the precedent already in qa/probes/_runtime.py; local runs finish in <2s and are unaffected) (#373).

--- a/qa/scenarios/_uia.py
+++ b/qa/scenarios/_uia.py
@@ -348,7 +348,9 @@ def _focus(wrapper: UIAWrapper, timeout: float = 1.5) -> None:
 # ---------------------------------------------------------------------------
 
 
-def connect_main(timeout: float = 5) -> tuple[Application, UIAWrapper]:
+def connect_main(timeout: float = 20) -> tuple[Application, UIAWrapper]:
+    # 20s default absorbs GitHub Actions Windows-runner cold-start variance;
+    # local runs finish in <2s and aren't affected by the higher ceiling.
     app = Application(backend="uia").connect(title_re=WINDOW_TITLE_RE, timeout=timeout)
     return app, app.top_window()
 


### PR DESCRIPTION
## Summary

- Raises `qa/scenarios/_uia.py::connect_main` default `timeout` from `5` → `20` seconds.
- Matches the precedent already established in `qa/probes/_runtime.py:150` (which has been on `timeout=20` since the probes runtime landed).
- Eliminates the UIA-timeout flake described in #373.

## Root cause

On Windows GitHub Actions runners under load (cold-start MSVC runtime, Defender scanning the freshly-built venv, etc.) the launch-to-UIA-ready budget can exceed 13s:

1. `_wait_for_main_window(timeout=8.0)` — non-fatal warner if the window doesn't appear in 8s.
2. `_uia.connect_main(timeout=5)` — fatal `ElementNotFoundError` if UIA can't connect within 5s of the warner returning.

PR #368 attempt 1 hit this on `s02_empty_folder` + `s12_save_manifest` simultaneously — both preceded by `WARN: main window did not appear within 8s for pid=…` and both failing at `pywinauto.findwindows.ElementNotFoundError: {'title_re': '.*Photo Manager.*', 'backend': 'uia'}`. Attempt 2 (re-run, no code change) passed all 11 scenarios.

## Choice of fix

Per #373's confirmation protocol, the issue was scoped as paper-trail-only: re-run, observe, close on flake-confirmed. Path C of the /work plan (chosen in chat) was instead to fix the underlying cause — the issue is `priority: high` and the precedent for the fix (`probes/_runtime.py` using `timeout=20`) already exists in the repo.

Bumping the default rather than passing `timeout=20` at all 122 default-call sites (across 55 scenario files) keeps the change minimal and self-documenting. Scenarios that intentionally want fast-fail (s22_language_switch.py:170 with `timeout=1`) pass explicitly and are unaffected.

## Trade-off

The only downside is that on a true launch failure (main.py crash at startup), every scenario will now take 20s to surface vs 5s. On a full 60-scenario batch in that disaster case, that adds ~15min — but if main.py crashes at startup, we have bigger problems than batch latency.

## Test plan

- [x] `python -c "from qa.scenarios._uia import connect_main; print(connect_main.__defaults__)"` → `(20,)`
- [ ] CI: pytest, gates, news-fragment expected green (no source code path touched)
- [ ] CI: qa shards 1–5 should pass on first attempt rather than needing re-run
- [ ] Local smoke: any single scenario via `python -m qa.scenarios.s07_format_dup` (post-merge — the fix is meant to be invisible locally where launch is <2s)

Closes #373

🤖 Generated with [Claude Code](https://claude.com/claude-code)