### PR TITLE
test(qa): fix s31 B2 probe and s43 counter assertion drift

### DIFF
--- a/news/388.misc
+++ b/news/388.misc
@@ -1,0 +1,1 @@
+Fix s31 B2 probe (mode-aware widget lookup) and s43 main-flow counter assertion (post-#378 format) — closes Wave 11 layer-3 test debt (#386, #387).

--- a/qa/scenarios/s31_simple_mode_regex.py
+++ b/qa/scenarios/s31_simple_mode_regex.py
@@ -367,45 +367,90 @@ def main() -> int:
                 print(f"probe_status: A7-recent-picks-simple FAIL — {_exc!r}")
     # ---------- end probe A7 ----------
 
+    # Close the A7 probe dialog before opening the B2 probe dialog.
+    # B2 opens its own fresh dialog (#386 fix) — reusing probe_dlg here
+    # left it in a state where the UIA tree was stale after the Recent
+    # menu's popup + click_input, and subsequent lookups for
+    # .regexModeRegex / .regexLineEdit returned None.
+    try:
+        _probe_close = _uia._find_dialog_button(probe_dlg, _uia.ACTION_DIALOG_BTN_CLOSE)
+        _probe_close.click_input()
+        time.sleep(0.3)
+    except Exception:
+        pass
+
     # ---------- Probe B2: Switch-to-Regex button appears and works ----------
     # Wave-7 (B2+B4) added _switch_to_regex_btn inside simple_outer —
     # shown alongside _simple_complex_notice when the current regex is not
     # Simple-representable. Clicking it flips to Regex losslessly.
+    #
+    # #386 fix: open a fresh dialog. The previous version reused
+    # probe_dlg from the A7 probe above, but A7's Recent-menu pick
+    # left the wrapper's UIA tree stale (a Recent-menu pick flips to
+    # Simple mode and may close + reopen internal layout widgets),
+    # so .regexModeRegex / .regexLineEdit lookups returned None.
     print("step: probe_b2_switch_to_regex_button")
-    # Type a non-Simple pattern in Regex mode, then toggle back to Simple
-    # to trigger the notice + button. Verify the button is visible, click
-    # it, and assert mode == Regex with pattern preserved.
+    _, win = _uia.connect_main()
+    probe_b2_dlg, _ = _uia.open_action_by_regex_dialog(win)
+    time.sleep(0.5)
+    # The dialog opens in whichever mode the prior probe persisted —
+    # typically Simple after the main-flow Apply. In Simple mode the
+    # regexLineEdit widget is HIDDEN, and UIA doesn't surface hidden
+    # widgets via descendants(). So we walk the radios first, click
+    # Regex (which surfaces regexLineEdit), then walk Edit descendants.
+    # (#386 root cause: original probe looked up both radio + edit
+    # before the mode switch and the edit lookup returned None.)
     probe_regex_radio = _uia._find_descendant_by_aid_suffix(
-        probe_dlg, "RadioButton", ".regexModeRegex"
+        probe_b2_dlg, "RadioButton", ".regexModeRegex"
     )
-    probe_regex_edit2 = _uia._find_descendant_by_aid_suffix(
-        probe_dlg, "Edit", ".regexLineEdit"
+    probe_simple_radio2 = _uia._find_descendant_by_aid_suffix(
+        probe_b2_dlg, "RadioButton", ".regexModeSimple"
     )
     _COMPLEX = r"\d{3}"
-    if probe_regex_radio is None or probe_regex_edit2 is None:
-        print("probe_status: B2-switch-to-regex FAIL — regex radio or line edit not found")
+    probe_regex_edit2 = None
+    if probe_regex_radio is None or probe_simple_radio2 is None:
+        print("probe_status: B2-switch-to-regex FAIL — mode-toggle radios not found")
     else:
         probe_regex_radio.click_input()
-        time.sleep(0.3)
+        time.sleep(0.4)
+        # Now Regex mode is active — regexLineEdit is in the UIA tree.
+        probe_regex_edit2 = _uia._find_descendant_by_aid_suffix(
+            probe_b2_dlg, "Edit", ".regexLineEdit"
+        )
+    if probe_regex_edit2 is None:
+        # Bail out of the B2 probe — without the line edit we can't
+        # set a non-Simple pattern. Other Wave 11 probes still need
+        # to run, so close the dialog and fall through (NOT return).
+        if probe_regex_radio is not None:
+            print(
+                "probe_status: B2-switch-to-regex FAIL — regexLineEdit "
+                "still missing after switching to Regex mode (hidden?)"
+            )
+    else:
         probe_regex_edit2.iface_value.SetValue(_COMPLEX)
         time.sleep(0.2)
-        probe_simple_radio2 = _uia._find_descendant_by_aid_suffix(
-            probe_dlg, "RadioButton", ".regexModeSimple"
-        )
-        if probe_simple_radio2 is not None:
-            probe_simple_radio2.click_input()
-            time.sleep(0.4)
+        probe_simple_radio2.click_input()
+        time.sleep(0.4)
         probe_switch_btn = _uia._find_descendant_by_aid_suffix(
-            probe_dlg, "Button", ".regexSwitchToRegexBtn"
+            probe_b2_dlg, "Button", ".regexSwitchToRegexBtn"
         )
         if probe_switch_btn is None:
             print("probe_status: B2-switch-to-regex FAIL — regexSwitchToRegexBtn not in UIA tree")
         elif probe_switch_btn.is_visible():
             probe_switch_btn.click_input()
             time.sleep(0.3)
-            probe_regex_radio2 = _uia._find_descendant_by_aid_suffix(
-                probe_dlg, "RadioButton", ".regexModeRegex"
-            )
+            # After Switch-to-Regex click, re-resolve the regex radio
+            # — the wrapper for the still-Simple-mode-snapshotted radio
+            # would read its old is_selected() state. Walk fresh.
+            probe_regex_radio2 = None
+            for _r in probe_b2_dlg.descendants(control_type="RadioButton"):
+                try:
+                    _aid = _r.element_info.automation_id or ""
+                except Exception:
+                    _aid = ""
+                if _aid.endswith(".regexModeRegex"):
+                    probe_regex_radio2 = _r
+                    break
             _regex_checked = (
                 probe_regex_radio2 is not None and probe_regex_radio2.is_selected()
             )
@@ -423,15 +468,11 @@ def main() -> int:
                 "regexSwitchToRegexBtn present but not visible after Simple-toggle "
                 "with complex pattern"
             )
-    # ---------- end probe B2 ----------
-
-    # Close the probe dialog before the final DONE print.
     try:
-        _probe_close = _uia._find_dialog_button(probe_dlg, _uia.ACTION_DIALOG_BTN_CLOSE)
-        _probe_close.click_input()
-        time.sleep(0.3)
+        _uia.close_action_dialog(probe_b2_dlg)
     except Exception:
         pass
+    # ---------- end probe B2 ----------
 
     # ════════════════════════════════════════════════════════════════════
     # Wave 11 probes — layer-3 coverage push (issues #359 #366 #374 #377 #379)

--- a/qa/scenarios/s43_numeric_condition.py
+++ b/qa/scenarios/s43_numeric_condition.py
@@ -267,12 +267,20 @@ def main() -> int:
     if counter_text is None:
         print("FAIL: live-preview counter not found — preview pane missing?")
         return 1
-    # Counter should mention 3 matches and 5 total (digit presence is enough —
-    # exact format is locale-dependent).
-    if "3" not in counter_text or "5" not in counter_text:
+    # #387 fix: counter_text is read AFTER Apply, so it reflects B9's
+    # match_counter_applied template ('Applied to {matched} rows' /
+    # '已套用至 {matched} 列') — not the pre-Apply 'X of Y match' shape.
+    # Wave 9b-trim (#378) introduced the flash; the prior assertion
+    # expected both '3' (matched) and '5' (total) and was always
+    # FAIL-printing because the flash doesn't carry total. Verify the
+    # matched count and the 'Applied to' / '已套用' marker instead.
+    _has_matched_count = "3" in counter_text
+    _has_applied_marker = "Applied to" in counter_text or "已套用" in counter_text
+    if not (_has_matched_count and _has_applied_marker):
         print(
-            f"FAIL: counter text {counter_text!r} should mention "
-            f"3 matched and 5 total"
+            f"FAIL: counter text {counter_text!r} missing matched "
+            f"count '3' or 'Applied to'/'已套用' flash marker — "
+            f"#378 match_counter_applied template may have regressed"
         )
         # Don't return immediately — manifest check below is the
         # load-bearing assertion.


### PR DESCRIPTION
## Summary

Wave 11 closure bundle — both issues surfaced during PR #384's local-run validation as pre-existing test debt that the Wave-11 probe additions accidentally exposed.

## #386 — s31 B2 probe FAIL

The B2 probe was reusing the A7 probe's dialog wrapper. After A7's Recent-menu pick + click_input, the dialog wrapper's UIA tree was stale and subsequent lookups for `.regexModeRegex` / `.regexLineEdit` returned None.

**Fix:** open a fresh dialog for B2. While rewriting, discovered the deeper root cause: the fresh dialog opens in whichever mode was persisted (Simple, after the main-flow Apply). In Simple mode, `regexLineEdit` is HIDDEN — and UIA doesn't surface hidden widgets via `descendants()`. The original probe was looking up both the regex radio AND the regex line edit BEFORE switching to Regex mode, so the edit lookup always returned None.

**Pattern:** walk radios first → click Regex radio (which surfaces regexLineEdit in the UIA tree) → then look up the edit.

## #387 — s43 main-flow counter assertion drift

The main-flow assertion checked the counter contains both '3' (matched) and '5' (total). But `counter_text` is read AFTER Apply, where Wave 9b-trim (#378) `match_counter_applied` template fires as `Applied to N rows` — the flash text doesn't carry a total. The assertion was always printing `FAIL: counter text 'Applied to 3 rows' should mention 3 matched and 5 total`, but the scenario rc=0 path was intact (FAIL was informational), so this drifted silently for 2 PRs.

**Fix:** assert the matched count '3' AND the `Applied to` / `已套用` marker (locale-aware).

## Verification

Both fixes verified locally — final batch run shows **13 PASS + 5 SKIP-soft + 0 FAIL** across s31 and s43 (matching the Wave 11 baseline plus the B2 fix). No regression in any previously-passing probe.

## Test plan

- [x] `python -c \"from qa.scenarios import _uia, s31_simple_mode_regex, s43_numeric_condition\"` — imports OK
- [x] Local `python -m qa.scenarios._batch s31_simple_mode_regex s43_numeric_condition` — both rc=0, all probes PASS or SKIP-soft (no FAIL)
- [ ] CI green

## Closes

Closes #386
Closes #387

[docs-not-needed: test-only corrections — no user-visible behaviour changed; assertion + lookup-order updates only]
[qa-not-needed: this PR IS the qa test-debt cleanup]

🤖 Generated with [Claude Code](https://claude.com/claude-code)