### PR TITLE
perf(auto-select): combine post-scan decision+lock writes into one transaction

### DIFF
--- a/core/services/auto_select.py
+++ b/core/services/auto_select.py
@@ -81,9 +81,11 @@ def apply_auto_select_decisions(
     # so the cost on already-migrated DBs is a couple of failed
     # ALTERs (caught and ignored).
     repo.ensure_schema(manifest_path)
-    repo.batch_update_decisions(manifest_path, decisions)
-    repo.batch_update_lock_state(
-        manifest_path, {p: True for p in keepers}
+    # Single-transaction write — saves one connection-open + one fsync
+    # vs the original split call pair. Microsecond gain on local SSD,
+    # measurable over SMB/NAS.
+    repo.batch_update_decisions_and_lock(
+        manifest_path, decisions, {p: True for p in keepers}
     )
 
 

--- a/infrastructure/manifest_repository.py
+++ b/infrastructure/manifest_repository.py
@@ -370,6 +370,40 @@ class ManifestRepository:
         finally:
             conn.close()
 
+    def batch_update_decisions_and_lock(
+        self,
+        manifest_path: str,
+        decisions: dict[str, str],
+        lock_states: dict[str, bool],
+    ) -> None:
+        """Combined batch — both updates under one connection + commit.
+
+        Same semantics as calling :meth:`batch_update_decisions` followed
+        by :meth:`batch_update_lock_state`, but issues one ``COMMIT`` (one
+        fsync) instead of two. Used by the post-scan auto-select write
+        path (:func:`core.services.auto_select.apply_auto_select_decisions`,
+        #393): negligible on local SSD, meaningful over SMB/NAS where the
+        per-commit round-trip dominates. Empty dicts on either side are
+        skipped; both empty short-circuits before opening the connection.
+        """
+        if not decisions and not lock_states:
+            return
+        conn = _connect(manifest_path)
+        try:
+            if decisions:
+                conn.executemany(
+                    _UPDATE_DECISION_SQL,
+                    [(v, k) for k, v in decisions.items()],
+                )
+            if lock_states:
+                conn.executemany(
+                    _UPDATE_LOCK_SQL,
+                    [(1 if v else 0, k) for k, v in lock_states.items()],
+                )
+            conn.commit()
+        finally:
+            conn.close()
+
     def rescore(
         self,
         manifest_path: str,

--- a/news/406.misc
+++ b/news/406.misc
@@ -1,0 +1,1 @@
+Combine auto-select's post-scan decision + lock writes into a single SQLite transaction; saves one connection-open and one fsync per scan.

--- a/tests/test_manifest_repository.py
+++ b/tests/test_manifest_repository.py
@@ -525,6 +525,79 @@ class TestBatchUpdateDecisions:
         assert row[0] == "keep"  # unchanged
 
 
+class TestBatchUpdateDecisionsAndLock:
+    """Combined batch method — used by the auto-select post-scan write
+    path (#393) to land both writes in a single transaction.
+    """
+
+    def test_writes_both_decision_and_lock_in_one_call(self, tmp_path):
+        """Catches: the combined method drops one side (e.g. forgets
+        the lock executemany, or commits before the second statement).
+        Mixing keepers (keep+lock=1) with non-keepers (delete only,
+        lock untouched) exercises both columns and confirms they
+        don't bleed onto each other.
+        """
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": "/k.jpg", "group_id": None,
+                  "hamming_distance": None, "action": "MOVE"}),
+            _row({"source_path": "/d.jpg", "group_id": None,
+                  "hamming_distance": None, "action": "MOVE"}),
+            _row({"source_path": "/untouched.jpg", "group_id": None,
+                  "hamming_distance": None, "action": "MOVE"}),
+        ])
+        # Add is_locked column for parity with the production schema
+        # path (auto-select migrates lazily before this call).
+        ManifestRepository().ensure_schema(str(db))
+
+        ManifestRepository().batch_update_decisions_and_lock(
+            str(db),
+            decisions={"/k.jpg": "keep", "/d.jpg": "delete"},
+            lock_states={"/k.jpg": True},
+        )
+
+        conn = sqlite3.connect(db)
+        try:
+            rows = {
+                r[0]: (r[1], r[2]) for r in conn.execute(
+                    "SELECT source_path, user_decision, is_locked "
+                    "FROM migration_manifest"
+                ).fetchall()
+            }
+        finally:
+            conn.close()
+        assert rows["/k.jpg"] == ("keep", 1)
+        assert rows["/d.jpg"] == ("delete", 0)
+        assert rows["/untouched.jpg"] == ("", 0)
+
+    def test_both_empty_short_circuits_without_opening_connection(
+        self, tmp_path, monkeypatch
+    ):
+        """Catches: the short-circuit guard regresses and we open a
+        connection (+ optionally commit an empty transaction) when
+        there's literally nothing to write. The auto-select caller
+        invokes unconditionally on empty-keepers scans; this must
+        stay free.
+        """
+        from infrastructure import manifest_repository as repo_mod
+
+        db = _make_manifest(tmp_path, [
+            _row({"source_path": "/a.jpg", "group_id": None,
+                  "hamming_distance": None, "action": "MOVE"}),
+        ])
+        opens: list[str] = []
+        real_connect = repo_mod._connect
+
+        def _spy(path):
+            opens.append(path)
+            return real_connect(path)
+
+        monkeypatch.setattr(repo_mod, "_connect", _spy)
+        ManifestRepository().batch_update_decisions_and_lock(
+            str(db), decisions={}, lock_states={}
+        )
+        assert opens == []
+
+
 class TestRemoveFromReview:
     """remove_from_review() and the load() filter for user_decision='removed'."""
 


### PR DESCRIPTION
## Summary
- `apply_auto_select_decisions` previously called `batch_update_decisions` followed by `batch_update_lock_state` — two connections, two `executemany`, two `COMMIT`s, two fsyncs.
- New `ManifestRepository.batch_update_decisions_and_lock` runs both `executemany` calls under one connection + one commit.
- Saves one connection-open and one fsync per scan: microseconds on local SSD, measurable over SMB/NAS where per-commit round-trips dominate.

Pure refactor — same end state on disk. 15 existing `TestApplyAutoSelectDecisions` tests pass unchanged, proving the call-site swap is behaviour-preserving.

Motivation: user noticed the auto-select log lines and asked whether the writes were being batched. They already were (one `executemany` per side via PR #18 + #398), but the two separate transactions were a tiny gap worth closing.

[docs-not-needed: additive `ManifestRepository` method (no `_MIGRATIONS` change, no schema change), pure refactor of the auto-select call-site. README.md's schema table only documents columns + migration ordering, both unchanged. docs/features.md describes user-visible behaviour, also unchanged (same final on-disk state).]

## Test plan
- [x] `python -m pytest tests/test_manifest_repository.py::TestBatchUpdateDecisionsAndLock tests/test_auto_select.py -x` → 17 passed (2 new + 15 existing auto-select)
- [x] `python -m pytest` → 1756 passed, 2 skipped (was 1754; +2), 89.12% coverage
- [x] 2 new tests: combined writes both columns correctly + both-empty short-circuits without opening a connection

🤖 Generated with [Claude Code](https://claude.com/claude-code)