### PR TITLE
chore(release): package Windows .exe via PyInstaller + tag-trigger workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,171 @@
+name: release
+
+# Tag-push trigger only — pushing v*.*.* (incl. -rc1 etc) builds the
+# standalone Windows bundle and publishes it as a GitHub Release.
+# Manual / PR runs are intentionally absent: a release is a deliberate
+# act, and the gate is "did you push a version tag".
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+# A failed build must NOT clobber an in-flight successful one. Tags
+# are immutable in practice, so each tag-ref gets its own concurrency
+# group.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write  # gh release create needs write on the repo
+
+jobs:
+  build-and-release:
+    runs-on: windows-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout source at the tag
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # CHANGELOG section extraction may walk history
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Derive version from tag
+        id: version
+        shell: pwsh
+        run: |
+          $tag = "${{ github.ref_name }}"
+          $version = $tag -replace '^v', ''
+          "tag=$tag"         | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "version=$version" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          "asset_name=photo-manager-$version-windows-x64.zip" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
+          Write-Host "tag=$tag version=$version"
+
+      # Clean venv with ONLY requirements.txt + build-requirements.txt
+      # — dev-requirements (pytest/ruff/etc) intentionally absent so
+      # the bundle reflects production deps, not dev tooling.
+      - name: Create clean build venv
+        shell: pwsh
+        run: |
+          python -m venv .venv-build
+          .venv-build\Scripts\python -m pip install --upgrade pip
+          .venv-build\Scripts\python -m pip install -r requirements.txt -r build-requirements.txt
+
+      - name: Build with PyInstaller (--onedir)
+        shell: pwsh
+        run: |
+          .venv-build\Scripts\python -m PyInstaller pyinstaller.spec --clean --noconfirm
+          if (-not (Test-Path "dist\photo-manager\photo-manager.exe")) {
+            Write-Error "PyInstaller did not produce dist\photo-manager\photo-manager.exe"
+            exit 1
+          }
+          $size = (Get-ChildItem -Recurse "dist\photo-manager" | Measure-Object Length -Sum).Sum / 1MB
+          Write-Host ("Bundle size: {0:N1} MB" -f $size)
+
+      # Headless smoke: launch under the Qt offscreen platform plugin
+      # so no display is required. Watchdog kills the process after a
+      # short window — we're asserting "starts without crashing", not
+      # "completes some task". A non-zero exit before the watchdog
+      # fires = crash = workflow fails.
+      - name: Headless smoke test
+        shell: pwsh
+        env:
+          QT_QPA_PLATFORM: offscreen
+          QT_LOGGING_RULES: '*.debug=false'
+        run: |
+          $exe = "dist\photo-manager\photo-manager.exe"
+          $stderrFile = "$env:RUNNER_TEMP\smoke-stderr.log"
+          $stdoutFile = "$env:RUNNER_TEMP\smoke-stdout.log"
+          $p = Start-Process -FilePath $exe `
+                             -RedirectStandardError $stderrFile `
+                             -RedirectStandardOutput $stdoutFile `
+                             -PassThru -NoNewWindow
+          Start-Sleep -Seconds 5
+          if ($p.HasExited) {
+            Write-Host "--- exe exited prematurely (exit=$($p.ExitCode)) ---"
+            Write-Host "--- stdout ---"
+            if (Test-Path $stdoutFile) { Get-Content $stdoutFile }
+            Write-Host "--- stderr ---"
+            if (Test-Path $stderrFile) { Get-Content $stderrFile }
+            exit 1
+          }
+          Write-Host "Process still running after 5s — no immediate crash. Stopping."
+          Stop-Process -Id $p.Id -Force
+          # Print stderr regardless so missing-module warnings surface
+          # in the workflow log even when the smoke passes.
+          Write-Host "--- stderr (post-kill) ---"
+          if (Test-Path $stderrFile) { Get-Content $stderrFile }
+
+      - name: Zip bundle
+        shell: pwsh
+        run: |
+          $asset = "${{ steps.version.outputs.asset_name }}"
+          Compress-Archive -Path "dist\photo-manager\*" -DestinationPath $asset -Force
+          Write-Host "Built $asset"
+          Get-Item $asset | Select-Object Name, Length
+
+      # CHANGELOG.md is produced by towncrier ahead of the tag push;
+      # we extract the section for THIS version. If the section is
+      # missing (towncrier wasn't run for this tag), fall back to a
+      # generic body — Release still ships but the maintainer is
+      # nudged via the body content to backfill notes.
+      - name: Build release notes
+        id: notes
+        shell: pwsh
+        run: |
+          $version = "${{ steps.version.outputs.version }}"
+          $body = "release-body.md"
+          python - <<PY > $body
+          import re, sys
+          version = "$version"
+          try:
+              text = open("CHANGELOG.md", encoding="utf-8").read()
+          except OSError:
+              text = ""
+          # Match `## [<version>] - <date>` through to the next `## [`
+          # or EOF. Escaped via re.escape so rc1 / pre-release segments
+          # work without surprises.
+          pat = re.compile(
+              r"^## \[" + re.escape(version) + r"\][^\n]*\n(.*?)(?=^## \[|\Z)",
+              re.DOTALL | re.MULTILINE,
+          )
+          m = pat.search(text)
+          if m:
+              print(m.group(1).strip())
+          else:
+              print(f"_No towncrier section found for {version} in CHANGELOG.md. See [`news/`](news/) for fragments._")
+          print()
+          print("---")
+          print()
+          print("### Installing on Windows")
+          print()
+          print("1. Download `${{ steps.version.outputs.asset_name }}` from the Assets section below.")
+          print("2. Extract the zip anywhere — the bundle is self-contained, no installer.")
+          print("3. Run `photo-manager.exe`.")
+          print()
+          print("**SmartScreen note:** the binary is unsigned, so Windows SmartScreen will show \"Windows protected your PC\" on first launch. Click **More info** → **Run anyway**. This will go away once we publish a signed release.")
+          PY
+          Write-Host "--- release-body.md ---"
+          Get-Content $body
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: pwsh
+        run: |
+          $tag = "${{ steps.version.outputs.tag }}"
+          $asset = "${{ steps.version.outputs.asset_name }}"
+          # --verify-tag ensures we're creating the release against
+          # the tag that actually triggered this run, not a moved ref.
+          $isPrerelease = if ($tag -match '-(rc|alpha|beta)') { "--prerelease" } else { "" }
+          gh release create $tag $asset `
+            --title $tag `
+            --notes-file release-body.md `
+            --verify-tag `
+            $isPrerelease.Split() | Out-Null
+          Write-Host "Release $tag created with asset $asset"

--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,7 @@ MANIFEST
 
 # Virtual environments
 .venv/
+.venv-build/
 venv/
 ENV/
 env/
@@ -36,6 +37,10 @@ env/
 # PyInstaller
 *.manifest
 *.spec
+# Exception: the canonical release spec lives at repo root and is
+# the single source of truth for the standalone Windows bundle —
+# tracked so the release workflow can checkout + invoke it.
+!pyinstaller.spec
 
 # Installer logs
 pip-log.txt

--- a/README.md
+++ b/README.md
@@ -39,7 +39,23 @@ Produces `migration_manifest.sqlite` consumed by **[photo-transfer](https://gith
 
 ---
 
-## Getting started
+## Download (Windows)
+
+A pre-built standalone bundle is published on every release tag — no Python install required.
+
+1. Grab the latest zip from **[Releases → latest](https://github.com/jackal998/photo-manager/releases/latest)**: look for `photo-manager-<version>-windows-x64.zip`.
+2. Extract anywhere — the folder is self-contained.
+3. Run `photo-manager.exe`.
+
+You still need [exiftool](https://exiftool.org/) on `PATH` for EXIF date extraction (same prerequisite as the source install).
+
+> **SmartScreen note:** the binary is unsigned, so on first launch Windows shows *"Windows protected your PC"*. Click **More info → Run anyway**. The warning is expected and will disappear once we publish a signed release.
+
+Settings (`settings.json`, `window_state.ini`) are written next to `photo-manager.exe`, so the extracted folder is portable — copy it to a USB stick and your config travels with it.
+
+---
+
+## Getting started (from source)
 
 ### Prerequisites
 

--- a/build-requirements.txt
+++ b/build-requirements.txt
@@ -1,0 +1,7 @@
+# Build-time-only deps for the standalone Windows release.
+# Kept separate from requirements.txt so the runtime dep set stays
+# clean (CI / dev install only what the running app needs).
+#
+# Installed alongside requirements.txt by .github/workflows/release.yml
+# and by local-build smoke testing — see CLAUDE.md release section.
+pyinstaller==6.11.1

--- a/main.py
+++ b/main.py
@@ -16,13 +16,21 @@ from infrastructure.image_service import ImageService
 from infrastructure.logging import init_logging
 from infrastructure.settings import JsonSettings
 
-BASE_DIR = Path(__file__).parent
-# QA / test runs may point at an alternative config root by setting
-# PHOTO_MANAGER_HOME. When unset, we keep the historical behavior of
-# reading settings.json from the repo root. Relative paths are
-# resolved against the repo root so the env var is robust to cwd.
-_home_env = os.environ.get("PHOTO_MANAGER_HOME")
-CONFIG_HOME = (BASE_DIR / _home_env).resolve() if _home_env else BASE_DIR
+if getattr(sys, "frozen", False):
+    # PyInstaller --onedir: bundled read-only assets (translations/) live
+    # under sys._MEIPASS, but writable user state (settings.json,
+    # window_state.ini) must sit next to the executable so it survives
+    # process exit and is discoverable / portable.
+    BASE_DIR = Path(sys._MEIPASS)  # type: ignore[attr-defined]
+    CONFIG_HOME = Path(sys.executable).parent
+else:
+    BASE_DIR = Path(__file__).parent
+    # QA / test runs may point at an alternative config root by setting
+    # PHOTO_MANAGER_HOME. When unset, we keep the historical behavior of
+    # reading settings.json from the repo root. Relative paths are
+    # resolved against the repo root so the env var is robust to cwd.
+    _home_env = os.environ.get("PHOTO_MANAGER_HOME")
+    CONFIG_HOME = (BASE_DIR / _home_env).resolve() if _home_env else BASE_DIR
 
 
 def _parse_default_sort(settings: JsonSettings) -> list[tuple[str, bool]]:

--- a/news/420.feature
+++ b/news/420.feature
@@ -1,0 +1,1 @@
+Standalone Windows .exe via PyInstaller — tag-push release pipeline, bundled HEIC + RAW codecs.

--- a/pyinstaller.spec
+++ b/pyinstaller.spec
@@ -1,0 +1,150 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""PyInstaller spec for photo-manager — --onedir Windows bundle.
+
+Built by .github/workflows/release.yml on tag push (v*.*.*) and
+locally via `pyinstaller pyinstaller.spec --clean --noconfirm`.
+
+Reproducibility:
+- No machine-specific absolute paths. SPECPATH resolves to the
+  directory holding this spec at build time (set automatically by
+  PyInstaller), keeping the spec portable across machines.
+- Hidden-imports and add-binary entries for pillow-heif and rawpy
+  are driven by their published packaging quirks, not guesses — see
+  the comments next to each block before editing.
+
+Iteration policy: refine the `excludes` list from real PyInstaller
+WARNINGs + the smoke step's stderr, never from speculation. The
+starter list is a generous trim aimed at PySide6's optional Qt
+modules and dev-only stdlib; entries that turn out to be required
+will show up as missing-module errors at runtime.
+"""
+
+from PyInstaller.utils.hooks import collect_all, collect_dynamic_libs
+
+# pillow-heif ships a compiled extension plus libheif/libde265/etc
+# native DLLs. collect_all picks up the Python package, data files,
+# and binaries in one call — the documented "just works" path for
+# this package.
+heif_datas, heif_binaries, heif_hiddenimports = collect_all("pillow_heif")
+
+# rawpy bundles libraw.dll under rawpy/libraw_*.dll on Windows.
+# collect_dynamic_libs is the documented helper for grabbing the
+# DLL without dragging in the entire site-packages tree.
+rawpy_binaries = collect_dynamic_libs("rawpy")
+
+block_cipher = None
+
+
+a = Analysis(
+    ["main.py"],
+    pathex=[],
+    binaries=heif_binaries + rawpy_binaries,
+    datas=heif_datas + [
+        # Bundled read-only assets resolved via sys._MEIPASS / BASE_DIR
+        # in main.py. translations/ holds the YAML catalogs the i18n
+        # layer reads at startup. No icons/PNGs are loaded by the app
+        # today (verified by grep) so only translations/ is bundled.
+        ("translations", "translations"),
+    ],
+    hiddenimports=heif_hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[
+        # PySide6 — optional modules the app doesn't import. Trims
+        # tens of MB. Refine from PyInstaller WARNINGs if any of these
+        # turn out to be transitively required.
+        "PySide6.Qt3DCore",
+        "PySide6.Qt3DRender",
+        "PySide6.Qt3DInput",
+        "PySide6.Qt3DLogic",
+        "PySide6.Qt3DAnimation",
+        "PySide6.Qt3DExtras",
+        "PySide6.QtWebEngine",
+        "PySide6.QtWebEngineCore",
+        "PySide6.QtWebEngineWidgets",
+        "PySide6.QtWebView",
+        "PySide6.QtCharts",
+        "PySide6.QtDataVisualization",
+        "PySide6.QtNetworkAuth",
+        "PySide6.QtBluetooth",
+        "PySide6.QtNfc",
+        "PySide6.QtPositioning",
+        "PySide6.QtLocation",
+        "PySide6.QtSerialPort",
+        "PySide6.QtSerialBus",
+        "PySide6.QtSensors",
+        "PySide6.QtTextToSpeech",
+        "PySide6.QtRemoteObjects",
+        "PySide6.QtScxml",
+        "PySide6.QtSql",
+        "PySide6.QtTest",
+        "PySide6.QtHelp",
+        "PySide6.QtDesigner",
+        # Stdlib modules pulled in by transitive deps but never used
+        # by the app's runtime path.
+        "tkinter",
+        "unittest",
+        "pydoc",
+        "doctest",
+        "pdb",
+        "bdb",
+        # Dev / test tooling — present in the build venv via
+        # requirements.txt? No: requirements.txt is runtime-only.
+        # Listed defensively in case a transitive dep imports them.
+        "pip",
+        "setuptools",
+        "wheel",
+        "pytest",
+        "_pytest",
+        "coverage",
+        "pylint",
+        "mypy",
+        "black",
+        "isort",
+        "ruff",
+        "jupyter",
+        "IPython",
+        "matplotlib",
+        # NOTE: scipy is NOT excluded — imagehash uses scipy.fftpack
+        # for phash() (verified: `import imagehash` source references
+        # scipy). Excluding it silently breaks deduplication scanning.
+        # rawpy itself doesn't need scipy, but imagehash does.
+    ],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name="photo-manager",
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=False,  # UPX often triggers AV false positives on Windows;
+                # SmartScreen unhappiness is already enough friction.
+    console=False,  # GUI app — no console window on launch.
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=False,
+    upx_exclude=[],
+    name="photo-manager",
+)


### PR DESCRIPTION
## Summary

Adds a tag-driven release pipeline so Windows end-users can grab a self-contained zip instead of cloning + venv + pip-install. Runtime deps stay clean — PyInstaller lives in `build-requirements.txt`, not `requirements.txt`.

## What changes

- `.github/workflows/release.yml` (new) — `push: tags: ['v*.*.*']` on `windows-latest`. Clean venv → PyInstaller `--onedir` → headless offscreen 5s no-crash smoke → zipped asset → `gh release create` with towncrier-section body from `CHANGELOG.md` + SmartScreen guidance. `-rc/-alpha/-beta` tags are auto-flagged as prerelease.
- `pyinstaller.spec` (new) — `--onedir`, `collect_all('pillow_heif')` + `collect_dynamic_libs('rawpy')` for the two finicky native deps, `translations/` bundled, exclude list for unused Qt modules / stdlib / dev tooling. scipy intentionally NOT excluded (imagehash uses scipy.fftpack for phash — verified).
- `build-requirements.txt` (new) — `pyinstaller==6.11.1` only.
- `main.py` — frozen-mode branch: `BASE_DIR = sys._MEIPASS` for bundled read-only assets, `CONFIG_HOME = Path(sys.executable).parent` so `settings.json` / `window_state.ini` persist next to the .exe (portable). Dev mode unchanged.
- `README.md` — new "Download (Windows)" section ahead of source install, with link to `/releases/latest` and SmartScreen "More info → Run anyway" note.
- `.gitignore` — `!pyinstaller.spec` exception (canonical spec is trackable); `.venv-build/` ignored.

## Local verification (already run)

| Check | Result |
|---|---|
| Fresh `.venv-build` install | PASS |
| `pyinstaller pyinstaller.spec --clean --noconfirm` | PASS — 289 MB bundle |
| Native libs in `_internal/` (libheif, libde265, raw_r.dll) | PASS |
| Translations bundled | PASS |
| exe boots offscreen 5s — no crash | PASS |
| HEIC decode via bundled libs (`scene_a.heic`) | PASS |
| DNG decode via bundled libs (`IMG_1026.DNG`) | PASS |

Only PyInstaller WARNING: `Hidden import "scipy.special._cdflib" not found!` — harmless, not in the app's code path.

## Constraint compliance

Touched ONLY the files in the goal's allow-list (plus `.gitignore` — mechanically required to make the spec trackable, narrowest possible `!pyinstaller.spec` exception). Did not modify: 5 existing CI workflows, `scanner/`, `core/`, `app/views/`, `tests/`, `qa/`, `translations/`, `requirements.txt`.

## Test plan

- [ ] CI tests still green on this branch (unchanged behaviour for `python main.py` path).
- [ ] After merge: push tag `v0.1.0-rc1` from master, watch `release.yml` go green, download the zip asset.
- [ ] Extract on a clean Windows machine WITHOUT Python installed, run `photo-manager.exe`, scan a small folder, preview HEIC + RAW.

🤖 Generated with [Claude Code](https://claude.com/claude-code)