### PR TITLE
fix(release): pwsh here-string in release-notes step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -117,19 +117,23 @@ jobs:
       - name: Build release notes
         id: notes
         shell: pwsh
+        env:
+          RELEASE_VERSION: ${{ steps.version.outputs.version }}
+          RELEASE_ASSET: ${{ steps.version.outputs.asset_name }}
         run: |
-          $version = "${{ steps.version.outputs.version }}"
-          $body = "release-body.md"
-          python - <<PY > $body
-          import re, sys
-          version = "$version"
+          # PowerShell here-string (@' ... '@) piped to `python -`.
+          # Bash-style `python - <<PY` heredoc isn't valid pwsh — pwsh
+          # parses `<` as a redirection operator. Variables flow in via
+          # env vars so the script body has no ${{ }} interpolation
+          # that could collide with Python's f-string braces.
+          $py = @'
+          import os, re
+          version = os.environ["RELEASE_VERSION"]
+          asset = os.environ["RELEASE_ASSET"]
           try:
               text = open("CHANGELOG.md", encoding="utf-8").read()
           except OSError:
               text = ""
-          # Match `## [<version>] - <date>` through to the next `## [`
-          # or EOF. Escaped via re.escape so rc1 / pre-release segments
-          # work without surprises.
           pat = re.compile(
               r"^## \[" + re.escape(version) + r"\][^\n]*\n(.*?)(?=^## \[|\Z)",
               re.DOTALL | re.MULTILINE,
@@ -144,14 +148,15 @@ jobs:
           print()
           print("### Installing on Windows")
           print()
-          print("1. Download `${{ steps.version.outputs.asset_name }}` from the Assets section below.")
+          print(f"1. Download `{asset}` from the Assets section below.")
           print("2. Extract the zip anywhere — the bundle is self-contained, no installer.")
           print("3. Run `photo-manager.exe`.")
           print()
-          print("**SmartScreen note:** the binary is unsigned, so Windows SmartScreen will show \"Windows protected your PC\" on first launch. Click **More info** → **Run anyway**. This will go away once we publish a signed release.")
-          PY
+          print("**SmartScreen note:** the binary is unsigned, so Windows SmartScreen will show \"Windows protected your PC\" on first launch. Click **More info** -> **Run anyway**. This will go away once we publish a signed release.")
+          '@
+          $py | python - | Out-File -FilePath release-body.md -Encoding utf8
           Write-Host "--- release-body.md ---"
-          Get-Content $body
+          Get-Content release-body.md
 
       - name: Create GitHub Release
         env:

--- a/news/421.bugfix
+++ b/news/421.bugfix
@@ -1,0 +1,1 @@
+Fix release.yml "Build release notes" step — bash heredoc syntax replaced with PowerShell here-string piped to `python -`.


### PR DESCRIPTION
## Summary

Hotfix for #420's `release.yml`. The "Build release notes" step used `python - <<PY > \$body` — bash heredoc syntax. The step runs under `shell: pwsh`, which parses `<` as a redirection operator and errors with:

```
ParserError: Missing file specification after redirection operator.
```

Discovered when tag `v0.1.0-rc1` fired the workflow: build + smoke + zip all green ✅, then release-notes failed and the Release was never created. Workflow run: https://github.com/jackal998/photo-manager/actions/runs/26431719041

## Fix

Rewrite the step to use a PowerShell here-string (`@'...'@`) piped to `python -`. Version + asset name flow in via env vars (`RELEASE_VERSION`, `RELEASE_ASSET`) so the Python body has no `${{ }}` interpolation that could collide with f-string braces.

## What this confirms (positive data from the failed run)

Even though release-notes failed, the run gave us strong evidence the rest works on the hosted runner:

- ✅ Clean venv install from `requirements.txt` + `build-requirements.txt`
- ✅ PyInstaller `--onedir` build (matches local 289 MB)
- ✅ Headless offscreen 5s no-crash smoke
- ✅ Zip asset created

Once this hotfix merges, re-tagging `v0.1.0-rc1` against the new master tip should produce a green workflow + Release.

## Test plan

- [ ] Merge this PR.
- [ ] Delete + recreate `v0.1.0-rc1` tag against new master tip.
- [ ] Verify `release.yml` goes fully green + Release published with asset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)