### PR TITLE
fix(release): pure-pwsh release-notes step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,40 +121,31 @@ jobs:
           RELEASE_VERSION: ${{ steps.version.outputs.version }}
           RELEASE_ASSET: ${{ steps.version.outputs.asset_name }}
         run: |
-          # PowerShell here-string (@' ... '@) piped to `python -`.
-          # Bash-style `python - <<PY` heredoc isn't valid pwsh — pwsh
-          # parses `<` as a redirection operator. Variables flow in via
-          # env vars so the script body has no ${{ }} interpolation
-          # that could collide with Python's f-string braces.
-          $py = @'
-          import os, re
-          version = os.environ["RELEASE_VERSION"]
-          asset = os.environ["RELEASE_ASSET"]
-          try:
-              text = open("CHANGELOG.md", encoding="utf-8").read()
-          except OSError:
-              text = ""
-          pat = re.compile(
-              r"^## \[" + re.escape(version) + r"\][^\n]*\n(.*?)(?=^## \[|\Z)",
-              re.DOTALL | re.MULTILINE,
+          $version = $env:RELEASE_VERSION
+          $asset = $env:RELEASE_ASSET
+          $changelog = if (Test-Path CHANGELOG.md) { Get-Content -Raw CHANGELOG.md } else { "" }
+          $escaped = [regex]::Escape($version)
+          $pattern = '(?ms)^## \[' + $escaped + '\][^\n]*\n(.*?)(?=^## \[|\z)'
+          $m = [regex]::Match($changelog, $pattern)
+          if ($m.Success) {
+            $section = $m.Groups[1].Value.Trim()
+          } else {
+            $section = "_No towncrier section found for $version in CHANGELOG.md. See news/ for fragments._"
+          }
+          $lines = @(
+            $section,
+            "",
+            "---",
+            "",
+            "### Installing on Windows",
+            "",
+            "1. Download ``$asset`` from the Assets section below.",
+            "2. Extract the zip anywhere - the bundle is self-contained, no installer.",
+            "3. Run ``photo-manager.exe``.",
+            "",
+            "**SmartScreen note:** the binary is unsigned, so Windows SmartScreen will show ""Windows protected your PC"" on first launch. Click **More info** -> **Run anyway**. This will go away once we publish a signed release."
           )
-          m = pat.search(text)
-          if m:
-              print(m.group(1).strip())
-          else:
-              print(f"_No towncrier section found for {version} in CHANGELOG.md. See [`news/`](news/) for fragments._")
-          print()
-          print("---")
-          print()
-          print("### Installing on Windows")
-          print()
-          print(f"1. Download `{asset}` from the Assets section below.")
-          print("2. Extract the zip anywhere — the bundle is self-contained, no installer.")
-          print("3. Run `photo-manager.exe`.")
-          print()
-          print("**SmartScreen note:** the binary is unsigned, so Windows SmartScreen will show \"Windows protected your PC\" on first launch. Click **More info** -> **Run anyway**. This will go away once we publish a signed release.")
-          '@
-          $py | python - | Out-File -FilePath release-body.md -Encoding utf8
+          $lines -join "`n" | Out-File -FilePath release-body.md -Encoding utf8
           Write-Host "--- release-body.md ---"
           Get-Content release-body.md
 

--- a/news/422.bugfix
+++ b/news/422.bugfix
@@ -1,0 +1,1 @@
+release.yml release-notes step rewritten as pure PowerShell — drops Python+here-string interaction that GitHub Actions YAML parser rejected.


### PR DESCRIPTION
## Summary

PR #421's pwsh here-string + `python -` rewrite parsed locally (PyYAML) but GitHub Actions rejected the workflow file at parse time. Symptoms: workflow runs displayed the file path instead of the `name:` field, jobs array empty, generic "workflow file issue" error with no annotations. Couldn't pin down the exact character pattern GH's parser disliked — likely interaction between the `@'...'@` here-string body's Python f-string braces (`{version}`, `{asset}`) and GH's expression evaluator, even though those were single-brace literals not `${{ }}`.

## Fix

Drop Python from the step. Rewrite as pure PowerShell using `[regex]::Match` against `CHANGELOG.md`. No here-string, no nested quoting, no Python invocation. Much simpler to audit and avoids the parse failure mode entirely.

## Iteration log so far

- Workflow attempt #1 (tag rc1, run 26431719041, commit d0f8a43): build + smoke + zip ✅, release-notes ❌ (bash heredoc in pwsh) — known root cause.
- Hotfix #1 (PR #421, commit f3633af): pwsh here-string + python. **Workflow file failed to parse on GH** despite PyYAML accepting it. Run 26432195302 — file path instead of workflow name, zero jobs.
- Hotfix #2 (this PR, commit 83ea320): pure pwsh. Goal: GH parser accepts it AND release-notes step produces a valid body.

## Test plan

- [ ] Merge this PR.
- [ ] Delete + recreate `v0.1.0-rc1` tag.
- [ ] Verify `release.yml` runs to completion: build ✅ → smoke ✅ → zip ✅ → release-notes ✅ → `gh release create` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)