### PR TITLE
fix(i18n): preserve loaded manifest across language switch (#428)

### DIFF
--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -807,18 +807,23 @@ class MainWindow(QMainWindow):
 
     def _capture_relocalize_state(self) -> dict:
         """Snapshot the bits of UI state worth carrying across a live
-        language switch — window geometry, splitter sizes, and the
-        selected file row's path. Tree expansion isn't preserved
+        language switch — window geometry, splitter sizes, the
+        selected file row's path, and the loaded manifest path so the
+        new window can re-load it. Tree expansion isn't preserved
         because ``TreeController.refresh_model`` always expands all
         groups by default; preview doesn't need preservation because
-        re-selecting the same row triggers it. vm-side state
-        (manifest, decisions) survives automatically because vm
-        outlives the window."""
+        re-selecting the same row triggers it. vm holds the in-memory
+        groups but the freshly-constructed MainWindow never calls
+        ``refresh_tree`` on its own, so without ``manifest_path`` the
+        user would land on the empty-state hint despite
+        ``language.confirm_body`` promising the manifest stays intact
+        (#428)."""
         state: dict = {
             "geometry": bytes(self.saveGeometry()),
             "splitter_state": None,
             "selected_path": None,
             "thumb_size": self._thumb_size,
+            "manifest_path": getattr(self.file_operations, "_manifest_path", None),
         }
         try:
             splitter = self.layout_manager.get_splitter()
@@ -853,8 +858,40 @@ class MainWindow(QMainWindow):
                 splitter.restoreState(sp_state)
         except Exception:
             pass
+        # #428 — restore the manifest BEFORE re-selecting. The freshly
+        # built MainWindow has no tree rows of its own; vm still holds
+        # the groups in memory but the new window never auto-renders
+        # them. Calling _load_manifest_from_path re-reads from the
+        # SQLite path, repopulates the tree, refreshes status-bar +
+        # menu-action gates, and makes _reselect_by_path's walk find
+        # anything. Done unconditionally when a path was captured —
+        # the vm-in-memory state and on-disk state are kept in sync
+        # by file_operations.save_manifest_decisions_silent() being
+        # called in relocalize() before the swap.
+        manifest_path = state.get("manifest_path")
+        if manifest_path:
+            try:
+                self._load_manifest_from_path(manifest_path)
+            except Exception:
+                pass
+            # refresh_tree's "hide empty-state widget" branch is gated
+            # on ``self._empty_state_widget.isVisible()``, which Qt
+            # returns False for during the relocalize swap because the
+            # new MainWindow hasn't been show()'n yet. Without the
+            # explicit flip below the guard misses, leaving the tree
+            # hidden and the empty-state hint visible after show() —
+            # the user-visible half of the #428 regression. The
+            # initial-load flow doesn't hit this because the user
+            # discovers the menu on an already-shown window.
+            try:
+                self._empty_state_widget.setVisible(False)
+                self.tree.setVisible(True)
+            except Exception:
+                pass
         # Re-select the previously-selected row by file_path. The tree
-        # is already populated by refresh_tree at construction time.
+        # is now populated either by refresh_tree at construction time
+        # (no manifest case) or by the _load_manifest_from_path call
+        # above (#428).
         target = state.get("selected_path")
         if target:
             try:
@@ -891,6 +928,22 @@ class MainWindow(QMainWindow):
         # Local import avoids a module-level cycle (main imports
         # MainWindow at module level; this is a runtime call).
         from main import install_locale_translators, make_main_window
+
+        # #428 — flush pending decisions to disk BEFORE the swap. The
+        # new MainWindow re-loads the manifest from SQLite (see
+        # _apply_relocalize_state), so any in-memory decisions the
+        # user set after the last save would otherwise be silently
+        # discarded by the reload. The save is a no-op when nothing
+        # is dirty, and the silent helper returns False on
+        # save-failure rather than raising — we proceed with the swap
+        # either way because dropping the language switch entirely
+        # after the user already clicked "Yes" on the confirm prompt
+        # is the worse UX failure mode.
+        try:
+            if self.file_operations.is_dirty():
+                self.file_operations.save_manifest_decisions_silent()
+        except Exception:
+            pass
 
         saved = self._capture_relocalize_state()
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -233,10 +233,10 @@ for the chore plan.
 
 - **Entry point:** Main window menu → **View > Language** submenu — built by `menu_controller.py` via `QActionGroup(exclusive=True)`.
 - **Trigger:** User picks a locale from the Language submenu.
-- **Behaviour:** A Yes/No confirm prompt appears. On Yes the `MainWindow` rebuilds in place via the same factory used at startup — no app restart needed. State preserved best-effort: window geometry, splitter sizes, selected row's path. The chosen locale persists to `settings.json` under `ui.locale`.
+- **Behaviour:** A Yes/No confirm prompt appears. On Yes the `MainWindow` rebuilds in place via the same factory used at startup — no app restart needed. State preserved best-effort: window geometry, splitter sizes, selected row's path. If a manifest was loaded pre-switch, it is re-loaded into the new window so the result tree stays populated — any pending decisions are silent-saved to the manifest's SQLite before the swap so the reload sees the user's latest state ([#428](https://github.com/jackal998/photo-manager/issues/428)). The chosen locale persists to `settings.json` under `ui.locale`.
 - **Conditions / variants:** Available locales are discovered from `translations/<code>.yml` files. Each new YAML file appearing alongside `en.yml` shows up automatically in the picker on the next launch (no enum to update). Adding a new locale: copy `en.yml` → `<code>.yml`, translate values, restart once. Picking the already-active locale is a no-op (no confirm fires).
-- **Related:** [PR #157](https://github.com/jackal998/photo-manager/pull/157); QA scenario [`qa/scenarios/s22_language_switch.py`](../qa/scenarios/s22_language_switch.py); translator workflow in [`docs/i18n.md`](i18n.md).
-- **Last verified:** 2026-05-21 (sweep for [#326](https://github.com/jackal998/photo-manager/issues/326))
+- **Related:** [PR #157](https://github.com/jackal998/photo-manager/pull/157), [#428](https://github.com/jackal998/photo-manager/issues/428); QA scenarios [`qa/scenarios/s22_language_switch.py`](../qa/scenarios/s22_language_switch.py) and [`qa/scenarios/s58_language_switch_preserves_manifest.py`](../qa/scenarios/s58_language_switch_preserves_manifest.py); translator workflow in [`docs/i18n.md`](i18n.md).
+- **Last verified:** 2026-05-27 (manifest-preservation behaviour landed via [#428](https://github.com/jackal998/photo-manager/issues/428))
 
 ---
 

--- a/news/434.bugfix
+++ b/news/434.bugfix
@@ -1,0 +1,1 @@
+Preserve loaded manifest visibility across View → Language switch. (#428)

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -235,6 +235,12 @@ ALL_SCENARIOS = [
     # scored group user_decision='delete'. Non-destructive (manifest
     # writes only).
     "s57_scan_auto_select_aggressive",
+    # s58 (#428) — language switch preserves the loaded manifest.
+    # Scan + load the near-duplicates fixture, then trigger View →
+    # Language → 繁體中文; the post-switch result tree MUST still
+    # show the 5 file rows the user had pre-switch. Driver restores
+    # ui.locale=en on exit (mirrors s22).
+    "s58_language_switch_preserves_manifest",
 ]
 
 

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -228,6 +228,12 @@ SCENARIO_SOURCES: dict[str, list[str] | None] = {
     # the four non-keepers user_decision='delete'. Non-destructive
     # (writes manifest decisions only — no file moves).
     "s57_scan_auto_select_aggressive": ["qa/sandbox/near-duplicates"],
+    # s58 (#428) — language switch must preserve the loaded manifest
+    # across the live-relocalize rebuild. Same near-duplicates fixture
+    # so the post-switch row count is non-zero (5 files in 1 group);
+    # zero rows would be ambiguous with "manifest never loaded".
+    # Driver MUST restore ui.locale=en before exiting (see s22).
+    "s58_language_switch_preserves_manifest": ["qa/sandbox/near-duplicates"],
 }
 
 

--- a/qa/scenarios/s58_language_switch_preserves_manifest.py
+++ b/qa/scenarios/s58_language_switch_preserves_manifest.py
@@ -1,0 +1,237 @@
+"""Scenario 58 — language switch preserves the loaded manifest (#428).
+
+Required source: ``qa/sandbox/near-duplicates`` (5 files, basenames
+``neardup_NN_qXX.jpg``). The scan-and-load preamble is what makes
+this scenario different from s22 — s22 only checks menu wiring
+post-switch (the menu titles become zh_TW), and intentionally runs
+on an empty source list. This driver loads a manifest first so the
+relocalize path is exercised in the state where the bug actually
+fires: ``MainWindow._capture_relocalize_state`` snapshots a
+manifest in flight, the swap happens, and the new MainWindow has
+to repopulate the tree.
+
+What this catches that s22 can't:
+  * The user-visible #428 regression — language.confirm_body
+    promises "your loaded manifest and decisions stay intact", but
+    pre-fix the freshly-built MainWindow showed the empty-state
+    hint despite vm still holding the groups in memory. Pre-fix
+    ``read_tree_row_order`` post-switch would return ``[]``;
+    post-fix it returns the 5 neardup basenames the user saw before
+    clicking the language item.
+  * Coupling between ``_capture_relocalize_state`` and
+    ``_apply_relocalize_state`` — a future refactor that strips
+    ``manifest_path`` from the state-dict on one side but not the
+    other would pass s22 (no manifest involved) and fail here.
+
+What this does NOT verify (covered elsewhere):
+  * Language switch end-to-end (menu → confirm → relocale) — s22.
+  * No-path (cancel) confirm branch — layer-1 in
+    ``tests/test_menu_controller_manifest_actions.py``.
+  * Per-key capture/apply round-trip of ``manifest_path`` — layer-1
+    in ``tests/test_main_window.py``.
+
+INI / settings.json lifecycle:
+  * Mirrors s22 — read ``qa/settings.json`` to snapshot ``ui.locale``,
+    ALWAYS restore to ``en`` on exit (success or failure) so the
+    next scenario in the batch doesn't relaunch in 繁體中文.
+"""
+from __future__ import annotations
+
+import json
+import sys
+import time
+from pathlib import Path
+
+from qa.scenarios import _uia
+
+REPO = Path(__file__).resolve().parents[2]
+SETTINGS_PATH = REPO / "qa" / "settings.json"
+
+
+def _read_settings() -> dict:
+    if not SETTINGS_PATH.exists():
+        return {}
+    return json.loads(SETTINGS_PATH.read_text(encoding="utf-8"))
+
+
+def _write_settings(data: dict) -> None:
+    SETTINGS_PATH.write_text(
+        json.dumps(data, indent=2, ensure_ascii=False), encoding="utf-8"
+    )
+
+
+def _set_locale(data: dict, locale: str) -> dict:
+    out = dict(data)
+    ui = dict(out.get("ui", {}))
+    ui["locale"] = locale
+    out["ui"] = ui
+    return out
+
+
+def main() -> int:
+    print("scenario: s58_language_switch_preserves_manifest")
+    app, win = _uia.connect_main()
+    pid = win.process_id()
+    print(f"connected: pid={pid} title={win.window_text()!r}")
+
+    failures: list[str] = []
+    initial_settings = _read_settings()
+    print(f"  initial_locale={initial_settings.get('ui', {}).get('locale', 'en')!r}")
+
+    # ── Preamble: scan + close-and-load so a manifest is in flight ──
+    # Mirrors AUTHORING.md "Scan + close-and-load to set up a manifest"
+    # row — the standard way to reach a "manifest loaded" state
+    # without poking at SQLite directly.
+    print("step: scan_and_load_manifest")
+    try:
+        scan_dlg, _ = _uia.open_scan_dialog(win)
+        log, elapsed = _uia.run_scan_and_wait(scan_dlg, timeout=30)
+        print(f"  scan_elapsed_s={elapsed:.2f}")
+        _uia.close_and_load_manifest(scan_dlg)
+        # close_and_load_manifest tears down the dialog wrapper; refresh
+        # the main-window handle for the menu-driven step below.
+        _, win = _uia.connect_main()
+    except Exception as exc:
+        print(f"FAIL: scan preamble raised {exc!r}")
+        _write_settings(_set_locale(initial_settings, "en"))
+        return 1
+
+    # Capture the pre-switch tree state — the user's oracle for "did
+    # my manifest survive". Use the same basename-regex helper s49 /
+    # s52 / s56 use; it returns file rows in display order, so the
+    # post-switch comparison is order-sensitive (within-group order
+    # is part of the language switch's "intact" promise).
+    print("step: capture_pre_switch_tree_rows")
+    pre_rows = _uia.read_tree_row_order(win)
+    print(f"  pre_rows={pre_rows!r}")
+    if not pre_rows:
+        # The scan should have produced 5 neardup file rows in 1 group.
+        # If we got 0 here, the preamble failed silently — bail rather
+        # than running the language switch and asserting nothing.
+        failures.append(
+            "Pre-switch tree had no file rows — scan preamble failed "
+            "silently. Aborting before language switch."
+        )
+        _write_settings(_set_locale(initial_settings, "en"))
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    old_hwnd = win.handle
+
+    # ── Trigger View → Language → 繁體中文 ──────────────────────────
+    print("step: open_view_language_zh_tw")
+    try:
+        _uia.open_menu(win, _uia.MENU_VIEW)
+        _uia.select_popup_menu_path(
+            pid, [_uia.VIEW_LANGUAGE, _uia.VIEW_LANG_ZH_TW]
+        )
+    except Exception as exc:
+        print(f"FAIL: navigating View → Language → 繁體中文 raised {exc!r}")
+        _write_settings(_set_locale(initial_settings, "en"))
+        return 1
+
+    print("step: confirm_language_switch_yes")
+    try:
+        confirm_hwnd = _uia.wait_for_dialog(
+            pid, _uia.LANGUAGE_CONFIRM_TITLE, timeout=3
+        )
+    except Exception as exc:
+        print(f"FAIL: language-confirm prompt did not appear: {exc!r}")
+        _write_settings(_set_locale(initial_settings, "en"))
+        return 1
+    confirm_dlg = _uia.connect_by_handle(confirm_hwnd)
+    confirm_dlg.child_window(title="Yes", control_type="Button").click_input()
+
+    # ── Reconnect to the post-switch window ─────────────────────────
+    # Same poll pattern as s22 — the relocalize swap can take >1 s on
+    # CI runners, and the result-tree population on the new window is
+    # what we actually care about, not just "a new HWND exists". Poll
+    # for both (HWND change AND tree rows non-empty) so the assertion
+    # below isn't racing the relocalize.
+    print("step: reconnect_after_live_switch")
+    deadline = time.time() + 15.0
+    new_win = None
+    last_hwnd: int | None = None
+    last_rows: list[str] = []
+    while time.time() < deadline:
+        try:
+            _, candidate = _uia.connect_main(timeout=1)
+        except Exception:
+            time.sleep(0.2)
+            continue
+        cand_hwnd = candidate.handle
+        if cand_hwnd == old_hwnd:
+            time.sleep(0.2)
+            continue
+        last_hwnd = cand_hwnd
+        last_rows = _uia.read_tree_row_order(candidate)
+        if last_rows:
+            new_win = candidate
+            break
+        # New window exists but tree not yet rebuilt — keep polling.
+        # If this loop times out with new_win=None but last_hwnd set,
+        # the bug is present (window was rebuilt but tree never
+        # repopulated) and the assertion below will report it.
+        time.sleep(0.2)
+    print(
+        f"  new_hwnd={last_hwnd!r}  old_hwnd={old_hwnd!r}  "
+        f"reconnect_ok={new_win is not None}"
+    )
+
+    # ── Core assertion (#428) ────────────────────────────────────────
+    # Post-switch the tree MUST show file rows. Pre-fix this is where
+    # the scenario fails — last_rows stays [] for the full 15 s deadline
+    # because the new MainWindow never calls refresh_tree on its own.
+    print("step: verify_tree_repopulated_after_switch")
+    post_rows = last_rows if new_win is None else _uia.read_tree_row_order(new_win)
+    print(f"  post_rows={post_rows!r}")
+    if not post_rows:
+        failures.append(
+            "Post-switch tree has no file rows — language.confirm_body "
+            "promises the manifest stays intact, but the new MainWindow "
+            "is showing the empty-state hint instead (#428 regressed)."
+        )
+
+    # Stronger oracle when the basic check passed — the user-visible
+    # promise is the SAME manifest, not just A manifest. Compare the
+    # display-ordered basenames; tolerate order-only drift by treating
+    # them as multisets too (with a separate failure message so the
+    # bisect points at the right thing).
+    if post_rows:
+        if set(post_rows) != set(pre_rows):
+            failures.append(
+                f"Post-switch row basenames {sorted(post_rows)!r} "
+                f"don't match pre-switch {sorted(pre_rows)!r} — "
+                f"different manifest survived the swap"
+            )
+        elif post_rows != pre_rows:
+            failures.append(
+                f"Row order shifted across switch: pre={pre_rows!r} "
+                f"post={post_rows!r} — within-group display order is "
+                f"part of the 'stays intact' promise"
+            )
+
+    # ── Cleanup — ALWAYS restore en, even on failure ───────────────
+    print("step: restore_locale_to_en")
+    persisted = _read_settings()
+    _write_settings(_set_locale(persisted or initial_settings, "en"))
+    restored = _read_settings().get("ui", {}).get("locale")
+    print(f"  restored_locale={restored!r}")
+    if restored != "en":
+        failures.append(
+            f"Could not restore ui.locale=en for subsequent scenarios; "
+            f"settings.json still says {restored!r}"
+        )
+
+    if failures:
+        for f in failures:
+            print(f"FAIL: {f}")
+        return 1
+
+    print("scenario: s58_language_switch_preserves_manifest DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1131,6 +1131,10 @@ def test_capture_relocalize_state_captures_first_selected_file_path():
         layout_manager=fake_layout,
         tree_controller=fake_tc,
         _thumb_size=512,
+        # #428 — capture now reads file_operations._manifest_path too.
+        # An unloaded handler (no _manifest_path attr) is the
+        # relevant baseline for the selected-path contract.
+        file_operations=SimpleNamespace(),
     )
 
     state = MainWindow._capture_relocalize_state(fake_self)
@@ -1181,6 +1185,138 @@ def test_apply_relocalize_state_skips_reselect_when_no_path():
     )
 
     fake_self._reselect_by_path.assert_not_called()
+
+
+# ── relocalize manifest_path round-trip (#428) ───────────────────────────
+
+
+def test_capture_relocalize_state_captures_manifest_path():
+    """``_capture_relocalize_state`` must include the loaded manifest
+    path so the post-switch MainWindow can re-load it (#428).
+
+    Failure mode (the original #428 bug, restated as a test): without
+    this key the new MainWindow shows the empty-state hint after a
+    language switch even though ``language.confirm_body`` told the
+    user "your loaded manifest and decisions stay intact". A
+    regression would silently strip the key from the snapshot — the
+    new window would have nothing to call ``_load_manifest_from_path``
+    on and the tree would render empty.
+    """
+    fake_layout = MagicMock()
+    fake_layout.get_splitter.return_value = None
+    fake_tc = MagicMock()
+    fake_tc.get_selected_items.return_value = []
+    fake_self = SimpleNamespace(
+        saveGeometry=lambda: b"",
+        layout_manager=fake_layout,
+        tree_controller=fake_tc,
+        _thumb_size=256,
+        file_operations=SimpleNamespace(_manifest_path="/tmp/m.sqlite"),
+    )
+
+    state = MainWindow._capture_relocalize_state(fake_self)
+
+    assert state["manifest_path"] == "/tmp/m.sqlite"
+
+
+def test_capture_relocalize_state_manifest_path_none_when_unloaded():
+    """When no manifest is loaded, ``_manifest_path`` may be unset on
+    file_operations. The capture must fall back to ``None`` rather
+    than raising — relocalize is reachable from the menu before any
+    scan / open has populated the handler attr."""
+    fake_layout = MagicMock()
+    fake_layout.get_splitter.return_value = None
+    fake_tc = MagicMock()
+    fake_tc.get_selected_items.return_value = []
+    fake_self = SimpleNamespace(
+        saveGeometry=lambda: b"",
+        layout_manager=fake_layout,
+        tree_controller=fake_tc,
+        _thumb_size=256,
+        # Handler with no _manifest_path attribute at all — mirrors the
+        # pre-first-scan state of the real FileOperationsHandler.
+        file_operations=SimpleNamespace(),
+    )
+
+    state = MainWindow._capture_relocalize_state(fake_self)
+
+    assert state["manifest_path"] is None
+
+
+def test_apply_relocalize_state_reloads_manifest_when_path_in_state():
+    """``_apply_relocalize_state`` with a non-None ``manifest_path``
+    must call ``_load_manifest_from_path``. This is the user-visible
+    half of the #428 fix — the freshly-built MainWindow has no tree
+    rows until something repopulates them, and the SQLite re-load
+    rebuilds tree + status bar + menu-action gating in one call.
+    Reload happens BEFORE the reselect call so the row walk has
+    something to find.
+    """
+    call_order: list[str] = []
+    fake_empty = MagicMock()
+    fake_tree = MagicMock()
+    fake_self = SimpleNamespace(
+        restoreGeometry=lambda b: None,
+        layout_manager=MagicMock(),
+        _load_manifest_from_path=MagicMock(
+            side_effect=lambda _p: call_order.append("load")
+        ),
+        _reselect_by_path=MagicMock(
+            side_effect=lambda _p: call_order.append("select")
+        ),
+        _empty_state_widget=fake_empty,
+        tree=fake_tree,
+    )
+    fake_self.layout_manager.get_splitter.return_value = None
+
+    MainWindow._apply_relocalize_state(
+        fake_self,
+        {
+            "geometry": None,
+            "splitter_state": None,
+            "selected_path": "/photos/sel.jpg",
+            "thumb_size": 256,
+            "manifest_path": "/tmp/m.sqlite",
+        },
+    )
+
+    fake_self._load_manifest_from_path.assert_called_once_with("/tmp/m.sqlite")
+    # Reload must precede reselect — without rows the reselect walk
+    # finds nothing and the previous-row recovery silently no-ops.
+    assert call_order == ["load", "select"]
+    # Pin the explicit visibility flip — refresh_tree's isVisible()
+    # guard misses pre-show, so without this flip the empty-state
+    # widget stays visible and the tree stays hidden after show()
+    # even though the model has rows.
+    fake_empty.setVisible.assert_called_once_with(False)
+    fake_tree.setVisible.assert_called_once_with(True)
+
+
+def test_apply_relocalize_state_skips_reload_when_no_manifest_path():
+    """A relocalize with no manifest in flight (user switched language
+    on the empty-state window) must not call _load_manifest_from_path
+    — there's nothing to load, and the existing tree-empty state is
+    already the desired post-switch state."""
+    fake_self = SimpleNamespace(
+        restoreGeometry=lambda b: None,
+        layout_manager=MagicMock(),
+        _load_manifest_from_path=MagicMock(),
+        _reselect_by_path=MagicMock(),
+    )
+    fake_self.layout_manager.get_splitter.return_value = None
+
+    MainWindow._apply_relocalize_state(
+        fake_self,
+        {
+            "geometry": None,
+            "splitter_state": None,
+            "selected_path": None,
+            "thumb_size": 0,
+            "manifest_path": None,
+        },
+    )
+
+    fake_self._load_manifest_from_path.assert_not_called()
 
 
 def test_window_state_qsettings_shim_delegates_to_module():


### PR DESCRIPTION
## Summary

- `View > Language` switch now preserves the loaded manifest: the new MainWindow re-loads the SQLite path captured pre-swap, and pending decisions are silent-saved before the rebuild so the reload sees the user's latest state. Closes #428.
- Fixes the visibility gap where `refresh_tree`'s `isVisible()` guard misses on a never-shown window during relocalize, which left the empty-state hint up after the swap even with a populated tree model.
- New layer-3 driver `qa/scenarios/s58_language_switch_preserves_manifest.py` scans the near-duplicates fixture, switches to 繁體中文, and asserts the post-switch tree shows the same 5 file rows in the same display order. Layer-1 tests pin the capture/apply round-trip (manifest_path key, None fallback, reload-before-reselect order, visibility flip).
- `docs/features.md` Language switch entry updated to document the manifest-preservation behaviour.

## Test plan

- [x] `pytest` — 1761 passed, 2 skipped, 89% global coverage
- [x] `python scripts/check_coverage_per_file.py` — all 62 files clear the 70% per-file floor
- [x] `python -m qa.scenarios._batch s58_language_switch_preserves_manifest` — passes against the fix (post_rows match pre_rows; 5 neardup files in display order preserved across the swap)
- [ ] CI green on the PR

Closes #428