### PR TITLE
fix(scanner): suppress exiftool console window in windowed builds (#427)

### DIFF
--- a/news/435.bugfix
+++ b/news/435.bugfix
@@ -1,0 +1,1 @@
+Suppress visible exiftool console window during scans in PyInstaller windowed builds. (#427)

--- a/scanner/exif.py
+++ b/scanner/exif.py
@@ -4,11 +4,18 @@ from __future__ import annotations
 
 import json
 import subprocess
+import sys
 import threading
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
 from typing import Optional
+
+# Suppress the fresh-console window Windows allocates for a console-subsystem
+# child (exiftool) spawned by a windowed-subsystem parent (PyInstaller
+# ``--noconsole`` build, PR #420). On POSIX the constant is undefined, so we
+# fall back to 0 — a no-op ``creationflags`` value on every platform.
+_CREATE_NO_WINDOW = subprocess.CREATE_NO_WINDOW if sys.platform == "win32" else 0
 
 
 class ExiftoolProcess:
@@ -47,6 +54,7 @@ class ExiftoolProcess:
             stderr=subprocess.PIPE,
             encoding="utf-8",
             errors="replace",
+            creationflags=_CREATE_NO_WINDOW,
         )
         self._stderr_buf: list[str] = []
         self._stderr_lock = threading.Lock()

--- a/tests/test_scanner_exif.py
+++ b/tests/test_scanner_exif.py
@@ -444,6 +444,55 @@ class TestExiftoolProcess:
         assert captured_kwargs[0]["stderr"] is exif.subprocess.PIPE
         assert captured_kwargs[0]["stderr"] is not exif.subprocess.STDOUT
 
+    def test_init_passes_create_no_window_on_windows(self, monkeypatch):
+        """Regression for #427: PyInstaller ``--noconsole`` build (PR #420)
+        spawned a visible exiftool console window because Popen was called
+        without ``creationflags``. The fix is to pass
+        ``creationflags=_CREATE_NO_WINDOW`` (== Win32 ``CREATE_NO_WINDOW``
+        == 0x08000000 on Windows; 0 on POSIX).
+
+        Use the literal hex (0x08000000) rather than
+        ``subprocess.CREATE_NO_WINDOW`` so this test runs on POSIX CI
+        runners where the constant is undefined.
+        """
+        from scanner import exif
+
+        captured_kwargs: list[dict] = []
+
+        def fake_popen(args, **kwargs):
+            captured_kwargs.append(kwargs)
+            return self._make_mock_proc([])
+
+        monkeypatch.setattr(exif.subprocess, "Popen", fake_popen)
+        # Pin _CREATE_NO_WINDOW to the literal Win32 value so the assertion
+        # is platform-independent (the module-level constant resolves to 0
+        # on POSIX at import time).
+        monkeypatch.setattr(exif, "_CREATE_NO_WINDOW", 0x08000000)
+        exif.ExiftoolProcess()
+
+        assert captured_kwargs[0]["creationflags"] == 0x08000000
+
+    def test_init_creationflags_zero_on_non_windows(self, monkeypatch):
+        """Pins the cross-platform contract: on POSIX the constant
+        resolves to 0, which Popen accepts as a no-op ``creationflags``
+        value. Asserts the kwarg is explicitly forwarded — not omitted —
+        so the call shape stays uniform across platforms.
+        """
+        from scanner import exif
+
+        captured_kwargs: list[dict] = []
+
+        def fake_popen(args, **kwargs):
+            captured_kwargs.append(kwargs)
+            return self._make_mock_proc([])
+
+        monkeypatch.setattr(exif.subprocess, "Popen", fake_popen)
+        monkeypatch.setattr(exif, "_CREATE_NO_WINDOW", 0)
+        exif.ExiftoolProcess()
+
+        assert "creationflags" in captured_kwargs[0]
+        assert captured_kwargs[0]["creationflags"] == 0
+
     def test_execute_returns_lines_until_ready_sentinel(self, monkeypatch):
         """execute() collects readline output until '{ready}' is hit."""
         from scanner import exif

--- a/tests/test_ui_probes.py
+++ b/tests/test_ui_probes.py
@@ -842,3 +842,121 @@ def test_probe_production_code_does_not_write_literal_keep_to_user_decision():
         "Leaks: "
         + "\n".join(f"  {f}:{n}: {s}" for f, n, s in leaks)
     )
+
+
+# ── #427 — Popen creationflags probe ──────────────────────────────────────
+#
+# Context: PR #420 introduced a PyInstaller ``--noconsole`` (windowed)
+# Windows build. When a windowed-subsystem parent spawns a
+# console-subsystem child (e.g. ``exiftool.exe``) WITHOUT a
+# ``creationflags`` value that suppresses console allocation, Windows
+# allocates a fresh visible console window for the child. Users see
+# that console as spam, close it, and inadvertently kill the child
+# process mid-batch.
+#
+# Issue #427 was the concrete bite: ``scanner/exif.py`` spawned
+# exiftool with no ``creationflags`` and a visible console popped up
+# during scans. The fix passes ``creationflags=_CREATE_NO_WINDOW``
+# (== ``subprocess.CREATE_NO_WINDOW`` on Windows; 0 on POSIX).
+#
+# This probe walks every ``subprocess.Popen(...)`` call site in
+# ``scanner/`` and ``infrastructure/`` — the two trees that get
+# bundled into the windowed .exe — and asserts each call passes a
+# ``creationflags=`` kwarg of any value. The value doesn't matter at
+# probe time; what matters is that the developer made a CONSCIOUS
+# decision about creationflags rather than accepting the default
+# (which causes #427 on a windowed build).
+#
+# Out of scope: ``app/views/handlers/file_opener.py`` uses
+# ``subprocess.Popen(["explorer.exe", ...])`` — explorer is a Windows
+# GUI-subsystem app and never allocates a console regardless of
+# creationflags; auditing that callsite would be a false positive.
+# ``qa/``, ``scripts/``, and ``run_all_linters.py`` are dev tooling
+# that never ships inside the windowed .exe.
+
+# Allowlist for Popen call sites in scanner/ + infrastructure/ that
+# legitimately do NOT need a creationflags kwarg. Maps relative path
+# to a one-line reason. Currently empty — every Popen in those trees
+# spawns a child that COULD open a console on a windowed-build parent.
+# If a future Popen call legitimately needs to be exempt (e.g. spawns
+# a GUI-subsystem child like explorer.exe), add it here with the
+# reason so the probe stays honest.
+_POPEN_CREATIONFLAGS_ALLOWLIST: dict[str, str] = {}
+
+
+def _find_popen_calls_missing_creationflags(py_path: Path) -> list[tuple[int, str]]:
+    """Walk ``py_path``'s AST and return (line_no, snippet) tuples for
+    every ``subprocess.Popen(...)`` call that does NOT declare a
+    ``creationflags=`` keyword argument.
+
+    Detects calls of the form ``subprocess.Popen(...)`` (attribute call
+    on the imported ``subprocess`` module). Bare ``Popen(...)`` calls
+    (from ``from subprocess import Popen``) are also detected.
+    """
+    findings: list[tuple[int, str]] = []
+    tree = ast.parse(py_path.read_text(encoding="utf-8"))
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        is_popen = False
+        if isinstance(func, ast.Attribute) and func.attr == "Popen":
+            # subprocess.Popen(...) — the canonical shape
+            is_popen = True
+        elif isinstance(func, ast.Name) and func.id == "Popen":
+            # bare Popen(...) — from `from subprocess import Popen`
+            is_popen = True
+        if not is_popen:
+            continue
+        has_creationflags = any(
+            kw.arg == "creationflags" for kw in node.keywords
+        )
+        if not has_creationflags:
+            findings.append((node.lineno, "subprocess.Popen(...) without creationflags="))
+    return findings
+
+
+def test_probe_scanner_and_infrastructure_popen_declare_creationflags():
+    """#427 forward-defensive: every ``subprocess.Popen`` callsite in
+    ``scanner/`` and ``infrastructure/`` must declare a ``creationflags=``
+    keyword argument.
+
+    Why both trees: the PyInstaller ``--noconsole`` build (PR #420)
+    bundles ``scanner/`` (EXIF + scoring + scan loop) and
+    ``infrastructure/`` (logging, manifest repository, etc.) into the
+    windowed .exe. Any Popen in those trees that spawns a
+    console-subsystem child without ``creationflags`` will allocate a
+    visible console under Windows — the bite that produced #427.
+
+    The probe doesn't care WHAT value is passed (it can be 0 on POSIX,
+    ``CREATE_NO_WINDOW`` on Windows, or a more elaborate flags
+    expression) — only that the developer made a conscious choice.
+
+    Exempt: paths in ``_POPEN_CREATIONFLAGS_ALLOWLIST`` (e.g. a future
+    Popen that spawns a GUI-subsystem child like ``explorer.exe``,
+    which never allocates a console).
+    """
+    scan_roots = [REPO / "scanner", REPO / "infrastructure"]
+    leaks: list[tuple[str, int, str]] = []
+    for root in scan_roots:
+        if not root.exists():
+            continue
+        for py_path in root.rglob("*.py"):
+            rel = py_path.relative_to(REPO).as_posix()
+            if rel in _POPEN_CREATIONFLAGS_ALLOWLIST:
+                continue
+            for lineno, snippet in _find_popen_calls_missing_creationflags(py_path):
+                leaks.append((rel, lineno, snippet))
+
+    assert not leaks, (
+        "subprocess.Popen callsites in scanner/ or infrastructure/ are "
+        "missing a creationflags= keyword. On a PyInstaller --noconsole "
+        "(windowed) build, a console-subsystem child spawned without "
+        "creationflags=CREATE_NO_WINDOW allocates a visible console "
+        "window — the bug class fixed by #427. Pass "
+        "creationflags=_CREATE_NO_WINDOW (with the existing module-level "
+        "constant pattern from scanner/exif.py) or add the path to "
+        "_POPEN_CREATIONFLAGS_ALLOWLIST with a one-line reason if the "
+        "child is legitimately a GUI-subsystem process. Leaks: "
+        + "\n".join(f"  {f}:{n}: {s}" for f, n, s in leaks)
+    )


### PR DESCRIPTION
## Summary
- Fixes #427 — the PyInstaller `--noconsole` build (PR #420) was spawning a visible exiftool console window mid-scan. Users closed the console, killing exiftool, which then surfaced as the "exiftool not found on PATH" warning at scan_worker.py:228-233.
- Root cause: `scanner/exif.py` ran `subprocess.Popen(["exiftool", ...])` with no `creationflags`, so Windows allocated a fresh console for the console-subsystem child of a windowed-subsystem parent.
- Fix: pass `creationflags=_CREATE_NO_WINDOW`, where the module-level constant resolves to `subprocess.CREATE_NO_WINDOW` (0x08000000) on Windows and `0` (no-op) on POSIX where the constant is undefined.

## Audit (2026-05-27)
grep'd `subprocess\.(Popen|run|check_output)` across the codebase:

| Site | Verdict |
|---|---|
| `scanner/exif.py:43` | **THE BUG** — fixed here. |
| `app/views/handlers/file_opener.py:47,49` | `explorer.exe` — Windows GUI-subsystem app; never allocates a console. **Out of scope.** |
| `infrastructure/logging.py:89,101` | Linux-only `xdg-open` (gated `if os.name == "nt"` → falls to `os.startfile`). **No subprocess on Windows.** |
| `qa/**`, `scripts/**`, `run_all_linters.py` | Dev/CLI tooling, not bundled into the windowed .exe. **Out of scope.** |

Only `scanner/exif.py` needs the flag in the windowed-build hot path.

## Coverage
- 2 layer-1 unit tests in `tests/test_scanner_exif.py::TestExiftoolProcess`:
  - `test_init_passes_create_no_window_on_windows` — monkeypatches `_CREATE_NO_WINDOW` to the literal `0x08000000`, asserts the kwarg is forwarded. Runs on POSIX CI where the Win32 constant is undefined.
  - `test_init_creationflags_zero_on_non_windows` — pins the cross-platform contract: kwarg is explicitly `0` on POSIX, not omitted.
- Structural probe `test_probe_scanner_and_infrastructure_popen_declare_creationflags` in `tests/test_ui_probes.py` — AST-walks `scanner/` + `infrastructure/` (the two trees bundled into the windowed .exe), asserts every `subprocess.Popen(...)` callsite passes a `creationflags=` kwarg. Empty allowlist `_POPEN_CREATIONFLAGS_ALLOWLIST` for future GUI-subsystem exemptions.
- `scanner/exif.py` per-file coverage at 97%.

## Test plan
- [x] `pytest tests/test_scanner_exif.py -v` — 94 passed (incl. 2 new)
- [x] `pytest` (full) — 1757 passed / 2 skipped (baseline)
- [x] `scripts/check_coverage_per_file.py` — all 62 tracked files clear 70% floor
- [x] No regression in #145 stderr/stdout pipe-separation tests (pipe behaviour unchanged — only `creationflags` kwarg added)