### PR TITLE
fix(scan-dialog): give Advanced settings descriptions breathing room (#423)

### DIFF
--- a/app/views/dialogs/scan_dialog.py
+++ b/app/views/dialogs/scan_dialog.py
@@ -483,6 +483,11 @@ class ScanDialog(QDialog):
         phash_row.addWidget(self._phash_spin)
         params_layout.addWidget(phash_label)
         params_layout.addWidget(phash_desc)
+        # photo-manager#423 — descriptive QLabel sits flush against the
+        # slider's frame on narrow widths; the desc's last glyph row gets
+        # overdrawn (zh_TW is worst). Pad before the slider row so the
+        # text always clears the frame even when wrapped to 3 lines.
+        params_layout.addSpacing(6)
         params_layout.addLayout(phash_row)
 
         # Mean-color threshold
@@ -504,6 +509,9 @@ class ScanDialog(QDialog):
         color_row.addWidget(self._color_spin)
         params_layout.addWidget(color_label)
         params_layout.addWidget(color_desc)
+        # photo-manager#423 — mirror the phash row fix above so the
+        # mean-color desc clears its slider frame on narrow widths.
+        params_layout.addSpacing(6)
         params_layout.addLayout(color_row)
 
         # Auto-select after scan (#212).

--- a/news/436.bugfix
+++ b/news/436.bugfix
@@ -1,0 +1,1 @@
+Add row spacing so Advanced Settings descriptions no longer collide with their sliders. (#423)


### PR DESCRIPTION
## Summary

The pHash and Mean Color Gate description `QLabel`s in Scan Sources → Advanced settings render flush against their slider's frame on the default right-pane width (~450 px), causing the desc's last glyph row to be overdrawn. zh_TW is worse because Mandarin glyphs are denser per pixel column.

Implements **Option 1** from #423 — explicit row spacing. Adds `params_layout.addSpacing(6)` between each desc `QLabel` and its following slider row, mirroring the pattern across both Advanced settings rows (phash + mean-color).

Layout-only fix; translations unchanged.

## Files changed

- `app/views/dialogs/scan_dialog.py` — +8 lines, two `addSpacing(6)` calls + 2 inline comments referencing #423.

## Test plan

- [x] `pytest tests/test_scan_dialog.py` — 75 tests passing, `scan_dialog.py` at 92% coverage (≥ 70% per-file floor).
- [x] Full `pytest` — 1754 passed, 2 skipped, global coverage 89%.
- [x] `scripts/check_coverage_per_file.py` — all 62 files clear the 70% per-file floor.
- [ ] Manual visual verification (EN + zh_TW screenshots) — **deferred per user instruction**. No screenshots attached to this PR. A reviewer can `git checkout` the branch and eyeball Scan Sources → Advanced settings on both locales before merging.

## Waivers

`[qa-not-needed: layout-only fix; UIA cannot reliably assert text-clipping]` — UIA can't distinguish "label visible" from "label visible but clipped by a sibling frame" without pixel-level screenshot diffing, which isn't this project's qa-batch style.

`[docs-not-needed: layout-only fix; existing feature behaviour unchanged]` — the Advanced settings feature itself is unchanged; only the rendering of existing copy.

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)