### PR TITLE
feat(execute-dialog): offer to prune singleton groups after destructive ops

### DIFF
--- a/app/views/dialogs/singleton_prune_confirm_dialog.py
+++ b/app/views/dialogs/singleton_prune_confirm_dialog.py
@@ -1,0 +1,112 @@
+"""SingletonPruneConfirmDialog — offer to prune orphaned single-item
+groups after a destructive operation (#426).
+
+Surfaced once at the tail of any destructive op (Execute Action delete,
+Remove from List) that left at least one group with exactly one item
+remaining. A near-duplicate group whose peers were dropped is no
+longer a duplicate-review item, so the user is offered the option to
+clear those distractions in one batch.
+
+Three states encode the user's standing preference in JsonSettings under
+``ui.prune_singletons``:
+
+  * ``"ask"`` (default) — fire this dialog whenever singletons appear.
+  * ``"always"`` — silently prune; never show the dialog again.
+  * ``"never"`` — silently keep; never show the dialog again.
+
+The "Remember my choice" checkbox flips ``"ask"`` to either
+``"always"`` (when the user clicks Remove) or ``"never"`` (when the
+user clicks Keep all). Leaving the checkbox unchecked keeps the
+setting at ``"ask"`` — the next destructive op will prompt again.
+
+The dialog is **batched** — one modal per destructive op covering ALL
+singletons it produced, not one per group. The caller passes the
+total count; the actual prune is the caller's responsibility (so the
+caller controls the single ``vm.remove_from_list`` + single
+``repo.remove_from_review`` DB write, satisfying the issue's
+perf-aware acceptance criterion).
+"""
+
+from __future__ import annotations
+
+from PySide6.QtCore import Qt
+from PySide6.QtWidgets import (
+    QCheckBox,
+    QDialog,
+    QDialogButtonBox,
+    QLabel,
+    QPushButton,
+    QVBoxLayout,
+)
+
+from infrastructure.i18n import t
+
+
+class SingletonPruneConfirmDialog(QDialog):
+    """Two-button confirm with "don't ask again" checkbox."""
+
+    REMOVE = 1
+    KEEP = 2
+
+    def __init__(self, parent=None, *, count: int) -> None:
+        super().__init__(parent)
+        self.setWindowTitle(t("singleton_prune_confirm.title"))
+        self.setModal(True)
+        self._count = count
+        self._verdict = self.KEEP
+        self._remember = False
+
+        layout = QVBoxLayout(self)
+        label = QLabel(t("singleton_prune_confirm.body", count=count), self)
+        label.setWordWrap(True)
+        layout.addWidget(label)
+
+        self._checkbox = QCheckBox(
+            t("singleton_prune_confirm.checkbox_dont_ask"), self
+        )
+        layout.addWidget(self._checkbox)
+
+        button_box = QDialogButtonBox(self)
+        self._remove_btn = QPushButton(
+            t("singleton_prune_confirm.btn_remove", count=count), self
+        )
+        self._keep_btn = QPushButton(t("singleton_prune_confirm.btn_keep"), self)
+        button_box.addButton(self._remove_btn, QDialogButtonBox.AcceptRole)
+        button_box.addButton(self._keep_btn, QDialogButtonBox.RejectRole)
+        layout.addWidget(button_box)
+
+        self._remove_btn.clicked.connect(self._on_remove)
+        self._keep_btn.clicked.connect(self._on_keep)
+        # Esc / window close → KEEP (the safe default, matching #182's
+        # CANCEL-on-close pattern). User must explicitly click Remove.
+        self.rejected.connect(self._on_keep)
+
+        self._keep_btn.setDefault(True)
+
+    def _on_remove(self) -> None:
+        self._verdict = self.REMOVE
+        self._remember = self._checkbox.isChecked()
+        self.accept()
+
+    def _on_keep(self) -> None:
+        self._verdict = self.KEEP
+        self._remember = self._checkbox.isChecked()
+        # Only call done() if the dialog is still open (rejected signal
+        # can fire after explicit reject as well).
+        if self.result() == 0:
+            self.done(QDialog.Rejected)
+
+    @property
+    def verdict(self) -> int:
+        return self._verdict
+
+    @property
+    def remember(self) -> bool:
+        return self._remember
+
+    @classmethod
+    def ask(cls, parent, *, count: int) -> tuple[int, bool]:
+        """Convenience entry point — returns (verdict, remember_choice)."""
+        dlg = cls(parent, count=count)
+        dlg.exec()
+        return dlg.verdict, dlg.remember

--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -516,6 +516,9 @@ class FileOperationsHandler:
                     t("status.noun_item_from_list_singular"),
                     plural=t("status.noun_item_from_list_plural"),
                 )
+                # #426: offer to prune any groups that collapsed to a
+                # single item after this bulk remove.
+                self._maybe_offer_singleton_prune()
                 return
 
             QMessageBox.information(
@@ -565,6 +568,9 @@ class FileOperationsHandler:
                             t("status.noun_item_from_list_singular"),
                             plural=t("status.noun_item_from_list_plural"),
                         )
+                        # #426: offer to prune singletons created by
+                        # this partial remove too.
+                        self._maybe_offer_singleton_prune()
                     return
                 # APPLY_ALL_UNLOCKED: unlock the locked subset in memory
                 # and in SQLite, then fall through to remove everything.
@@ -617,6 +623,10 @@ class FileOperationsHandler:
                 t("status.noun_item_from_list_singular"),
                 plural=t("status.noun_item_from_list_plural"),
             )
+            # #426: offer to prune any groups that collapsed to a
+            # single item after this remove. Covers context-menu single
+            # + bulk + regex-driven flows that all funnel through here.
+            self._maybe_offer_singleton_prune()
 
         except Exception as e:
             logger.error("Remove items from list failed: {}", e)
@@ -636,6 +646,71 @@ class FileOperationsHandler:
             ManifestRepository().remove_from_review(manifest_path, file_paths)
         except Exception as exc:
             logger.warning("Failed to sync removed paths to manifest: {}", exc)
+
+    def _maybe_offer_singleton_prune(self) -> None:
+        """#426 — after a destructive op, if any group is now down to a
+        single item, offer to remove those singletons in one batch.
+
+        Honors ``settings.get("ui.prune_singletons", "ask")``:
+          * ``"ask"`` (default)  — fire the confirm dialog.
+          * ``"always"`` — silently prune; never ask again.
+          * ``"never"``  — silently keep; never ask again.
+
+        Batched: one dialog per destructive op covering ALL singletons it
+        produced, ONE ``vm.remove_from_list`` call + ONE
+        ``_sync_removed_to_db`` call (perf-aware per the issue's
+        ≤5000-singletons acceptance criterion). On a clean state with
+        no singletons present, this is a fast O(N) no-op.
+        """
+        # Collect singletons from the current vm state.
+        singleton_paths: list[str] = []
+        for g in self.vm.groups:
+            items = getattr(g, "items", [])
+            if len(items) == 1:
+                fp = getattr(items[0], "file_path", None)
+                if fp:
+                    singleton_paths.append(fp)
+        if not singleton_paths:
+            return
+
+        pref = "ask"
+        try:
+            pref = self.settings.get("ui.prune_singletons", "ask") or "ask"
+        except Exception:
+            pref = "ask"
+        if pref == "never":
+            return
+        if pref == "always":
+            self._apply_singleton_prune(singleton_paths)
+            return
+
+        # pref == "ask" — show the dialog.
+        from app.views.dialogs.singleton_prune_confirm_dialog import (
+            SingletonPruneConfirmDialog,
+        )
+        verdict, remember = SingletonPruneConfirmDialog.ask(
+            self.parent, count=len(singleton_paths)
+        )
+        if remember:
+            new_pref = "always" if verdict == SingletonPruneConfirmDialog.REMOVE else "never"
+            try:
+                self.settings.set("ui.prune_singletons", new_pref)
+                if hasattr(self.settings, "save"):
+                    self.settings.save()
+            except Exception as exc:
+                logger.warning("Failed to persist ui.prune_singletons: {}", exc)
+        if verdict == SingletonPruneConfirmDialog.REMOVE:
+            self._apply_singleton_prune(singleton_paths)
+
+    def _apply_singleton_prune(self, paths: list[str]) -> None:
+        """Run the batched prune — one vm call, one DB sync, one refresh."""
+        if not paths:
+            return
+        logger.info("Pruning {} singleton groups (#426)", len(paths))
+        self.vm.remove_from_list(paths)
+        self._sync_removed_to_db(paths)
+        self._mark_dirty()
+        self.ui_updater.refresh_tree(self.vm.groups)
 
     def set_decision(self, items: list[dict], new_decision: str) -> None:
         """Set user_decision for the given file items in memory and in SQLite.
@@ -1104,3 +1179,7 @@ class FileOperationsHandler:
             # applied to disk (or to the review list); no need to nag
             # the user about saving on the way out.
             self._mark_clean()
+            # #426: offer to prune any groups that just collapsed to a
+            # single item. Runs LAST so the report_count / refresh sequence
+            # above is unaffected — the prune itself does its own refresh.
+            self._maybe_offer_singleton_prune()

--- a/docs/features.md
+++ b/docs/features.md
@@ -220,6 +220,17 @@ for the chore plan.
 
 ---
 
+### Singleton-prune offer after destructive ops (#426)
+
+- **Entry point:** Fired automatically at the tail of every destructive op that may collapse a group to one item — `FileOperationsHandler._maybe_offer_singleton_prune` is called from the Execute Action accept branch, `remove_from_list_toolbar`, `remove_items_from_list`, and the lock-confirm "apply unlocked only" sub-branches that also remove rows. Single helper, single call site per flow.
+- **Trigger:** Helper scans `vm.groups` after the destructive op completes and short-circuits when no group has exactly one item left. If at least one singleton is present, behaviour branches on `JsonSettings.get("ui.prune_singletons", "ask")`.
+- **Behaviour:** Three preference states: `"ask"` (default) opens `SingletonPruneConfirmDialog` ([app/views/dialogs/singleton_prune_confirm_dialog.py](../app/views/dialogs/singleton_prune_confirm_dialog.py)) with [Remove N] / [Keep all] buttons and a "Remember my choice — don't ask again" checkbox; `"always"` silently prunes; `"never"` silently keeps. When the user checks the box, Remove flips the setting to `"always"` and Keep to `"never"`, persisted via `JsonSettings.set` + `.save()`. The prune itself is **batched** — ONE `vm.remove_from_list(paths)` call, ONE `_sync_removed_to_db(paths)` write, ONE `ui_updater.refresh_tree`, regardless of how many singletons were collected (perf-aware for the s44-scale ≤5000-singletons acceptance criterion). Esc / window close on the dialog yields Keep (the safe default).
+- **Conditions / variants:** The helper is a tail-call hook — every destructive method that lands rows in the prune-candidate state calls it as the LAST step (after refresh + status report + dirty flag). Skipping a destructive op (no rows actually removed) → no singletons appear → helper short-circuits without UI. Singleton state is read fresh from `vm.groups` each call, so deferred removals (Execute Action's `removed_from_list_paths`) are detected after the dialog accepts and dropping them happens before the offer fires.
+- **Related:** [#426](https://github.com/jackal998/photo-manager/issues/426); precedent for batched-confirm pattern is [#417](https://github.com/jackal998/photo-manager/issues/417) (LockedRowsConfirmDialog); the existing `vm.remove_deleted_and_prune(prune_singles=True)` was the alternative considered but rejected as too implicit — see issue body. The setting key `ui.prune_singletons` is gitignored via `settings.json`; an example default goes in `settings.json.example`.
+- **Last verified:** 2026-05-27 (#426)
+
+---
+
 ### Keep-worthiness scoring
 
 - **Entry point:** Score column (COL_SCORE at index 2) in the main result tree — [app/views/constants.py:22](../app/views/constants.py#L22). Within-group rows sort by score descending so the best copy lands at the top of every group.

--- a/news/440.feature
+++ b/news/440.feature
@@ -1,0 +1,1 @@
+Offer to prune singleton groups after destructive operations with a remembered preference (always / ask / never). (#426)

--- a/settings.json.example
+++ b/settings.json.example
@@ -9,6 +9,7 @@
     ]
   },
   "ui": {
-    "locale": "en"
+    "locale": "en",
+    "prune_singletons": "ask"
   }
 }

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -73,10 +73,19 @@ def _make_handler(vm, manifest_path: str | None, checked_paths=None, highlighted
     status_reporter = MagicMock()
     parent = MagicMock()
     parent.menu_controller = MagicMock()
+    # #426: opt unrelated tests OUT of the singleton-prune offer so a
+    # remove/execute path that happens to leave a single-item group
+    # doesn't try to open a real QDialog with a MagicMock parent.
+    # Tests that DO want to exercise the prune helper override this
+    # explicitly via their own settings mock (TestSingletonPruneOffer).
+    settings = MagicMock()
+    settings.get.side_effect = lambda key, default=None: (
+        "never" if key == "ui.prune_singletons" else (default if default is not None else MagicMock())
+    )
 
     handler = FileOperationsHandler(
         vm=vm,
-        settings=MagicMock(),
+        settings=settings,
         parent_widget=parent,
         ui_updater=ui_updater,
         status_reporter=status_reporter,
@@ -2212,3 +2221,161 @@ class TestSetDecisionByRegexLockConfirm:
         assert b.is_locked is False
         assert _read_locked(db, "/a.jpg") is False
         assert _read_locked(db, "/b.jpg") is False
+
+
+# ── #426: singleton-prune offer ────────────────────────────────────────────
+
+
+class TestSingletonPruneOffer:
+    """``_maybe_offer_singleton_prune`` is fired at the end of every
+    destructive op (Execute Action delete, Remove from List). It honors
+    the ``ui.prune_singletons`` setting and batches the prune into one
+    ``vm.remove_from_list`` + one ``_sync_removed_to_db`` call.
+
+    Guards three real failure modes:
+      - "never" preference is ignored → user sees the dialog every time
+        despite explicit opt-out.
+      - "always" preference forgets to skip the dialog → autonomous flow
+        breaks on a hidden modal.
+      - Batched prune fires per-group (N modals) instead of once → s44-
+        scale fixtures grind the UI thread.
+    """
+
+    def _build(self, group_layouts, *, pref="ask"):
+        """Build a handler whose vm.groups match group_layouts (a list
+        of group sizes — e.g. [1, 1, 3] = two singletons + a 3-row
+        group). ``pref`` seeds the settings reply."""
+        groups: list[PhotoGroup] = []
+        for gn, size in enumerate(group_layouts, start=1):
+            items = [_rec(f"/g{gn}_i{i}.jpg") for i in range(size)]
+            groups.append(PhotoGroup(group_number=gn, items=items))
+        vm = SimpleNamespace(
+            groups=groups,
+            remove_from_list=MagicMock(),
+        )
+        settings = MagicMock()
+        settings.get.return_value = pref
+        ui_updater = MagicMock()
+        from app.views.handlers.file_operations import FileOperationsHandler
+        parent = MagicMock()
+        parent.menu_controller = MagicMock()
+        handler = FileOperationsHandler(
+            vm=vm, settings=settings, parent_widget=parent,
+            ui_updater=ui_updater, status_reporter=MagicMock(),
+        )
+        return handler, vm, settings, ui_updater
+
+    def test_no_singletons_is_silent_noop(self):
+        """If no group has len==1, the helper must NOT open the dialog,
+        NOT touch settings, NOT call vm.remove_from_list. Guards
+        against an over-eager "prune everything" hammer."""
+        handler, vm, settings, ui = self._build([2, 3, 4])
+        with patch(
+            "app.views.dialogs.singleton_prune_confirm_dialog.SingletonPruneConfirmDialog.ask"
+        ) as ask:
+            handler._maybe_offer_singleton_prune()
+        ask.assert_not_called()
+        vm.remove_from_list.assert_not_called()
+
+    def test_never_preference_short_circuits(self):
+        """``pref="never"`` must NOT show the dialog even with
+        singletons present. Without this short-circuit the user's
+        explicit opt-out is meaningless."""
+        handler, vm, settings, ui = self._build([1, 1, 3], pref="never")
+        with patch(
+            "app.views.dialogs.singleton_prune_confirm_dialog.SingletonPruneConfirmDialog.ask"
+        ) as ask:
+            handler._maybe_offer_singleton_prune()
+        ask.assert_not_called()
+        vm.remove_from_list.assert_not_called()
+
+    def test_always_preference_prunes_silently(self):
+        """``pref="always"`` runs ONE batched prune and does NOT open
+        the dialog. Both singleton paths land in the single
+        ``vm.remove_from_list`` call."""
+        handler, vm, settings, ui = self._build([1, 1, 3], pref="always")
+        with patch(
+            "app.views.dialogs.singleton_prune_confirm_dialog.SingletonPruneConfirmDialog.ask"
+        ) as ask:
+            handler._maybe_offer_singleton_prune()
+        ask.assert_not_called()
+        vm.remove_from_list.assert_called_once()
+        passed = vm.remove_from_list.call_args[0][0]
+        # The two singletons (groups 1 and 2) get pruned together.
+        assert sorted(passed) == ["/g1_i0.jpg", "/g2_i0.jpg"]
+        ui.refresh_tree.assert_called_once()
+
+    def test_ask_remove_with_remember_persists_always(self):
+        """User picks Remove + checks "don't ask again" → settings
+        flip to ``"always"`` AND the prune fires."""
+        handler, vm, settings, ui = self._build([1, 1], pref="ask")
+        from app.views.dialogs.singleton_prune_confirm_dialog import (
+            SingletonPruneConfirmDialog,
+        )
+        with patch.object(
+            SingletonPruneConfirmDialog, "ask",
+            return_value=(SingletonPruneConfirmDialog.REMOVE, True),
+        ):
+            handler._maybe_offer_singleton_prune()
+        settings.set.assert_called_once_with("ui.prune_singletons", "always")
+        settings.save.assert_called_once()
+        vm.remove_from_list.assert_called_once()
+
+    def test_ask_keep_with_remember_persists_never(self):
+        """User picks Keep + checks "don't ask again" → settings
+        flip to ``"never"`` AND no prune fires."""
+        handler, vm, settings, ui = self._build([1, 1], pref="ask")
+        from app.views.dialogs.singleton_prune_confirm_dialog import (
+            SingletonPruneConfirmDialog,
+        )
+        with patch.object(
+            SingletonPruneConfirmDialog, "ask",
+            return_value=(SingletonPruneConfirmDialog.KEEP, True),
+        ):
+            handler._maybe_offer_singleton_prune()
+        settings.set.assert_called_once_with("ui.prune_singletons", "never")
+        settings.save.assert_called_once()
+        vm.remove_from_list.assert_not_called()
+
+    def test_ask_remove_without_remember_does_not_persist(self):
+        """Remove with the checkbox UNCHECKED → prune fires but the
+        next destructive op will prompt again (settings unchanged)."""
+        handler, vm, settings, ui = self._build([1], pref="ask")
+        from app.views.dialogs.singleton_prune_confirm_dialog import (
+            SingletonPruneConfirmDialog,
+        )
+        with patch.object(
+            SingletonPruneConfirmDialog, "ask",
+            return_value=(SingletonPruneConfirmDialog.REMOVE, False),
+        ):
+            handler._maybe_offer_singleton_prune()
+        settings.set.assert_not_called()
+        vm.remove_from_list.assert_called_once()
+
+    def test_ask_keep_without_remember_does_not_persist(self):
+        """Keep with the checkbox UNCHECKED → no prune, settings
+        unchanged."""
+        handler, vm, settings, ui = self._build([1], pref="ask")
+        from app.views.dialogs.singleton_prune_confirm_dialog import (
+            SingletonPruneConfirmDialog,
+        )
+        with patch.object(
+            SingletonPruneConfirmDialog, "ask",
+            return_value=(SingletonPruneConfirmDialog.KEEP, False),
+        ):
+            handler._maybe_offer_singleton_prune()
+        settings.set.assert_not_called()
+        vm.remove_from_list.assert_not_called()
+
+    def test_batched_single_remove_call_not_per_group(self):
+        """Perf-aware acceptance criterion: 50 singletons → exactly
+        ONE ``vm.remove_from_list`` call (not 50). Catches a regression
+        where someone refactors the helper to loop per group."""
+        handler, vm, settings, ui = self._build([1] * 50, pref="always")
+        with patch(
+            "app.views.dialogs.singleton_prune_confirm_dialog.SingletonPruneConfirmDialog.ask"
+        ):
+            handler._maybe_offer_singleton_prune()
+        assert vm.remove_from_list.call_count == 1
+        passed = vm.remove_from_list.call_args[0][0]
+        assert len(passed) == 50

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -190,6 +190,13 @@ execute_dialog:
 
 # LockedRowsConfirmDialog — unified confirm when an action would touch
 # locked rows. See photo-manager#182 (supersedes #175's hybrid).
+singleton_prune_confirm:
+  title: "Prune singleton groups?"
+  body: "{count} group(s) now have only one file remaining after the last action. They're no longer duplicate-review items.\n\nRemove these {count} singletons from the review list?"
+  checkbox_dont_ask: "Remember my choice — don't ask again"
+  btn_remove: "Remove {count}"
+  btn_keep: "Keep all"
+
 locked_confirm:
   title: "Locked Rows Affected"
   body: "Action '{action}' would affect {total} row(s); {locked} locked:\n\n{list}\n\nUnlock and apply to all {total}, apply to unlocked only ({unlocked}), or cancel?"

--- a/translations/zh_TW.yml
+++ b/translations/zh_TW.yml
@@ -151,6 +151,15 @@ execute_dialog:
   files_failed_body: "下列檔案無法刪除(權限不足、檔案鎖定或路徑過長):\n\n{failed}{suffix}"
   files_failed_more: "\n…以及其餘 {n} 個"
 
+# SingletonPruneConfirmDialog — photo-manager#426. 破壞性動作之後,
+# 提示是否清除只剩單一檔案的群組(它們不再具有重複審查價值)。
+singleton_prune_confirm:
+  title: "清除單一檔案群組?"
+  body: "上次操作之後,有 {count} 個群組只剩下一個檔案。這些群組已不再是重複審查的候選項。\n\n要從清單移除這 {count} 個單一檔案群組嗎?"
+  checkbox_dont_ask: "記住我的選擇,不要再詢問"
+  btn_remove: "移除 {count} 個"
+  btn_keep: "全部保留"
+
 # LockedRowsConfirmDialog — photo-manager#182(取代 #175 的混合語意)。
 locked_confirm:
   title: "受影響的鎖定列"


### PR DESCRIPTION
## Summary
- After Execute Action delete or any Remove from List flow, scan `vm.groups` for groups that just collapsed to a single item and offer the user a batched prune in one modal — not N modals.
- New helper `FileOperationsHandler._maybe_offer_singleton_prune` fires at the tail of every destructive entry point (Execute Action accept; toolbar / context-menu / regex remove; lock-confirm "apply unlocked only" sub-branches).
- New `SingletonPruneConfirmDialog` with [Remove N] / [Keep all] buttons and a "Remember my choice" checkbox. Esc / window close yields Keep.
- Three preferences in `ui.prune_singletons`: `"ask"` (default, fire dialog), `"always"` (silent prune), `"never"` (silent keep). Checkbox flips `"ask"` → `"always"` (on Remove) or `"never"` (on Keep), persisted via JsonSettings.
- Batched: ONE `vm.remove_from_list(paths)` + ONE `_sync_removed_to_db(paths)` + ONE refresh per destructive op, regardless of singleton count — satisfies the ≤5000-singletons perf budget.
- Translations added to en + zh_TW. `settings.json.example` gets the default key.

## Test plan
- [x] `tests/test_file_operations.py::TestSingletonPruneOffer` — 8 cases covering all three preference branches, ask+remember combinations, ask without remember, no-singletons short-circuit, and the batched-single-call perf guard (50 singletons → exactly 1 remove call).
- [x] Local pytest on `tests/test_file_operations.py tests/test_main_window.py tests/test_context_menu.py tests/test_ui_probes.py` — all green.
- [x] Per-file coverage on `app/views/handlers/file_operations.py` = 87% (≥ 70%).

[qa-not-needed: tail-call hook on existing destructive flows already covered by s13/s44/s29; the new dialog's contract is layer-1 tested via the helper (`SingletonPruneConfirmDialog.ask` patched), the dialog widget itself follows the same coverage-omitted pattern as `LockedRowsConfirmDialog` / `ExecuteActionDialog`. The layer-3 prune-offer end-to-end is a `[QA:s60]` follow-up if/when the human-visible flow needs UIA coverage.]

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)