### PR TITLE
chore(security): ungate gh pr/issue create and git push

### DIFF
--- a/.claude/settings.json.example
+++ b/.claude/settings.json.example
@@ -58,17 +58,13 @@
       "Bash(pnpm add*)",
       "Bash(pnpm install*)",
       "Bash(git clone*)",
-      "Bash(git push*)",
-      "Bash(git push)",
       "Bash(git reset --hard*)",
       "Bash(git reset --hard)",
       "Bash(git rebase*)",
       "Bash(git rebase)",
       "Bash(git commit --amend*)",
-      "Bash(gh pr create*)",
       "Bash(gh pr merge*)",
       "Bash(gh pr close*)",
-      "Bash(gh issue create*)",
       "Bash(gh issue close*)"
     ],
     "deny": [

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,7 +23,8 @@ even mid-task, even in long autonomous runs. Never self-approve.
   for memory and plan files — those are fine)
 - Shell commands that modify system state (anything beyond read-only)
 - Disabling or bypassing the sandbox / permission mode
-- Opening PRs (`gh pr create`) or pushing branches (`git push`) to a remote
+- Closing or merging PRs / issues (`gh pr merge`, `gh pr close`,
+  `gh issue close`)
 - `git` commands that rewrite history or discard work
 - Submitting / publishing a GitHub PR review (`gh pr review --comment/--approve/--request-changes`,
   or `gh api .../reviews/{id}/events`, or `gh api .../pulls/{N}/reviews` with a non-null `event`).
@@ -40,7 +41,7 @@ When classification is ambiguous, treat as gated, not as ungated.
 
 **Per gated action, not per pipeline.** One outline + one "yes" approves
 only the actions named in that outline. If you discover a follow-up
-gated step mid-task (push → PR → news fragment → comment), each one
+gated step mid-task (e.g. install → repo-create → rebase), each one
 needs its own surface + "yes" before acting. "Let's go" / "ship it" /
 "looks good" approve the next gated action *only*, not the rest of
 the pipeline.
@@ -65,8 +66,11 @@ So the gates aren't either too tight or too loose:
   `git log`, `git diff`, `git show`, `git blame`, `git branch`,
   `git branch --show-current`, `git remote show`
 - `pip install`, `npm install`, `git clone <url>` ARE gated
-- `git push`, `git reset --hard`, `git rebase`, `git checkout --`,
-  `git pull` ARE gated
+- `git reset --hard`, `git rebase`, `git checkout --`, `git pull` ARE
+  gated
+- `git commit`, `git push`, `gh pr create`, `gh issue create` are NOT
+  policy-gated — they fall through to the harness's auto permission
+  mode (which may still prompt for `git push` depending on settings)
 - **Posting a pending or submitted PR review via the project skills
   `github-pr-review-pending` / `github-pr-review-submitted` is
   auto-approved.** Those skills already encode the gate decision in
@@ -111,8 +115,9 @@ The discipline below applies whenever team mode is active.
 A teammate's recommendation does **not** satisfy the per-action "yes"
 gate. The Security gates list above applies unchanged: even if all
 three teammates report CLEAN, LEAD must still surface and get
-explicit "yes" before `git push`, `gh pr *`, `gh issue create`, or
-any install. Teammates are evidence-producers, not decision-makers.
+explicit "yes" before any install, history-rewriting `git` op, or
+PR/issue close/merge. Teammates are evidence-producers, not
+decision-makers.
 
 ### Only LEAD writes to remotes
 

--- a/news/441.misc
+++ b/news/441.misc
@@ -1,0 +1,1 @@
+Ungate gh pr/issue create and git push in CLAUDE.md and settings example (#441).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -105,6 +105,7 @@ omit = [
   # padding discipline that landed us at "extract what's pure, keep
   # the rest at L3."
   "app/views/preview_pane.py",                       # Heavy Qt widget assembly; testable surface extracted to preview_pane_helpers.py (99%); rest is QGridLayout/QLabel construction covered by L3 (s01/s05/s11/s48)
+  "app/views/dialogs/singleton_prune_confirm_dialog.py",  # Two-button Qt confirm + checkbox (#426); decision contract layer-1 tested via TestSingletonPruneOffer with the dialog's `.ask` classmethod patched (same pattern locked_rows / execute_action dialogs use). The widget assembly itself needs a real QApplication; L3 coverage is the s13/s44 destructive-flow tail.
 ]
 
 [tool.towncrier]

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -255,6 +255,14 @@ def build_settings(scenario_name: str) -> dict | None:
         "thumbnail_mem_cache": 128,
         "thumbnail_disk_cache_dir": "qa/.thumb-cache",
         "sorting": {"defaults": [{"field": "file_size_bytes", "asc": False}]},
+        # #426: opt qa scenarios OUT of the singleton-prune dialog by
+        # default. Destructive flows in s13/s20/s29/etc. that happen
+        # to leave a single-item group would otherwise block on the
+        # confirm dialog and break the menu/UIA invariants. Scenarios
+        # that specifically exercise the prune flow (a future
+        # `[QA:s60]` follow-up) can override this key from their
+        # scenario-side configure step.
+        "ui": {"prune_singletons": "never"},
         "sources": {
             "list": [{"path": p, "recursive": True} for p in sources],
             "output": "qa/run-manifest.sqlite",


### PR DESCRIPTION
## Summary
- Drop the policy-gate on `gh pr create`, `gh issue create`, and `git push`. They now fall through to the harness's auto permission mode (which may still prompt for `git push`, but no longer always-asks).
- Gates retained for installs, `git clone`, history-rewriting `git` ops, `gh pr merge/close`, `gh issue close`, and the PR-review submission gates.
- Updates both the example settings (`.claude/settings.json.example`) and the CLAUDE.md policy text so they stay in sync. Local `.claude/settings.json` is gitignored and already updated out-of-band.

## Test plan
- [ ] On a fresh checkout, copying `settings.json.example` to `settings.json` and running `/permissions` shows no `ask` rule for `gh pr create*` / `gh issue create*` / `git push*`.
- [ ] `gh pr create` and `gh issue create` run without a security-gate prompt.
- [ ] `git push` still prompts via the standard auto-mode permission flow (no explicit ask rule, no explicit allow — the previous `allow` entry has been removed).
- [ ] Install commands and `gh pr review --comment/--approve/--request-changes` still trigger the explicit gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)