### PR TITLE
perf(scanner): stream 12-byte header for magic-type check

### DIFF
--- a/news/447.bugfix
+++ b/news/447.bugfix
@@ -1,0 +1,1 @@
+Stream the 12-byte magic-bytes header during scan instead of fully reading every HEIC/RAW/PNG/GIF/WEBP file — halves NAS scan I/O for iPhone-photo libraries (#446).

--- a/scanner/media.py
+++ b/scanner/media.py
@@ -43,9 +43,17 @@ COMPANION_PHOTO_EXTS = [".HEIC", ".heic", ".JPG", ".jpg", ".JPEG", ".jpeg", ".PN
 # ---------------------------------------------------------------------------
 
 def _magic_type(path: Path) -> Optional[str]:
-    """Detect actual file type from magic bytes (first 12 bytes)."""
+    """Detect actual file type from magic bytes (first 12 bytes).
+
+    Stream-reads only the 12 header bytes — earlier versions used
+    ``path.read_bytes()[:12]`` which pulled the entire file over the
+    pipe before slicing. On NAS-stored HEIC libraries that doubled
+    scan I/O because the subsequent ``compute_hashes`` pass reads
+    the file again for the SHA / pHash single-pass (#446).
+    """
     try:
-        header = path.read_bytes()[:12]
+        with open(path, "rb") as fh:
+            header = fh.read(12)
     except OSError:
         return None
     if header[:2] == b"\xff\xd8":

--- a/tests/test_scanner_media.py
+++ b/tests/test_scanner_media.py
@@ -148,6 +148,50 @@ class TestGetFileType:
             assert kind == "heic", f"brand {brand!r}"
             assert mismatch is False
 
+    def test_magic_check_reads_only_12_bytes(self, tmp_path):
+        """#446 — _magic_type must stream the 12-byte header, not pull
+        the whole file. The pre-fix implementation used
+        ``path.read_bytes()[:12]`` which on NAS-stored HEIC libraries
+        doubled scan I/O (full read during Walking, then again during
+        Hashing for the SHA / pHash single-pass).
+
+        Assertion: writing a 1 MB HEIC and calling get_file_type
+        results in a file-handle read() that requested no more than
+        12 bytes. Patches ``builtins.open`` inside scanner.media to
+        capture the read call args without disturbing PIL / other
+        readers in the same process.
+        """
+        from unittest.mock import patch, mock_open, MagicMock
+
+        big_heic = _write(tmp_path, "big.heic", HEIC_MAGIC + b"\x00" * (1024 * 1024))
+
+        real_open = open
+        captured_read_sizes: list[int] = []
+
+        def tracking_open(file, mode="r", *args, **kwargs):
+            fh = real_open(file, mode, *args, **kwargs)
+            if "b" in mode and str(file) == str(big_heic):
+                original_read = fh.read
+
+                def tracking_read(size=-1):
+                    captured_read_sizes.append(size)
+                    return original_read(size)
+
+                fh.read = tracking_read
+            return fh
+
+        with patch("scanner.media.open", side_effect=tracking_open, create=True):
+            kind, _ = get_file_type(big_heic)
+
+        assert kind == "heic"
+        assert captured_read_sizes, "magic-byte read() was never called"
+        # Every read must be bounded — no read(-1) / read() / read(huge) calls.
+        for size in captured_read_sizes:
+            assert 0 < size <= 12, (
+                f"_magic_type read {size} bytes — expected ≤ 12. "
+                "Regression to read_bytes()[:12]?"
+            )
+
 
 # ---------------------------------------------------------------------------
 # parse_media_filename


### PR DESCRIPTION
## Summary

Closes #446 — scanner Walking stage was fully reading every HEIC / RAW / PNG / GIF / WEBP file just to inspect 12 bytes of header, then Hashing read them again. On NAS-stored iPhone libraries that doubled scan I/O.

Switch \`_magic_type\` from \`path.read_bytes()[:12]\` (full file read, slice 12) to a 12-byte streaming read:

\`\`\`python
with open(path, "rb") as fh:
    header = fh.read(12)
\`\`\`

No change to observable behaviour — every input maps to the same output as before. Pure I/O reduction.

## Impact

| File type | Walking reads (before → after) |
|---|---|
| HEIC | full file → 12 bytes |
| RAW | full file → 12 bytes |
| PNG / GIF / WEBP | full file → 12 bytes |
| JPEG / MP4 / MOV | unchanged (Walking didn't read these) |

## Test plan

- [x] \`pytest tests/test_scanner_media.py\` — 48 passed (47 existing + 1 new \`test_magic_check_reads_only_12_bytes\` pinning the streaming contract)
- [x] Full unit suite — 1816 passed, 2 skipped (was 1815, +1 new)
- [ ] Manual: run a scan against \`J:\圖片\` (NAS) before/after this change; eyeball the Walking-stage wall-clock improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)