### PR TITLE
docs(scanner): mmap audit — no code change warranted (#453)

### DIFF
--- a/news/459.doc
+++ b/news/459.doc
@@ -1,0 +1,1 @@
+Document the mmap-RAW audit decision in scanner/hasher.py — no code change warranted because rawpy needs a bytes buffer and video SHA already streams in 64 KB chunks (#453).

--- a/scanner/hasher.py
+++ b/scanner/hasher.py
@@ -1,4 +1,33 @@
-"""SHA-256 and perceptual hash computation for all media formats."""
+"""SHA-256 and perceptual hash computation for all media formats.
+
+Memory-footprint audit (#453)
+-----------------------------
+
+The hashing path holds the entire file in Python heap for image
+formats (JPEG / PNG / HEIC / WebP / RAW) because all three downstream
+operations — ``hashlib.sha256``, ``PIL.Image.open`` and
+``rawpy.open_buffer`` — want a ``bytes`` buffer. This is intentional:
+the single ``path.read_bytes()`` in ``compute_hashes`` was the #446
+fix that eliminated a double-read of every image and roughly halved
+NAS scan time. Backing it out for RAW (e.g. mmap the SHA pass,
+re-read for decode) would regress #446's gain — verified during the
+#453 audit: ``rawpy`` has no zero-copy decode path and a fresh
+``bytes(mm)`` materialisation costs the same RAM as ``read_bytes()``.
+
+The video path (``mp4`` / ``mov``) already streams via 64 KB chunks
+in ``compute_sha256`` — peak heap is ~64 KB regardless of file size.
+No code change needed for videos; mmap would not reduce the working
+set further (both rely on the kernel page cache for the actual I/O).
+
+Net memory ceiling per hash worker:
+  - video:   ~64 KB (chunked)
+  - image:   one full read (the file, plus a PIL decode buffer)
+
+If the scan.workers spinner (#449) is pushed past 8 on a low-RAM box
+with a RAW-heavy library, peak RAM during hashing scales linearly.
+That headroom concern lives with #449's spinner cap (1-32), not with
+the hasher implementation. See #453 closure note.
+"""
 
 from __future__ import annotations
 


### PR DESCRIPTION
## Summary

Audits the mmap-for-SHA proposal from #453 and closes the issue with a documented rationale.

The issue body itself flags this as *"may close as 'won't fix' after the audit"*. The audit confirms:

- **Video SHA already streams in 64 KB chunks** via ``compute_sha256``. Peak heap ≈ 64 KB regardless of file size — mmap would not reduce the working set further (both rely on the kernel page cache for actual I/O).
- **RAW SHA-via-mmap saves nothing** because ``rawpy.open_buffer`` requires a ``bytes`` buffer to decode the file. ``bytes(mm)`` materialises the same RAM as ``read_bytes()`` and would regress the #446 single-pass fix that eliminated a double-read of every image.

The actionable change is therefore a docstring + closure note. The RAM-headroom concern (worker count × file size) lives with the #449 worker spinner cap (1-32), not with the hasher implementation. Operators who hit RAM pressure on RAW-heavy NAS scans should lower ``scan.workers`` rather than reach for mmap.

Stacked on **#458 (#451 parallel exiftool)** — base = ``feat/451-parallel-exiftool``. Closes #453.

## Test plan

- [x] ``pytest tests/`` — 1833 passed, 2 skipped (no behaviour change; docs-only commit).
- [x] ``pytest tests/test_hasher.py`` — 23 passed.

[qa-not-needed: docs-only change; no behaviour delta, no UI surface touched. The audit confirms the existing hasher implementation is already correct for both code paths.]

🤖 Generated with [Claude Code](https://claude.com/claude-code)