### PR TITLE
fix(scanner): gate exact-pHash format-duplicate path on mean_color (#462)

### DIFF
--- a/news/478.bugfix
+++ b/news/478.bugfix
@@ -1,0 +1,1 @@
+Gate exact-pHash format-duplicate path on mean_color so flat images (solid colour / near-empty composition) no longer collide as EXACT duplicates on pHash 8000000000000000 (#462).

--- a/qa/scenarios/s24_stale_manifest_paths.py
+++ b/qa/scenarios/s24_stale_manifest_paths.py
@@ -67,25 +67,47 @@ NUM_FILES = 3
 
 
 def _setup_fixture() -> list[Path]:
-    """Wipe FIXTURE_DIR and write NUM_FILES fresh JPEGs.
+    """Wipe FIXTURE_DIR and write NUM_FILES copies of one gradient JPEG.
 
-    Files are deliberately distinct (different solid colours + EXIF
-    dates) so the scanner classifies them as MOVE (isolated single-
-    item groups), not REVIEW_DUPLICATE — keeps the manifest shape
-    simple. We don't need pHash clustering for this scenario; just
-    rows in the manifest that we can later orphan.
+    All NUM_FILES files have identical bytes (same image, same EXIF),
+    so they share a sha256 and group as EXACT duplicates via Pass 1's
+    fast-path SHA-based classification — the manifest carries multiple
+    rows pointing at the same bytes and the duplicate-group tree
+    renders them. That gives us rows to later orphan when the source
+    files are deleted.
+
+    Pre-#462 this fixture used distinct solid-colour JPEGs that
+    happened to share pHash ``8000000000000000`` and were grouped as
+    EXACT via the buggy format-duplicate path (flat-image pHash
+    collision). #462 fixed that bug with a mean-color gate, exposing
+    that this scenario depended on the bug to populate the tree. The
+    gradient + sha256-match approach decouples the test from the
+    dedup correctness state — rows render regardless of whether the
+    pHash collision path is gated or not.
     """
     if FIXTURE_DIR.exists():
         shutil.rmtree(FIXTURE_DIR)
     FIXTURE_DIR.mkdir(parents=True, exist_ok=True)
 
+    # Build ONE gradient image whose pHash is non-flat — avoids any
+    # accidental dependency on a future bug at the flat-image path.
+    arr = np.zeros((100, 100, 3), dtype=np.uint8)
+    for y in range(100):
+        for x in range(100):
+            arr[y, x] = [
+                (x * 3) % 256,
+                (y * 3) % 256,
+                ((x ^ y) * 2) % 256,
+            ]
+    img = Image.fromarray(arr)
+    exif = img.getexif()
+    exif[36867] = "2024:08:01 12:00:00"   # DateTimeOriginal — same for all copies
+
     paths: list[Path] = []
     for i in range(NUM_FILES):
-        # Solid distinct colour per file → unique pHash → distinct rows.
-        arr = np.full((100, 100, 3), [(i * 80) % 256, 100, 200], dtype=np.uint8)
-        img = Image.fromarray(arr)
-        exif = img.getexif()
-        exif[36867] = f"2024:08:01 1{i}:00:00"  # DateTimeOriginal
+        # Identical bytes — Pass 1 sha-256 EXACT classification groups
+        # them together; per-file path differs so the manifest has
+        # NUM_FILES distinct rows (not one row).
         out = FIXTURE_DIR / f"s24_photo_{i:02d}.jpg"
         img.save(str(out), "JPEG", quality=85, exif=exif.tobytes())
         paths.append(out)

--- a/scanner/dedup.py
+++ b/scanner/dedup.py
@@ -248,7 +248,7 @@ def _classify_phash(
     for group in by_phash.values():
         if len(group) < 2:
             continue
-        _classify_format_group(group, rows, source_priority)
+        _classify_format_group(group, rows, source_priority, mean_color_threshold)
 
     # Near-duplicate scan: compare all pairs with hamming distance ≤ threshold
     _classify_near_duplicates(candidates, rows, threshold, source_priority, mean_color_threshold)
@@ -258,6 +258,7 @@ def _classify_format_group(
     group: list[HashResult],
     rows: dict[str, ManifestRow],
     source_priority: dict[str, int],
+    mean_color_threshold: int = 30,
 ) -> None:
     """Within a pHash==0 group, apply RAW+lossy exception and format priority."""
     has_raw = any(hr.record.file_type == "raw" for hr in group)
@@ -280,6 +281,17 @@ def _classify_format_group(
         key = str(duplicate.record.path)
         if key in rows:
             continue
+        # #462 — mean-color gate on the exact-pHash path. Catches the
+        # catalogued domain pattern where flat images (solid color or
+        # near-empty composition) all collide on pHash 8000000000000000
+        # — without this guard, an arbitrary set of black / white / blank
+        # PNGs would be silently marked as EXACT duplicates of each other.
+        # Mirrors the gate already in _classify_near_duplicates (line 319);
+        # skipped when either side lacks mean_color (RAW thumbnail, hash
+        # failure) — matches the near-duplicate path's None-handling.
+        if mean_color_threshold > 0 and keeper.mean_color and duplicate.mean_color:
+            if _mean_color_distance(keeper.mean_color, duplicate.mean_color) > mean_color_threshold:
+                continue
         rows[key] = _make_row(
             duplicate,
             "EXACT",

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -145,6 +145,59 @@ class TestFormatDuplicate:
         assert rows["/a.arw"].action == "MOVE"
         assert rows["/a.jpg"].action == "MOVE"
 
+    def test_flat_image_phash_collision_rejected_by_mean_color(self):
+        """#462 — flat images (black/white/grey) sharing pHash 8000000000000000
+        must NOT be marked EXACT of each other; the format-duplicate path now
+        gates on mean_color the same way the near-duplicate path does."""
+        flat_hash = "8000000000000000"
+        black = _hr("/a.jpg", sha256="b1", phash=flat_hash, file_type="jpeg",
+                    mean_color="0,0,0", source_label="takeout", exif_date=_dt())
+        white = _hr("/b.jpg", sha256="w1", phash=flat_hash, file_type="jpeg",
+                    mean_color="255,255,255", source_label="takeout", exif_date=_dt())
+        grey = _hr("/c.jpg", sha256="g1", phash=flat_hash, file_type="jpeg",
+                   mean_color="128,128,128", source_label="takeout", exif_date=_dt())
+        rows = _rows(classify([black, white, grey]))
+        # None should be EXACT of another — mean_color differs >> threshold 30.
+        for path in ("/a.jpg", "/b.jpg", "/c.jpg"):
+            assert rows[path].action != "EXACT", (
+                f"{path}: expected non-EXACT, got {rows[path].action} — "
+                f"flat-image pHash collision gate didn't fire"
+            )
+
+    def test_format_duplicate_similar_mean_color_still_marked_exact(self):
+        """#462 regression guard — HEIC + JPEG with same pHash AND similar
+        mean_color must still be marked EXACT (the gate doesn't over-reject
+        genuine format duplicates)."""
+        heic = _hr("/a.heic", sha256="h1", phash="0" * 16, file_type="heic",
+                   mean_color="120,130,140", source_label="jdrive", exif_date=_dt())
+        jpeg = _hr("/a.jpg", sha256="h2", phash="0" * 16, file_type="jpeg",
+                   mean_color="118,132,138", source_label="jdrive", exif_date=_dt())
+        rows = _rows(classify([heic, jpeg]))
+        assert rows["/a.jpg"].action == "EXACT"
+
+    def test_format_duplicate_missing_mean_color_falls_back_to_phash_only(self):
+        """#462 — if either side lacks mean_color (RAW thumbnail, hash
+        failure), the format-duplicate path still marks EXACT; gate skips on
+        missing data, matching _classify_near_duplicates' behavior."""
+        heic = _hr("/a.heic", sha256="h1", phash="0" * 16, file_type="heic",
+                   mean_color=None, source_label="jdrive", exif_date=_dt())
+        jpeg = _hr("/a.jpg", sha256="h2", phash="0" * 16, file_type="jpeg",
+                   mean_color="118,132,138", source_label="jdrive", exif_date=_dt())
+        rows = _rows(classify([heic, jpeg]))
+        assert rows["/a.jpg"].action == "EXACT"
+
+    def test_raw_plus_lossy_with_color_mismatch_still_complementary(self):
+        """#462 — RAW + lossy with mismatched mean_color must still return
+        early (both MOVE); the gate must not affect the RAW+lossy
+        complementary branch."""
+        raw = _hr("/a.arw", sha256="r1", phash="0" * 16, file_type="raw",
+                  mean_color="10,20,30", source_label="jdrive", exif_date=_dt())
+        jpeg = _hr("/a.jpg", sha256="j1", phash="0" * 16, file_type="jpeg",
+                   mean_color="200,180,160", source_label="jdrive", exif_date=_dt())
+        rows = _rows(classify([raw, jpeg]))
+        assert rows["/a.arw"].action == "MOVE"
+        assert rows["/a.jpg"].action == "MOVE"
+
 
 # ---------------------------------------------------------------------------
 # REVIEW_DUPLICATE (near-duplicate)


### PR DESCRIPTION
## Summary

Closes #462. The mean_color_threshold gate at `scanner/dedup.py:319` only protected `_classify_near_duplicates`, NOT `_classify_format_group` (the exact-pHash routing path). Catalogued domain pattern (from `photo-scanner-patterns` skill): flat images (solid color, near-empty composition) all collide on pHash `8000000000000000`. Without the gate on the exact path, an arbitrary set of black/white/blank PNGs got silently marked as EXACT duplicates of each other.

Fix mirrors the near-dup path's gate exactly:
- Plumb `mean_color_threshold` into `_classify_format_group`
- Skip EXACT for any duplicate whose mean_color distance from the keeper exceeds the threshold
- Rejected files fall through to `_classify_near_duplicates` (also gated) and then to Pass 3 as MOVE
- Skipped when either side lacks `mean_color` (RAW thumbnail, hash failure) — matches the near-dup path's None-handling

## Test plan

- [x] 4 new unit tests in `tests/test_dedup.py::TestFormatDuplicate` covering all regression vectors:
  - Flat-image collision (3-way black/white/grey) → no EXACT
  - Genuine HEIC+JPEG dup with similar mean_color → still EXACT (regression guard)
  - Missing mean_color → still EXACT (gate skipped, matches near-dup path)
  - RAW+lossy complementary → still MOVE (gate doesn't affect that branch)
- [x] `tests/test_dedup.py` 33/33 passing (was 29 — 4 new tests added)
- [x] Scoped sanity sweep on affected modules — 157/157 passing
- [ ] CI green

## Docs decision

`[docs-not-needed: qa fixture-only change — scenario intent and assertions unchanged; docs/testing.md per-module table already covers s24 generically]`

## QA coverage decision

`[qa-not-needed: unit-test-only correctness fix]` — this is internal dedup logic, no UI surface. The 4 unit tests cover the bug + 3 regression-guard cases. No qa scenario exercises the format-duplicate path directly today; if a future regression emerges in qa, an integration scenario could be added then.

## Out of scope

- #464 (manifest atomic write), #466+#467 (scoring calibration) — separate cold-session-style PRs from the same Phase 3 workflow run
- #465 (exiftool readline timeout) — deferred until #477 merges

## Related

- Discovered by the scanner-sweep workflow (this session)
- Catalogued in `~/.claude/skills/photo-scanner-patterns/SKILL.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)