### PR TITLE
fix(scanner): atomic manifest .sqlite write via temp+os.replace (#464)

### DIFF
--- a/news/479.bugfix
+++ b/news/479.bugfix
@@ -1,0 +1,1 @@
+Atomically replace the manifest sqlite via temp + os.replace so orphan -wal/-shm sidecars no longer survive a write and partial-writes never reach the destination (#464).

--- a/scanner/manifest.py
+++ b/scanner/manifest.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import sqlite3
 from pathlib import Path
 
@@ -50,12 +51,47 @@ VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?, ?, ?,  ?, ?, ?, ?)
 
 
 def write_manifest(rows: list[ManifestRow], output: Path) -> None:
-    """Create (or overwrite) the SQLite manifest at output."""
-    output.parent.mkdir(parents=True, exist_ok=True)
-    if output.exists():
-        output.unlink()
+    """Create (or overwrite) the SQLite manifest at ``output``.
 
-    with sqlite3.connect(output) as conn:
+    #464 — writes to a sibling ``<output>.tmp.sqlite`` first, then
+    ``os.replace()`` over the destination once the connection is closed.
+    Guarantees:
+
+      * Orphan ``-wal`` / ``-shm`` sidecars from a previous writer (or a
+        mid-write cancel — see #463) never bleed into the new manifest;
+        the temp DB owns its own sidecars, which are checkpointed away
+        when the connection closes.
+      * A partial write (process killed mid-INSERT, see #460) never
+        reaches the destination — the temp file may be left behind for
+        cleanup on the next call, but the live manifest stays consistent.
+    """
+    output.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = output.with_name(output.name + ".tmp.sqlite")
+    # Sweep both:
+    #   1. Stale TEMP from a previously-killed run — would block sqlite3.connect
+    #      on Windows (file lock) and corrupt the new write otherwise.
+    #   2. Orphan DESTINATION -wal/-shm — os.replace below only renames the
+    #      .sqlite itself; if a prior writer crashed pre-checkpoint and left
+    #      sidecars next to the destination, they'd survive the replace.
+    #      SQLite invalidates them via salt mismatch on the next open, so they
+    #      don't corrupt the manifest — but they leave junk on disk and
+    #      compound debugging when "the manifest looks empty/old."
+    for stale in (
+        tmp_path,
+        tmp_path.with_name(tmp_path.name + "-wal"),
+        tmp_path.with_name(tmp_path.name + "-shm"),
+        output.with_name(output.name + "-wal"),
+        output.with_name(output.name + "-shm"),
+    ):
+        if stale.exists():
+            stale.unlink()
+
+    # ``with sqlite3.connect(...)`` only commits/rolls back on exit — it
+    # does NOT close the connection. On Windows the connection keeps a
+    # file lock that would fail ``os.replace`` below, so we use explicit
+    # try/finally with ``conn.close()`` to release the handle.
+    conn = sqlite3.connect(tmp_path)
+    try:
         conn.execute("PRAGMA journal_mode = WAL")
         conn.execute("PRAGMA synchronous = NORMAL")
         conn.executescript(_DDL)
@@ -87,6 +123,15 @@ def write_manifest(rows: list[ManifestRow], output: Path) -> None:
             ],
         )
         conn.commit()
+        # Force WAL checkpoint so the temp DB has no live sidecars when
+        # the connection closes — keeps the rename single-file atomic.
+        conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
+    finally:
+        conn.close()
+
+    # Connection is fully closed here. ``os.replace`` is atomic on POSIX
+    # and on Windows (Python 3.3+) when the destination exists.
+    os.replace(tmp_path, output)
 
 
 def print_summary(rows: list[ManifestRow], skipped: int = 0) -> None:

--- a/tests/test_scanner_manifest.py
+++ b/tests/test_scanner_manifest.py
@@ -135,6 +135,113 @@ class TestWriteManifest:
             val = conn.execute("SELECT group_id FROM migration_manifest").fetchone()[0]
         assert val == "/a.jpg"
 
+    def test_orphan_wal_shm_sidecars_removed_on_overwrite(self, tmp_path):
+        """#464 — destination's orphan -wal/-shm sidecars from a prior
+        writer must not survive a new write_manifest call."""
+        import gc
+        out = tmp_path / "manifest.sqlite"
+        write_manifest([_row("/old.jpg", "MOVE", dest_path="/d/old.jpg")], out)
+        gc.collect()
+        (tmp_path / "manifest.sqlite-wal").write_bytes(b"orphan-wal-bytes")
+        (tmp_path / "manifest.sqlite-shm").write_bytes(b"orphan-shm-bytes")
+        write_manifest([_row("/new.jpg", "MOVE", dest_path="/d/new.jpg")], out)
+        gc.collect()
+        with sqlite3.connect(out) as conn:
+            paths = [r[0] for r in conn.execute(
+                "SELECT source_path FROM migration_manifest"
+            ).fetchall()]
+        assert paths == ["/new.jpg"]
+        # SQLite may legitimately create fresh sidecars on the next open,
+        # but the orphan bytes must be gone (replaced by the temp DB's
+        # state, which os.replace transferred to the destination).
+        wal = tmp_path / "manifest.sqlite-wal"
+        shm = tmp_path / "manifest.sqlite-shm"
+        if wal.exists():
+            assert wal.read_bytes() != b"orphan-wal-bytes"
+        if shm.exists():
+            assert shm.read_bytes() != b"orphan-shm-bytes"
+
+    def test_temp_file_not_left_behind_on_success(self, tmp_path):
+        """#464 — after a clean write, no <output>.tmp.sqlite (or its own
+        sidecars) should remain in output.parent — os.replace moved the
+        temp file to the destination."""
+        out = tmp_path / "manifest.sqlite"
+        write_manifest([_row("/a.jpg", "MOVE", dest_path="/d/a.jpg")], out)
+        leftovers = [p.name for p in tmp_path.iterdir() if "tmp.sqlite" in p.name]
+        assert leftovers == [], f"temp-write artifacts left behind: {leftovers}"
+
+    def test_destination_unchanged_when_write_fails_midflight(
+        self, tmp_path, monkeypatch
+    ):
+        """#464 — atomic-temp guarantee: if executemany raises mid-write,
+        the destination .sqlite is untouched (still has the prior write's
+        row), because os.replace only runs after the connection
+        successfully commits + closes."""
+        import gc
+        from scanner import manifest as manifest_mod
+        out = tmp_path / "manifest.sqlite"
+        write_manifest([_row("/orig.jpg", "MOVE", dest_path="/d/orig.jpg")], out)
+        gc.collect()
+
+        real_connect = sqlite3.connect
+
+        class _FailingConn:
+            """Proxy that forwards everything except executemany, which
+            raises. sqlite3.Connection's bound methods are read-only on
+            CPython, so a wrapper is the cleanest way to inject failure."""
+            def __init__(self, conn):
+                self._conn = conn
+
+            def execute(self, *a, **kw):
+                return self._conn.execute(*a, **kw)
+
+            def executescript(self, *a, **kw):
+                return self._conn.executescript(*a, **kw)
+
+            def executemany(self, *a, **kw):
+                raise RuntimeError("simulated mid-write crash")
+
+            def commit(self):
+                return self._conn.commit()
+
+            def close(self):
+                return self._conn.close()
+
+        def _failing_connect(path, *args, **kwargs):
+            return _FailingConn(real_connect(path, *args, **kwargs))
+
+        # Patch sqlite3.connect in manifest module's namespace so only
+        # write_manifest sees the failing connect — verification below
+        # uses sqlite3.connect from THIS module unchanged.
+        monkeypatch.setattr(manifest_mod.sqlite3, "connect", _failing_connect)
+        with pytest.raises(RuntimeError, match="simulated mid-write crash"):
+            write_manifest(
+                [_row("/new.jpg", "MOVE", dest_path="/d/new.jpg")], out
+            )
+        gc.collect()
+        monkeypatch.undo()
+        with sqlite3.connect(out) as conn:
+            paths = [r[0] for r in conn.execute(
+                "SELECT source_path FROM migration_manifest"
+            ).fetchall()]
+        assert paths == ["/orig.jpg"]
+
+    def test_stale_tmp_sqlite_from_prior_crash_is_replaced(self, tmp_path):
+        """#464 — a stale <output>.tmp.sqlite (and its -wal/-shm) from a
+        previously-killed run must be removed at the start of the next
+        write_manifest call; otherwise sqlite3.connect would lock or
+        corrupt the new write on Windows."""
+        out = tmp_path / "manifest.sqlite"
+        (tmp_path / "manifest.sqlite.tmp.sqlite").write_bytes(b"junk")
+        (tmp_path / "manifest.sqlite.tmp.sqlite-wal").write_bytes(b"junk-wal")
+        (tmp_path / "manifest.sqlite.tmp.sqlite-shm").write_bytes(b"junk-shm")
+        write_manifest([_row("/a.jpg", "MOVE", dest_path="/d/a.jpg")], out)
+        with sqlite3.connect(out) as conn:
+            paths = [r[0] for r in conn.execute(
+                "SELECT source_path FROM migration_manifest"
+            ).fetchall()]
+        assert paths == ["/a.jpg"]
+
 
 # ── print_summary ──────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## Summary

Closes #464. Previously `write_manifest()` unlinked the destination `.sqlite` and opened a new one in-place — two gaps:

1. **Orphan `-wal`/`-shm` sidecars** from a prior writer (one killed mid-checkpoint, see #460) survived the unlink because only the `.sqlite` itself was removed. SQLite invalidates them via salt mismatch at next open so they don't corrupt data — but the symptom of "manifest looks empty / has old data" is hard to debug.
2. **Partial writes** (process killed mid-INSERT) reached the destination path mid-flight, replacing the prior good manifest with a corrupt one.

Fix: write to a sibling `<output>.tmp.sqlite` first, fully close the connection (so WAL sidecars are checkpointed/dropped), then `os.replace` over the destination. Atomicity guarantees:

- The destination is never partial — `os.replace` only runs after successful with-block exit + checkpoint.
- Destination orphan `-wal`/`-shm` are swept at the start of every write, so the destination directory never has stale sidecars next to a fresh manifest.
- Stale `<output>.tmp.sqlite` from a prior crash is also swept (would otherwise lock `sqlite3.connect` on Windows).

## CPython / Windows detail

`with sqlite3.connect(...) as conn:` only commits/rolls back the transaction — it does NOT close the connection. On Windows the lingering file lock would fail `os.replace`, so the diff uses explicit `try/finally` with `conn.close()` instead of the with-block.

## Composes with

- [PR #476](https://github.com/jackal998/photo-manager/pull/476) #463 (cancel-during-WRITE) — a late cancel now leaves the original manifest untouched and a `<output>.tmp.sqlite` for next-call cleanup.
- [PR #477](https://github.com/jackal998/photo-manager/pull/477) #460 (Windows Job Object) — the ungraceful-exit scenario (Explorer-freeze force-quit) is now fully covered: exiftool children die with the parent, no corrupt manifest is left on disk, no orphan sidecars persist.

## Test plan

- [x] 4 new unit tests in `tests/test_scanner_manifest.py::TestWriteManifest`:
  - Orphan destination `-wal`/`-shm` from a prior writer removed on overwrite
  - No `<output>.tmp.sqlite` left behind after a clean write
  - Destination unchanged when `executemany` raises mid-write (via wrapper-class injection — `sqlite3.Connection`'s methods are read-only on CPython, so a proxy is the cleanest test seam)
  - Stale `<output>.tmp.sqlite` + sidecars from a prior crash are swept and the new write succeeds
- [x] `tests/test_scanner_manifest.py` 41/41 passing
- [ ] CI green
- [ ] Manual smoke: kill app mid-scan, confirm next scan's manifest has the new rows and the destination directory is clean (no orphan `-wal`/`-shm`)

## QA coverage decision

`[qa-not-needed: filesystem-correctness fix without UI surface]` — the bug is silent (orphan sidecars + post-crash manifest state); not driveable via UIA. Unit tests cover the atomic guarantee + the four failure-mode regressions.

## Out of scope

- #462 (flat-image pHash) — separate PR ([#478](https://github.com/jackal998/photo-manager/pull/478))
- #466 + #467 (scoring calibration) — next PR in this Phase 3 batch
- #465 (exiftool readline timeout) — deferred until #477 merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)