### PR TITLE
fix(scanner): scoring calibration bundle — path basename + tz pragmatic (#466, #467)

### DIFF
--- a/news/480.bugfix
+++ b/news/480.bugfix
@@ -1,0 +1,1 @@
+Fix scoring path penalty to exclude the basename (no double-count vs filename score) and de-duplicate per-segment hits when one folder matches multiple bad keywords; add forward-defensive tz-mismatch fallback to date-provenance heuristic (#466, #467).

--- a/scanner/scoring.py
+++ b/scanner/scoring.py
@@ -276,6 +276,18 @@ def _score_date_provenance(row: "ManifestRow") -> float:
     shot_date because no real EXIF DateTimeOriginal exists. Without
     storing the source tag separately in the DB, this comparison is the
     best heuristic available.
+
+    Tz-mismatch pragmatic fallback (#467): ``shot_date`` is camera-local
+    with tz info stripped (scanner/exif.py), while ``mtime`` is
+    scanner-local (scanner/dedup.py uses ``fromtimestamp``). When
+    camera and scanner are in different zones, a real EXIF date can be
+    off from mtime by a whole-hour multiple. The 2s gate doesn't trip
+    on the resulting large diff (the score happens to be 1.0 already),
+    but the explicit hour-multiple check makes the invariant
+    load-bearing — if the gate ever widened, the tz-mismatch case
+    would otherwise be wrongly demoted. Strict tz-aware handling via
+    OffsetTimeOriginal is deferred until scanner/exif.py is unlocked
+    by #460's PR merge.
     """
     if row.shot_date is None:
         return 0.0
@@ -283,8 +295,19 @@ def _score_date_provenance(row: "ManifestRow") -> float:
         try:
             shot = datetime.fromisoformat(row.shot_date)
             mt = datetime.fromisoformat(row.mtime)
-            if abs((shot - mt).total_seconds()) < 2.0:
+            diff = abs((shot - mt).total_seconds())
+            # Same-tz mtime-derived: very small diff. Check FIRST because
+            # the tz-mismatch test below would also match diff < 2.0
+            # (remainder == diff in that range), which would wrongly
+            # promote a suspicious row.
+            if diff < 2.0:
                 return 0.3   # suspicious: shot_date == mtime, likely derived
+            # Cross-tz tz-strip artefact: diff is close to a whole-hour
+            # multiple — likely a real EXIF date that just looks far
+            # from mtime because of the camera↔scanner tz delta.
+            remainder = diff % 3600.0
+            if remainder < 2.0 or remainder > 3598.0:
+                return 1.0
         except (ValueError, TypeError):
             # Malformed date string — fall through to the default below.
             pass
@@ -314,13 +337,17 @@ def _score_path(row: "ManifestRow") -> float:
     """Penalty score from directory path. Each path segment matching a
     'bad' substring (Downloads, WhatsApp, Screenshots, temp, …)
     subtracts 0.25 from a 1.0 base; floor 0.0.
+
+    Only directory segments are inspected — the basename is scored
+    by ``_score_filename`` and excluding it here avoids double-counting
+    (#466). Each segment contributes at most one −0.25, even if it
+    matches multiple bad-keyword keys (e.g. a folder named
+    "screenshots" hits both ``screenshots`` and ``screenshot``).
     """
-    parts_lower = [p.lower() for p in Path(row.source_path).parts]
+    parts_lower = [p.lower() for p in Path(row.source_path).parent.parts]
     hits = sum(
-        1
-        for seg in parts_lower
-        for bad in _BAD_PATH_SEGMENTS
-        if bad in seg
+        1 for seg in parts_lower
+        if any(bad in seg for bad in _BAD_PATH_SEGMENTS)
     )
     return max(0.0, 1.0 - 0.25 * hits)
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -250,6 +250,30 @@ class TestDateProvenanceScore:
         )
         assert _score_date_provenance(row) == 1.0
 
+    def test_whole_hour_tz_offset_treated_as_real_exif(self):
+        """#467 — when shot_date and mtime differ by a whole-hour
+        multiple (camera-local-tz-stripped vs scanner-local-tz),
+        treat the diff as a tz-mismatch artefact and score 1.0.
+        Forward-defensive: today the result is 1.0 anyway via the
+        diff > 2 fall-through, but the explicit hour-multiple check
+        guards against future widening of the 2s gate."""
+        # Camera-JST shot scanned on a UTC box: shot_date is naive
+        # camera-local (12:00:00), mtime is naive scanner-local
+        # (03:00:00 — same instant in UTC, 9-hour delta).
+        row = _row(
+            "/x/a.jpg",
+            shot_date="2024-06-15T12:00:00",
+            mtime="2024-06-15T03:00:00",
+        )
+        assert _score_date_provenance(row) == 1.0
+        # Edge: diff just below an hour-multiple boundary (within ±2s).
+        row2 = _row(
+            "/x/a.jpg",
+            shot_date="2024-06-15T11:59:58",
+            mtime="2024-06-15T03:00:00",
+        )
+        assert _score_date_provenance(row2) == 1.0
+
 
 # ── Tier 2 dimension 5: GPS ────────────────────────────────────────────────
 
@@ -329,6 +353,22 @@ class TestPathScore:
         """Filesystems vary on case sensitivity — match must work
         regardless of how the OS rendered the path."""
         row = _row("/Users/me/DOWNLOADS/photo.jpg")
+        assert _score_path(row) == pytest.approx(0.75)
+
+    def test_basename_matching_bad_keyword_not_counted_by_path(self):
+        """#466 — `_score_path` inspects only directory parts, not the
+        basename. A file named 'screenshot.jpg' in an otherwise clean
+        directory scores 1.0 from path; the filename penalty is
+        `_score_filename`'s job — counting it here would double-count."""
+        row = _row("/Users/me/Photos/2024/screenshot.jpg")
+        assert _score_path(row) == 1.0
+
+    def test_segment_matching_multiple_keys_counts_once(self):
+        """#466 — a single folder segment that matches multiple
+        bad-keyword keys (e.g. 'screenshots' matches both
+        ``screenshots`` and ``screenshot`` via substring) should only
+        contribute one -0.25, not -0.50."""
+        row = _row("/Users/me/screenshots/2024/photo.jpg")
         assert _score_path(row) == pytest.approx(0.75)
 
 


### PR DESCRIPTION
## Summary

Closes #466 AND #467. Two distinct calibration bugs in `scanner/scoring.py`, bundled because both touch the same file and would conflict if landed in separate parallel sessions.

### #466 — `_score_path` double-counts filename + multi-bad segments

`Path.parts` includes the basename, so a file named `Screenshot 2024.png` in an otherwise-clean directory took -0.25 from `_score_path` ON TOP of the -0.30 from `_score_filename`, despite the docstring saying "directory path". Plus the nested loop summed penalties per `(segment, bad_keyword)` pair: a folder `whatsapp-downloads` matched both `whatsapp` and `downloads` keys → -0.50 from one segment instead of -0.25.

**Fix:**
- `Path(...).parent.parts` instead of `Path(...).parts` — excludes basename, matches docstring
- `any()` so each segment contributes at most one -0.25 regardless of keyword-key count

### #467 — `_score_date_provenance` pragmatic tz-mismatch fallback

`shot_date` is camera-local with tz info stripped (`scanner/exif.py`), `mtime` is scanner-local (`scanner/dedup.py`). Cross-tz files have shot_date and mtime offset by a whole-hour multiple. The 2s gate doesn't trip on the resulting large diff (score = 1.0 already), but if the gate ever widened, the tz-mismatch case would be wrongly demoted.

**Fix:** explicit hour-multiple check so the invariant is load-bearing. Strict tz-aware handling via EXIF `OffsetTimeOriginal` is the correct long-term fix but requires touching `scanner/exif.py`, locked by [PR #477](https://github.com/jackal998/photo-manager/pull/477)'s merge order — deferred until the #465 work.

## Ordering bug in the investigator's draft (caught during apply)

The investigator's draft put the `remainder < 2` check BEFORE the `diff < 2` check. But when `diff < 2.0`, `remainder == diff` in that range — so the wrong order would wrongly promote a suspicious mtime-derived row (diff 0.5s) to 1.0 via the tz-mismatch path. Flipped to `diff < 2` first during apply; this preserves the original `diff < 2 → 0.3` behaviour for same-tz mtime-derived rows.

## Test plan

- [x] 3 new unit tests covering all four regression vectors:
  - `#466`: basename matching bad-keyword in clean directory → 1.0 (not 0.75)
  - `#466`: folder 'screenshots' (substring-matches both 'screenshots' and 'screenshot' keys) → 0.75 (not 0.5)
  - `#467`: whole-hour tz offset (9-hour diff) → 1.0 explicit
  - `#467` edge: ±2s of hour-multiple boundary → 1.0
- [x] All existing `test_scoring.py` tests still pass (78/78 — was 75 + 3 new)
- [x] `test_multiple_bad_segments_compound` regression-checked: `/Users/me/Downloads/WhatsApp Images/photo.jpg` still scores 0.5 (two distinct segments, each one hit)
- [ ] CI green

## QA coverage decision

`[qa-not-needed: scoring-calibration unit-only]` — scoring is an internal calibration surface; no UI flow tests it directly. The 7 unit tests in `TestDateProvenanceScore` + 7 in `TestPathScore` (3 new) cover the heuristic shape comprehensively.

## Out of scope

- #462 (flat-image pHash) — separate PR ([#478](https://github.com/jackal998/photo-manager/pull/478))
- #464 (atomic manifest write) — separate PR ([#479](https://github.com/jackal998/photo-manager/pull/479))
- #465 (exiftool readline timeout) — deferred until [PR #477](https://github.com/jackal998/photo-manager/pull/477) merges
- Strict tz-aware date handling via `OffsetTimeOriginal` — pragmatic fallback covers the common case; strict approach requires `scanner/exif.py` changes locked by #477

🤖 Generated with [Claude Code](https://claude.com/claude-code)