### PR TITLE
fix(scanner): skip $RECYCLE.BIN + system folders during walk

### DIFF
--- a/news/482.bugfix
+++ b/news/482.bugfix
@@ -1,0 +1,1 @@
+Skip Windows $RECYCLE.BIN and System Volume Information during scans so deleted-by-other-means files no longer leak into the manifest and trip send2trash's "can't recycle a recycle-bin file" error (#482).

--- a/scanner/media.py
+++ b/scanner/media.py
@@ -28,6 +28,28 @@ LOSSY_EXTENSIONS = {".jpg", ".jpeg", ".heic", ".heif", ".png", ".gif", ".webp", 
 
 SKIP_FILENAMES = {"thumbs.db", "desktop.ini", "failed_inserting_exif.txt", ".ds_store"}
 
+# Directory names that should NEVER be walked into during a scan. Match
+# is case-insensitive against each path segment between scan root and
+# file. Anything under one of these is system / OS-managed scratch
+# space and treated as out-of-scope for dedup:
+#
+#   - ``$RECYCLE.BIN`` — Windows per-drive Recycle Bin. Files inside
+#     are already user-deleted; including them in a scan also causes
+#     send2trash to fail with WinError -2147024809 (E_INVALIDARG)
+#     when the user tries to delete via the Execute Action flow,
+#     because send2trash can't send a recycle-bin file to itself.
+#   - ``System Volume Information`` — Windows shadow-copy / restore
+#     point store. Hidden, system-owned, never user-meaningful media.
+#   - ``.Trashes`` / ``.Trash-*`` — macOS / *nix trash dirs that show
+#     up on networked drives mounted from non-Windows hosts. Same
+#     "already deleted" semantics as ``$RECYCLE.BIN``.
+SKIP_DIRECTORIES = {
+    "$recycle.bin",
+    "system volume information",
+    ".trashes",
+    ".trash",
+}
+
 # Google Takeout: "IMG_9556(1).HEIC" → base="IMG_9556", number=1
 DUPE_RE = re.compile(r"^(.*)\((\d+)\)$")
 

--- a/scanner/walker.py
+++ b/scanner/walker.py
@@ -11,10 +11,36 @@ from loguru import logger
 from scanner.media import (
     EDITED_SUFFIXES,
     MEDIA_EXTENSIONS,
+    SKIP_DIRECTORIES,
     SKIP_FILENAMES,
     get_file_type,
     parse_media_filename,
 )
+
+
+def _is_in_skip_directory(path: Path, root: Path) -> bool:
+    """Return True if any ancestor of ``path`` between ``root`` and
+    ``path`` is in :data:`SKIP_DIRECTORIES` (case-insensitive).
+
+    Catches files inside Windows ``$RECYCLE.BIN`` / ``System Volume
+    Information`` / ``.Trashes`` regardless of where the user pointed
+    the scan root. The walker's normal filename / extension filters
+    would happily pull a recycle-bin ``$Rxxxxxx.jpg`` into the
+    manifest — leading to the user-reported "send2trash WinError
+    -2147024809" cluster when the user tries to delete via Execute
+    Action (already-in-recycle-bin files can't be sent to the
+    recycle bin again).
+
+    Args:
+        path: The candidate file path (any descendant of ``root``).
+        root: The scan root for the current source.
+    """
+    current = path.parent if path.is_file() else path
+    while current != root and current != current.parent:
+        if current.name.lower() in SKIP_DIRECTORIES:
+            return True
+        current = current.parent
+    return False
 
 
 def _has_win32_unsafe_name(name: str) -> bool:
@@ -131,6 +157,8 @@ def _scan_dir(
         if not path.is_file():
             continue
         if _traverses_symlink(path, root):
+            continue
+        if _is_in_skip_directory(path, root):
             continue
         if path.name.lower() in SKIP_FILENAMES:
             continue

--- a/tests/test_walker.py
+++ b/tests/test_walker.py
@@ -456,6 +456,124 @@ class TestWalkerExclusionsFixture:
 
 
 # ---------------------------------------------------------------------------
+# SKIP_DIRECTORIES — system / OS-managed folders never walked into
+# ---------------------------------------------------------------------------
+
+class TestWalkerSkipDirectories:
+    """Pin the SKIP_DIRECTORIES filter — system folders like
+    ``$RECYCLE.BIN`` and ``System Volume Information`` must never be
+    walked into.
+
+    Real-world regression: a user's scan against ``J:\\圖片`` walked
+    into ``J:\\圖片\\$RECYCLE.BIN`` and pulled the recycle bin's
+    ``$Rxxxxxx.jpg`` files into the manifest. The later Execute Action
+    delete then failed with ``WinError -2147024809`` (E_INVALIDARG)
+    on every recycle-bin row, because ``send2trash`` correctly refuses
+    to send a recycle-bin file back to the recycle bin.
+    """
+
+    def test_skips_recycle_bin_directory(self, tmp_path):
+        """Files inside ``$RECYCLE.BIN/`` must not appear in the
+        walker's output. Mirrors a real-world Windows scan layout."""
+        from scanner.walker import scan_sources
+
+        recycle = tmp_path / "$RECYCLE.BIN"
+        recycle.mkdir()
+        _write_jpeg(recycle / "$R0KXSFA.jpg")
+        _write_jpeg(tmp_path / "real_photo.jpg")
+
+        records = scan_sources({"src": tmp_path})
+        names = sorted(r.path.name for r in records)
+        assert names == ["real_photo.jpg"], (
+            f"walker pulled in recycle-bin file: {names}"
+        )
+
+    def test_skips_system_volume_information(self, tmp_path):
+        """Windows ``System Volume Information`` is restore-point /
+        shadow-copy store — never user-meaningful media."""
+        from scanner.walker import scan_sources
+
+        sysvol = tmp_path / "System Volume Information"
+        sysvol.mkdir()
+        _write_jpeg(sysvol / "shadow.jpg")
+        _write_jpeg(tmp_path / "real_photo.jpg")
+
+        records = scan_sources({"src": tmp_path})
+        names = sorted(r.path.name for r in records)
+        assert names == ["real_photo.jpg"]
+
+    def test_skip_directories_case_insensitive(self, tmp_path):
+        """The filter is case-insensitive — ``$Recycle.Bin``,
+        ``$RECYCLE.BIN``, ``$recycle.bin`` all match. Windows
+        preserves case but the recycle-bin folder name varies across
+        machines / locales."""
+        from scanner.walker import scan_sources
+
+        # Mixed-case variant — same semantics as the all-uppercase form.
+        recycle = tmp_path / "$Recycle.Bin"
+        recycle.mkdir()
+        _write_jpeg(recycle / "$R0U4AEF.jpg")
+        _write_jpeg(tmp_path / "real_photo.jpg")
+
+        records = scan_sources({"src": tmp_path})
+        names = sorted(r.path.name for r in records)
+        assert names == ["real_photo.jpg"]
+
+    def test_skips_nested_recycle_bin_subfolder(self, tmp_path):
+        """Recycle bin can contain its own subdirectory tree (e.g.
+        ``$R6M1QOM\\Photos from 2016\\...``). Every descendant of a
+        skip-directory ancestor must be excluded, not just direct
+        children."""
+        from scanner.walker import scan_sources
+
+        recycle = tmp_path / "$RECYCLE.BIN" / "$R6M1QOM" / "Photos from 2016"
+        recycle.mkdir(parents=True)
+        _write_jpeg(recycle / "IMAG0059.jpg")
+        _write_jpeg(tmp_path / "real_photo.jpg")
+
+        records = scan_sources({"src": tmp_path})
+        names = sorted(r.path.name for r in records)
+        assert names == ["real_photo.jpg"]
+
+    def test_does_not_skip_normal_files_alongside_recycle_bin(self, tmp_path):
+        """A sibling ``$RECYCLE.BIN`` folder must not suppress real
+        media files at the same depth — only descendants of
+        ``$RECYCLE.BIN`` are filtered, not the scan root itself."""
+        from scanner.walker import scan_sources
+
+        recycle = tmp_path / "$RECYCLE.BIN"
+        recycle.mkdir()
+        _write_jpeg(recycle / "$R0KXSFA.jpg")
+        # Normal media folder alongside the recycle bin.
+        normal = tmp_path / "DCIM"
+        normal.mkdir()
+        _write_jpeg(normal / "IMG_0001.jpg")
+        _write_jpeg(normal / "IMG_0002.jpg")
+
+        records = scan_sources({"src": tmp_path})
+        names = sorted(r.path.name for r in records)
+        assert names == ["IMG_0001.jpg", "IMG_0002.jpg"]
+
+    def test_scan_root_named_recycle_bin_is_still_scanned(self, tmp_path):
+        """Edge: if the user explicitly points the scan at a path NAMED
+        ``$RECYCLE.BIN`` (unlikely but possible), the root itself is
+        the scan scope — only its DESCENDANTS get the skip-directory
+        filter. Documents the intent of the ``_is_in_skip_directory``
+        walk-up-to-root pattern."""
+        from scanner.walker import scan_sources
+
+        # Treat the user's chosen root as scope, even if it happens
+        # to be named like a skip directory.
+        root = tmp_path / "$RECYCLE.BIN"
+        root.mkdir()
+        _write_jpeg(root / "real_photo.jpg")
+
+        records = scan_sources({"src": root})
+        names = sorted(r.path.name for r in records)
+        assert names == ["real_photo.jpg"]
+
+
+# ---------------------------------------------------------------------------
 # Win32-unsafe filename detection (photo-manager#169)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

User-reported (2026-05-30): a scan against `J:\圖片` walked INTO `J:\圖片\$RECYCLE.BIN` and pulled the recycle bin's `$Rxxxxxx.jpg` files into the manifest. The later Execute Action delete pass then failed with `[WinError -2147024809]` (E_INVALIDARG) on every recycle-bin row — `send2trash` correctly refuses to send a recycle-bin file back to the recycle bin. User saw "127 files queued, 14+ fail with 參數錯誤, all paths under \$RECYCLE.BIN\\".

Fix scope: **walker-only**. Per user direction the delete path is NOT changed to fall back to permanent unlink — `send2trash` remains the single delete mechanism. Files already in `$RECYCLE.BIN` that landed in a pre-existing manifest can be cleared via "Remove from list" in the review UI; the walker fix prevents recurrence.

## Implementation

- New `SKIP_DIRECTORIES` set in `scanner/media.py` (case-insensitive): `$recycle.bin`, `system volume information`, `.trashes`, `.trash`
- New `_is_in_skip_directory(path, root)` helper in `scanner/walker.py` that walks the parent chain up to `root` and returns True if any ancestor name matches
- `_scan_dir` filter chain adds the skip-directory check after the existing symlink-traversal check, before SKIP_FILENAMES and MEDIA_EXTENSIONS

System Volume Information and `.Trashes`/`.Trash` get the same treatment for consistency: they're the cross-platform recycle-bin equivalents that show up on NAS shares mounted from non-Windows hosts.

## Test plan

6 new tests in `tests/test_walker.py::TestWalkerSkipDirectories` pin every edge case:

- [x] Direct child of `$RECYCLE.BIN` excluded
- [x] Nested descendant (`$RECYCLE.BIN/$R6M1QOM/Photos from 2016/IMAG0059.jpg`) excluded — mirrors the actual user-reported path shape
- [x] Case-insensitive match (`$Recycle.Bin` works same as `$RECYCLE.BIN`)
- [x] `System Volume Information` excluded
- [x] Sibling normal folders alongside `$RECYCLE.BIN` still scanned (filter is descendant-of-skip, not absolute-name)
- [x] Scan root explicitly NAMED like a skip directory is still scope — only descendants get filtered

Full scanner suite: 296 passing, 2 skipped (pre-existing).

## QA coverage decision

`[qa-not-needed: walker-level filter with no UI surface]` — the bug surfaces in the existing Execute Action flow but the FIX is in the scanner pipeline. The 6 new unit tests cover every edge case deterministically; no qa scenario would meaningfully add over them.

## Out of scope

- **Permanent-unlink fallback in delete handler** — explicitly rejected by user. `send2trash` remains the sole delete mechanism.
- **Cleanup of existing manifests** that already contain `$RECYCLE.BIN` rows — user can mark those via the existing "Remove from list" flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)