### PR TITLE
refactor(scanner): extract run_hash_for_record as picklable pure compute path

### DIFF
--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -204,8 +204,8 @@ class ScanWorker(QThread):
         import threading
         from concurrent.futures import ThreadPoolExecutor, as_completed
         from scanner.walker import scan_sources
-        from scanner.hasher import compute_hashes
-        from scanner.exif import ExiftoolProcess, batch_read_extracts, parse_exif_date
+        from scanner.hasher import HashFailure, run_hash_for_record
+        from scanner.exif import ExiftoolProcess, batch_read_extracts
         from scanner.dedup import HashResult, classify
         from scanner.manifest import write_manifest, print_summary
         from scanner.scoring import apply_scoring_to_rows
@@ -322,20 +322,12 @@ class ScanWorker(QThread):
         cancel_flag = threading.Event()
         skipped: list[tuple[Path, str, str]] = []  # (path, exc type, exc msg)
 
-        # Detect silent image-decode failures: compute_hashes returned without
-        # raising but PIL couldn't produce a pHash — the file is truncated or
-        # corrupt. Route to the same skip channel as exception failures so the
-        # user sees them in the log instead of getting a misleading UNDATED row.
-        #
-        # Restricted to formats where PIL is the primary decoder and a missing
-        # pHash unambiguously means decode-failure:
-        #   - GIF excluded: compute_hashes always returns phash=None for GIF
-        #     (intentional early-return at scanner/hasher.py:53), so flagging
-        #     phash=None as corruption false-positives 100% of the time (#75).
-        #   - RAW excluded: rawpy is the decoder, and rawpy fails on legitimate
-        #     non-camera-RAW TIFFs (Photoshop / scanner output) — flagging
-        #     those as corrupt drops real user files from the manifest (#75).
-        _IMAGE_TYPES = frozenset(("jpeg", "heic", "png", "webp"))
+        # Silent image-decode-failure detection lives in
+        # scanner.hasher.run_hash_for_record now (#486 refactor). The
+        # closure below only routes the HashFailure / HashResult outcomes
+        # into ``skipped`` and ``exif_queue``; the compute and the
+        # corrupt-image gate are inside run_hash_for_record so the same
+        # pure function can be reused by a future ProcessPoolExecutor path.
 
         exif_queue: _queue.Queue = _queue.Queue()
         extracts: dict = {}
@@ -357,38 +349,29 @@ class ScanWorker(QThread):
         exiftool_missing = [False]
 
         def _hash_one(idx_record: tuple) -> tuple:
+            """Dispatch-only closure: call the pure compute path, route
+            the outcome into ``skipped`` / ``exif_queue`` based on
+            type. Cancellation short-circuits before any compute.
+            """
             idx, record = idx_record
             if cancel_flag.is_set():
                 return idx, None
-            try:
-                sha256, phash, mean_color, raw_date, px_w, px_h = compute_hashes(record.path, record.file_type)
-            except Exception as exc:  # pylint: disable=broad-exception-caught
-                # One bad file must never abort the whole scan — log + skip.
-                skipped.append((record.path, type(exc).__name__, str(exc)))
+            _, outcome = run_hash_for_record(idx, record)
+            if isinstance(outcome, HashFailure):
+                # Both raised exceptions and silent decode failures
+                # land here — the HashFailure carries a distinct
+                # exc_type so the user-visible log line stays
+                # distinguishable.
+                skipped.append((record.path, outcome.exc_type, outcome.exc_msg))
                 return idx, None
-            pil_date = parse_exif_date(raw_date) if raw_date else None
-            result = HashResult(
-                record=record, sha256=sha256, phash=phash, mean_color=mean_color,
-                exif_date=pil_date, pixel_width=px_w, pixel_height=px_h,
-            )
-            # #450 — corrupt-image detection lives here now so the
-            # exif queue never receives a truncated/corrupt file. Mirrors
-            # the pre-#450 post-hash sweep exactly, including the
-            # GIF / RAW exclusions documented above.
-            if record.file_type in _IMAGE_TYPES and phash is None:
-                skipped.append((
-                    record.path,
-                    "ImageDecodeError",
-                    "image file could not be decoded (truncated or corrupt)",
-                ))
-                return idx, None
-            # Queue for exif unless this is a skip-type record (the
-            # exiftool pass excludes "skip" anyway pre-#450).
+            # outcome is a HashResult — queue for exif unless this is
+            # a skip-type record (the exiftool pass excludes "skip"
+            # anyway pre-#450).
             if record.file_type != "skip":
-                exif_queue.put(result)
+                exif_queue.put(outcome)
                 with exif_total_lock:
                     exif_total[0] += 1
-            return idx, result
+            return idx, outcome
 
         def _exif_consumer() -> None:
             """Drain ``exif_queue`` into 500-batches fed to one

--- a/news/487.misc
+++ b/news/487.misc
@@ -1,0 +1,1 @@
+Extract per-file hash compute into a top-level picklable ``run_hash_for_record`` — structural precondition for a future ProcessPoolExecutor migration of the HASH stage (#486).

--- a/scanner/hasher.py
+++ b/scanner/hasher.py
@@ -33,8 +33,15 @@ from __future__ import annotations
 
 import hashlib
 import io
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional, Union
+
+from scanner.dedup import HashResult
+from scanner.exif import parse_exif_date
+
+if TYPE_CHECKING:
+    from scanner.walker import FileRecord
 
 try:
     from PIL import Image
@@ -135,6 +142,83 @@ def compute_hashes(
         # though the dimensions are known and valid; phash failure shouldn't
         # cascade into a fake resolution-zero penalty.
         return sha, None, None, raw_date, px_w, px_h
+
+
+# Formats where PIL is the primary decoder and a missing pHash unambiguously
+# means decode-failure:
+#   - GIF excluded: compute_hashes always returns phash=None for GIF
+#     (intentional early-return at scanner/hasher.py:53), so flagging
+#     phash=None as corruption false-positives 100% of the time (#75).
+#   - RAW excluded: rawpy is the decoder, and rawpy fails on legitimate
+#     non-camera-RAW TIFFs (Photoshop / scanner output) — flagging
+#     those as corrupt drops real user files from the manifest (#75).
+_IMAGE_TYPES = frozenset(("jpeg", "heic", "png", "webp"))
+
+
+@dataclass
+class HashFailure:
+    """Marker returned by :func:`run_hash_for_record` when a file cannot
+    be hashed. Carries the exception type name + message so the caller
+    can append to its ``skipped`` log without re-deriving the failure
+    reason.
+
+    Used for both raised exceptions (``compute_hashes`` failed) and
+    silent decode failures (``compute_hashes`` returned with
+    ``phash=None`` for an image-typed file). The latter is surfaced as
+    ``exc_type="ImageDecodeError"`` so the user-visible log line stays
+    distinguishable from a real Python exception trace.
+    """
+
+    exc_type: str
+    exc_msg: str
+
+
+def run_hash_for_record(
+    idx: int, record: "FileRecord"
+) -> tuple[int, Union[HashResult, HashFailure, None]]:
+    """Pure compute path for one ``FileRecord``.
+
+    Returns ``(idx, outcome)`` where ``outcome`` is one of:
+
+    * :class:`HashResult` — happy path, record was hashed successfully
+    * :class:`HashFailure` — ``compute_hashes`` raised OR returned
+      ``phash=None`` for a format where that means decode-failure
+      (see :data:`_IMAGE_TYPES`)
+    * ``None`` — currently unused; reserved for caller-driven skip
+      signals (e.g. cancel-flag short-circuit, which lives in the
+      dispatch closure, not here)
+
+    The ``idx`` is passed through unchanged so the caller can map
+    out-of-order completions back to the original input ordering.
+    This function is intentionally side-effect-free and picklable so
+    it can be submitted to either a ``ThreadPoolExecutor`` (current
+    use) or a ``ProcessPoolExecutor`` (planned, see follow-up to #486).
+    """
+    try:
+        sha256, phash, mean_color, raw_date, px_w, px_h = compute_hashes(
+            record.path, record.file_type
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        # One bad file must never abort the whole scan — caller logs + skips.
+        return idx, HashFailure(type(exc).__name__, str(exc))
+    if record.file_type in _IMAGE_TYPES and phash is None:
+        # Silent decode failure: PIL couldn't produce a pHash for an
+        # image-typed file → truncated / corrupt. Caller routes this
+        # to its skipped[] log alongside real exceptions.
+        return idx, HashFailure(
+            "ImageDecodeError",
+            "image file could not be decoded (truncated or corrupt)",
+        )
+    pil_date = parse_exif_date(raw_date) if raw_date else None
+    return idx, HashResult(
+        record=record,
+        sha256=sha256,
+        phash=phash,
+        mean_color=mean_color,
+        exif_date=pil_date,
+        pixel_width=px_w,
+        pixel_height=px_h,
+    )
 
 
 def _raw_exif_date(img: "Image.Image") -> Optional[str]:


### PR DESCRIPTION
[qa-not-needed: pure internal refactor, zero behaviour change — closure-bound compute step moves into a top-level picklable function, dispatch closure shrinks. All existing tests/test_scan_worker.py qa-equivalent regressions (#46/#51/#56/#57/#49) pass unchanged with no source edits to those tests.]

## Summary

Refactor lift of the closure-bound compute step from `ScanWorker._hash_one` into a top-level `run_hash_for_record()` in `scanner/hasher.py`. Zero behaviour change — same inputs, same outputs, same side effects routed through the same dispatch closure. Structural precondition for a future ProcessPoolExecutor migration of the HASH stage.

Closes #486.

## What changed

- **`scanner/hasher.py`** (+86 LOC)
  - New `HashFailure` dataclass — marker for both raised exceptions and silent decode failures (`exc_type` distinguishes `"ImageDecodeError"` from real exception class names)
  - New `_IMAGE_TYPES` module-level frozenset (lifted from `scan_worker.py` with comment block intact)
  - New `run_hash_for_record(idx, record) -> tuple[int, HashResult | HashFailure | None]` — pure, side-effect-free, picklable
  - New top-level imports: `from scanner.dedup import HashResult`, `from scanner.exif import parse_exif_date` (no circular import — verified)

- **`app/views/workers/scan_worker.py`** (-30 LOC net)
  - `_hash_one` closure shrinks to dispatch-only: cancel check + `isinstance(outcome, HashFailure)` routing into `skipped[]` / `exif_queue`
  - Local `_IMAGE_TYPES` + comment block removed (now lives in hasher.py)
  - Imports updated: `from scanner.hasher import HashFailure, run_hash_for_record` (was `compute_hashes`); `parse_exif_date` no longer imported (only called inside `run_hash_for_record` now)

## Why a separate file's worth of tests vs new file

Issue body proposed `tests/test_hasher_run_hash_for_record.py`. I added `TestRunHashForRecord` to the existing `tests/test_hasher.py` instead — it mirrors the source file 1:1 (the convention everywhere else in `tests/`), helps `hasher.py`'s per-file coverage rise, and keeps related tests co-located. Decision called out here so the deviation is reviewable.

## Tests

- **New** — `TestRunHashForRecord` (4 tests, all use real fixtures, no mocks):
  - `test_happy_path_returns_hash_result` — happy-path JPEG → `HashResult` with all 6 fields populated
  - `test_oserror_returns_hash_failure` — non-existent path → `HashFailure("FileNotFoundError", ...)`
  - `test_truncated_jpeg_returns_image_decode_error` — truncated JPEG → `HashFailure("ImageDecodeError", "...truncated or corrupt")`
  - `test_gif_with_null_phash_returns_hash_result_not_failure` — valid GIF with `phash=None` → `HashResult` (NOT flagged as corrupt; regression for #75)

- **Unchanged** — `tests/test_scan_worker.py` (all 7 test classes, 20+ tests including #46/#51/#56/#57/#49 regressions) — pass without any modification. Researcher-verified that the monkeypatch pattern at `tests/test_scan_worker.py:58` still works because `run_hash_for_record` calls `compute_hashes` as a bare name (module-level lookup picks up the patched version).

- **Full unit suite**: 89% coverage (up from 88%), per-file 70% floor green on all 63 tracked files.

## Test plan

- [x] `pytest tests/test_hasher.py::TestRunHashForRecord -v` → 4 passed
- [x] `pytest tests/test_hasher.py tests/test_scan_worker.py tests/test_scan_worker_progress.py` → 53 passed, 0 failed
- [x] `pytest tests/ --ignore=tests/integration` → all green
- [x] `scripts/check_coverage_per_file.py` → all 63 files clear the 70% floor

## Out of scope

- ProcessPoolExecutor migration itself — that's the follow-up enhancement (will file as a sibling issue once this lands)
- Auto-calibration / settings surface for choosing pool kind — third PR in the planned sequence
- Any change to EXIF consumer threads (#451), walk parallelism (#452), or the hash-queue-exif pipeline (#450)

🤖 Generated with [Claude Code](https://claude.com/claude-code)