### PR TITLE
[ci-probe source-only] #486 bisect — DO NOT MERGE

### DIFF
--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -204,8 +204,8 @@ class ScanWorker(QThread):
         import threading
         from concurrent.futures import ThreadPoolExecutor, as_completed
         from scanner.walker import scan_sources
-        from scanner.hasher import compute_hashes
-        from scanner.exif import ExiftoolProcess, batch_read_extracts, parse_exif_date
+        from scanner.hasher import HashFailure, run_hash_for_record
+        from scanner.exif import ExiftoolProcess, batch_read_extracts
         from scanner.dedup import HashResult, classify
         from scanner.manifest import write_manifest, print_summary
         from scanner.scoring import apply_scoring_to_rows
@@ -322,20 +322,12 @@ class ScanWorker(QThread):
         cancel_flag = threading.Event()
         skipped: list[tuple[Path, str, str]] = []  # (path, exc type, exc msg)
 
-        # Detect silent image-decode failures: compute_hashes returned without
-        # raising but PIL couldn't produce a pHash — the file is truncated or
-        # corrupt. Route to the same skip channel as exception failures so the
-        # user sees them in the log instead of getting a misleading UNDATED row.
-        #
-        # Restricted to formats where PIL is the primary decoder and a missing
-        # pHash unambiguously means decode-failure:
-        #   - GIF excluded: compute_hashes always returns phash=None for GIF
-        #     (intentional early-return at scanner/hasher.py:53), so flagging
-        #     phash=None as corruption false-positives 100% of the time (#75).
-        #   - RAW excluded: rawpy is the decoder, and rawpy fails on legitimate
-        #     non-camera-RAW TIFFs (Photoshop / scanner output) — flagging
-        #     those as corrupt drops real user files from the manifest (#75).
-        _IMAGE_TYPES = frozenset(("jpeg", "heic", "png", "webp"))
+        # Silent image-decode-failure detection lives in
+        # scanner.hasher.run_hash_for_record now (#486 refactor). The
+        # closure below only routes the HashFailure / HashResult outcomes
+        # into ``skipped`` and ``exif_queue``; the compute and the
+        # corrupt-image gate are inside run_hash_for_record so the same
+        # pure function can be reused by a future ProcessPoolExecutor path.
 
         exif_queue: _queue.Queue = _queue.Queue()
         extracts: dict = {}
@@ -357,38 +349,29 @@ class ScanWorker(QThread):
         exiftool_missing = [False]
 
         def _hash_one(idx_record: tuple) -> tuple:
+            """Dispatch-only closure: call the pure compute path, route
+            the outcome into ``skipped`` / ``exif_queue`` based on
+            type. Cancellation short-circuits before any compute.
+            """
             idx, record = idx_record
             if cancel_flag.is_set():
                 return idx, None
-            try:
-                sha256, phash, mean_color, raw_date, px_w, px_h = compute_hashes(record.path, record.file_type)
-            except Exception as exc:  # pylint: disable=broad-exception-caught
-                # One bad file must never abort the whole scan — log + skip.
-                skipped.append((record.path, type(exc).__name__, str(exc)))
+            _, outcome = run_hash_for_record(idx, record)
+            if isinstance(outcome, HashFailure):
+                # Both raised exceptions and silent decode failures
+                # land here — the HashFailure carries a distinct
+                # exc_type so the user-visible log line stays
+                # distinguishable.
+                skipped.append((record.path, outcome.exc_type, outcome.exc_msg))
                 return idx, None
-            pil_date = parse_exif_date(raw_date) if raw_date else None
-            result = HashResult(
-                record=record, sha256=sha256, phash=phash, mean_color=mean_color,
-                exif_date=pil_date, pixel_width=px_w, pixel_height=px_h,
-            )
-            # #450 — corrupt-image detection lives here now so the
-            # exif queue never receives a truncated/corrupt file. Mirrors
-            # the pre-#450 post-hash sweep exactly, including the
-            # GIF / RAW exclusions documented above.
-            if record.file_type in _IMAGE_TYPES and phash is None:
-                skipped.append((
-                    record.path,
-                    "ImageDecodeError",
-                    "image file could not be decoded (truncated or corrupt)",
-                ))
-                return idx, None
-            # Queue for exif unless this is a skip-type record (the
-            # exiftool pass excludes "skip" anyway pre-#450).
+            # outcome is a HashResult — queue for exif unless this is
+            # a skip-type record (the exiftool pass excludes "skip"
+            # anyway pre-#450).
             if record.file_type != "skip":
-                exif_queue.put(result)
+                exif_queue.put(outcome)
                 with exif_total_lock:
                     exif_total[0] += 1
-            return idx, result
+            return idx, outcome
 
         def _exif_consumer() -> None:
             """Drain ``exif_queue`` into 500-batches fed to one

--- a/scanner/hasher.py
+++ b/scanner/hasher.py
@@ -33,8 +33,21 @@ from __future__ import annotations
 
 import hashlib
 import io
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional
+from typing import TYPE_CHECKING, Optional, Union
+
+if TYPE_CHECKING:
+    # Type-only references — kept out of runtime import graph so that
+    # importing scanner.hasher doesn't eagerly pull scanner.dedup +
+    # scanner.exif + scanner.walker. The runtime symbols are looked up
+    # lazily inside run_hash_for_record below. See PR #487 — eager
+    # module-level imports here surfaced a Windows-CI Qt access
+    # violation in an unrelated dialog test via test-ordering / memory
+    # layout shift; lazy import sidesteps the heisenflake without
+    # giving up the picklability the refactor enables.
+    from scanner.dedup import HashResult
+    from scanner.walker import FileRecord
 
 try:
     from PIL import Image
@@ -135,6 +148,92 @@ def compute_hashes(
         # though the dimensions are known and valid; phash failure shouldn't
         # cascade into a fake resolution-zero penalty.
         return sha, None, None, raw_date, px_w, px_h
+
+
+# Formats where PIL is the primary decoder and a missing pHash unambiguously
+# means decode-failure:
+#   - GIF excluded: compute_hashes always returns phash=None for GIF
+#     (intentional early-return at scanner/hasher.py:53), so flagging
+#     phash=None as corruption false-positives 100% of the time (#75).
+#   - RAW excluded: rawpy is the decoder, and rawpy fails on legitimate
+#     non-camera-RAW TIFFs (Photoshop / scanner output) — flagging
+#     those as corrupt drops real user files from the manifest (#75).
+_IMAGE_TYPES = frozenset(("jpeg", "heic", "png", "webp"))
+
+
+@dataclass
+class HashFailure:
+    """Marker returned by :func:`run_hash_for_record` when a file cannot
+    be hashed. Carries the exception type name + message so the caller
+    can append to its ``skipped`` log without re-deriving the failure
+    reason.
+
+    Used for both raised exceptions (``compute_hashes`` failed) and
+    silent decode failures (``compute_hashes`` returned with
+    ``phash=None`` for an image-typed file). The latter is surfaced as
+    ``exc_type="ImageDecodeError"`` so the user-visible log line stays
+    distinguishable from a real Python exception trace.
+    """
+
+    exc_type: str
+    exc_msg: str
+
+
+def run_hash_for_record(
+    idx: int, record: "FileRecord"
+) -> "tuple[int, Union[HashResult, HashFailure, None]]":
+    """Pure compute path for one ``FileRecord``.
+
+    Returns ``(idx, outcome)`` where ``outcome`` is one of:
+
+    * :class:`HashResult` — happy path, record was hashed successfully
+    * :class:`HashFailure` — ``compute_hashes`` raised OR returned
+      ``phash=None`` for a format where that means decode-failure
+      (see :data:`_IMAGE_TYPES`)
+    * ``None`` — currently unused; reserved for caller-driven skip
+      signals (e.g. cancel-flag short-circuit, which lives in the
+      dispatch closure, not here)
+
+    The ``idx`` is passed through unchanged so the caller can map
+    out-of-order completions back to the original input ordering.
+    This function is intentionally side-effect-free and picklable so
+    it can be submitted to either a ``ThreadPoolExecutor`` (current
+    use) or a ``ProcessPoolExecutor`` (planned, see follow-up to #486).
+    HashResult / parse_exif_date are imported lazily here — see the
+    TYPE_CHECKING block at the top of the module for the rationale
+    (#487 CI Qt heisenflake).
+    """
+    # Lazy imports — see module-level TYPE_CHECKING block for why.
+    # Python caches imports in sys.modules so this is one dict lookup
+    # after the first call; per-call cost is negligible.
+    from scanner.dedup import HashResult
+    from scanner.exif import parse_exif_date
+
+    try:
+        sha256, phash, mean_color, raw_date, px_w, px_h = compute_hashes(
+            record.path, record.file_type
+        )
+    except Exception as exc:  # pylint: disable=broad-exception-caught
+        # One bad file must never abort the whole scan — caller logs + skips.
+        return idx, HashFailure(type(exc).__name__, str(exc))
+    if record.file_type in _IMAGE_TYPES and phash is None:
+        # Silent decode failure: PIL couldn't produce a pHash for an
+        # image-typed file → truncated / corrupt. Caller routes this
+        # to its skipped[] log alongside real exceptions.
+        return idx, HashFailure(
+            "ImageDecodeError",
+            "image file could not be decoded (truncated or corrupt)",
+        )
+    pil_date = parse_exif_date(raw_date) if raw_date else None
+    return idx, HashResult(
+        record=record,
+        sha256=sha256,
+        phash=phash,
+        mean_color=mean_color,
+        exif_date=pil_date,
+        pixel_width=px_w,
+        pixel_height=px_h,
+    )
 
 
 def _raw_exif_date(img: "Image.Image") -> Optional[str]:


### PR DESCRIPTION
[skip-news: ci-probe]
[qa-not-needed: probe — only scanner pipeline refactor, exercised by existing test_scan_worker.py]

## Purpose

Source-only half of the #486 / PR #487 bisect. Applies ONLY the
scanner/hasher.py + app/views/workers/scan_worker.py changes from
PR #487, with NO test changes.

## Pair

`ci-probe/test-only` (PR — TBD) — applies ONLY PR1's test additions.

## Hypothesis

If this branch's pytest passes and test-only's fails → the new test
class addition is the trigger. If this fails and test-only passes →
the source diff is the trigger. If both fail → the interaction is.
If both pass → the combination triggers something we still can't
explain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)