### PR TITLE
fix(select-dialog): stop preview timer on close to prevent Qt UAF (#492)

### DIFF
--- a/app/views/dialogs/select_dialog.py
+++ b/app/views/dialogs/select_dialog.py
@@ -2179,6 +2179,16 @@ class ActionDialog(QDialog):
         current_field = self._current_field()
         if current_field:
             self._settings_set(self._field_key, current_field)
+        # #492: stop the debounced live-preview timer before the dialog
+        # tears down. _preview_timer is a singleShot QTimer (150ms); if a
+        # keystroke armed it just before close, an un-stopped timer leaves
+        # a pending timeout queued against this dialog. When the orphaned
+        # dialog is later collected and its deferred-delete drains during a
+        # subsequent test's processEvents(), that stale timer is a
+        # use-after-free (Windows/3.11 abort in CI test isolation). Stopping
+        # it here makes the timer a plain child QObject, safe to destroy.
+        if hasattr(self, "_preview_timer"):
+            self._preview_timer.stop()
         super().done(result)
 
 

--- a/news/495.bugfix
+++ b/news/495.bugfix
@@ -1,0 +1,1 @@
+Stop the Action dialog's live-preview timer on close so an orphaned dialog can't fire a stale timeout into a destroyed widget (a Windows/3.11 use-after-free that surfaced as CI test-isolation flake) (#492).


### PR DESCRIPTION
## What

Stop the debounced live-preview `QTimer` (`_preview_timer`, singleShot 150ms) in `ActionDialog.done()`, before `super().done()` tears the dialog down.

## Why

The timer was never stopped on close. If a keystroke armed it just before close, the pending 150ms timeout stayed queued against the dialog. When an orphaned `ActionDialog` was later garbage-collected and its deferred-delete drained during a *subsequent* test's `processEvents()`, the stale timer became a use-after-free — a Windows / Python-3.11 access-violation abort.

This surfaced as the CI test-isolation flake during the #486 hash refactor (`test_select_dialog.py::test_both_sections_visible_with_match_fn`). Local Python 3.12 cannot reproduce it (confirmed via a 50-iteration forced gc+DeferredDelete-drain probe), so it stayed latent until the 3.11 Windows runner hit it.

## How

`close()` routes through `done()` (via `QDialog.closeEvent` → `reject()` → `done()`), so stopping the timer there guarantees it fires on every close path. A stopped `QTimer` is a plain child `QObject`, safe to destroy during deferred-delete. Guarded with `hasattr` because `_preview_timer` is created conditionally (only when a `match_fn` wires up the preview pane).

Surgical root-cause fix — no autouse test fixture added: an autouse gc+drain teardown risked activating other dormant orphan-leaks on 3.11 and would muddy the single-hypothesis CI signal. If this proves insufficient on CI, the fixture is the documented next step.

Fixes #492

[docs-not-needed: pure Qt object-lifecycle teardown fix; no user-visible behaviour change — preview debounce behaves identically during use]
[qa-not-needed: pure Qt object-lifecycle teardown fix; no user-facing flow change to drive in a scenario]

🤖 Generated with [Claude Code](https://claude.com/claude-code)