### PR TITLE
feat(scanner): add scan.hash_pool ProcessPool opt-in for HASH stage (#486)

### DIFF
--- a/app/views/dialogs/scan_dialog.py
+++ b/app/views/dialogs/scan_dialog.py
@@ -983,6 +983,15 @@ class ScanDialog(QDialog):
         except (TypeError, ValueError):
             exif_workers = 2
 
+        # #486-PR2 — hash_pool is a setting-only knob today (no UI). Default
+        # "thread" preserves pre-PR2 behaviour; set ``scan.hash_pool`` to
+        # "process" in settings.json to run the HASH stage across a
+        # ProcessPoolExecutor (escapes the GIL on CPU-bound hashing at the
+        # cost of per-worker spawn re-imports on Windows). The worker
+        # validates the value at construction, falling back to "thread" on
+        # anything unrecognised.
+        hash_pool = self.settings.get("scan.hash_pool", "thread")
+
         self._worker = ScanWorker(
             sources=sources,
             output_path=output,
@@ -991,6 +1000,7 @@ class ScanDialog(QDialog):
             mean_color_threshold=self._color_slider.value(),
             workers=self._workers_spin.value(),
             exif_workers=exif_workers,
+            hash_pool=hash_pool,
             auto_select_enabled=self._auto_select_check.isChecked(),
             auto_select_aggressive_delete=(
                 self._auto_select_aggressive_check.isChecked()

--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -126,6 +126,7 @@ class ScanWorker(QThread):
         limit: int | None = None,
         workers: int = 4,
         exif_workers: int = 2,
+        hash_pool: str = "thread",
         auto_select_enabled: bool = False,
         auto_select_aggressive_delete: bool = False,
     ) -> None:
@@ -149,6 +150,15 @@ class ScanWorker(QThread):
         cpu = _os.cpu_count() or 4
         cap = max(1, min(4, cpu // 2))
         self.exif_workers = max(1, min(exif_workers, cap))
+        # #486 follow-up (PR2) — HASH-stage executor selector. "thread"
+        # (default) keeps the in-process ThreadPoolExecutor; "process"
+        # runs the picklable run_hash_for_record across a
+        # ProcessPoolExecutor to escape the GIL on CPU-bound hashing.
+        # Default stays "thread" because the Windows spawn start-method
+        # re-imports PIL/rawpy per worker (~150-300ms each) — a cost only
+        # worth paying on large scans, decided per-machine later (PR3
+        # auto-calibration). Unknown values fall back to "thread".
+        self.hash_pool = hash_pool if hash_pool in ("thread", "process") else "thread"
         # #212 — when True, promote the top-scored row in each duplicate
         # group to action="KEEP" before writing the manifest. The scan
         # dialog persists the corresponding setting; defaults False so
@@ -202,7 +212,11 @@ class ScanWorker(QThread):
 
     def _run_pipeline(self) -> None:
         import threading
-        from concurrent.futures import ThreadPoolExecutor, as_completed
+        from concurrent.futures import (
+            ProcessPoolExecutor,
+            ThreadPoolExecutor,
+            as_completed,
+        )
         from scanner.walker import scan_sources
         from scanner.hasher import HashFailure, run_hash_for_record
         from scanner.exif import ExiftoolProcess, batch_read_extracts
@@ -367,22 +381,29 @@ class ScanWorker(QThread):
         # block in the log.
         exiftool_missing = [False]
 
-        def _hash_one(idx_record: tuple) -> tuple:
-            """Dispatch-only closure: call the pure compute path, route
-            the outcome into ``skipped`` / ``exif_queue`` based on
-            type. Cancellation short-circuits before any compute.
+        def _route_outcome(record, outcome):
+            """Route one compute outcome into the shared dispatch state and
+            return the ``HashResult`` to store (or ``None`` to skip).
+
+            #486-PR2 — extracted from ``_hash_one`` so both executor paths
+            share ONE routing implementation. The thread path runs this
+            inside the worker (via ``_hash_one``); the process path runs it
+            in the parent drain loop after the picklable
+            ``run_hash_for_record`` returns across the process boundary.
+            Both contexts are safe: ``skipped.append`` is GIL-atomic,
+            ``exif_queue`` is thread-safe, and the ``exif_total`` bump is
+            taken under ``exif_total_lock`` for the consumers' cross-thread
+            read.
             """
-            idx, record = idx_record
-            if cancel_flag.is_set():
-                return idx, None
-            _, outcome = run_hash_for_record(idx, record)
             if isinstance(outcome, HashFailure):
                 # Both raised exceptions and silent decode failures
                 # land here — the HashFailure carries a distinct
                 # exc_type so the user-visible log line stays
                 # distinguishable.
                 skipped.append((record.path, outcome.exc_type, outcome.exc_msg))
-                return idx, None
+                return None
+            if outcome is None:
+                return None
             # outcome is a HashResult — queue for exif unless this is
             # a skip-type record (the exiftool pass excludes "skip"
             # anyway pre-#450).
@@ -390,7 +411,23 @@ class ScanWorker(QThread):
                 exif_queue.put(outcome)
                 with exif_total_lock:
                     exif_total[0] += 1
-            return idx, outcome
+            return outcome
+
+        def _hash_one(idx_record: tuple) -> tuple:
+            """Thread-path dispatch closure: cancel-check, call the pure
+            compute path, then route the outcome. Cancellation
+            short-circuits before any compute.
+
+            The process path can't use this closure (it captures the
+            thread-only ``cancel_flag`` / ``exif_queue``); it submits
+            ``run_hash_for_record`` directly and routes in the parent drain
+            loop below.
+            """
+            idx, record = idx_record
+            if cancel_flag.is_set():
+                return idx, None
+            _, outcome = run_hash_for_record(idx, record)
+            return idx, _route_outcome(record, outcome)
 
         def _exif_consumer() -> None:
             """Drain ``exif_queue`` into 500-batches fed to one
@@ -456,7 +493,10 @@ class ScanWorker(QThread):
             # Once hashing finishes the totals settle.
             self._emit_stage(exif_tracker, done_snapshot, total_snapshot)
 
-        self._emit(f"Hashing {len(records):,} files (workers={self.workers})…")
+        self._emit(
+            f"Hashing {len(records):,} files (workers={self.workers},"
+            f" pool={self.hash_pool})…"
+        )
         self._emit(
             f"EXIF + scoring signals via exiftool — pipelined,"
             f" {self.exif_workers} parallel process(es)…"
@@ -488,8 +528,23 @@ class ScanWorker(QThread):
         for t in consumer_threads:
             t.start()
 
-        with ThreadPoolExecutor(max_workers=self.workers) as pool:
-            futures = {pool.submit(_hash_one, (i, r)): i for i, r in enumerate(records)}
+        # #486-PR2 — executor selector. Process path submits the picklable
+        # run_hash_for_record directly (the child can't touch the
+        # thread-only cancel_flag / exif_queue); the parent routes each
+        # outcome in the drain loop. Thread path (default) keeps the
+        # in-worker routing via _hash_one — identical to pre-PR2.
+        use_process = self.hash_pool == "process"
+        executor_cls = ProcessPoolExecutor if use_process else ThreadPoolExecutor
+        with executor_cls(max_workers=self.workers) as pool:
+            if use_process:
+                futures = {
+                    pool.submit(run_hash_for_record, i, r): i
+                    for i, r in enumerate(records)
+                }
+            else:
+                futures = {
+                    pool.submit(_hash_one, (i, r)): i for i, r in enumerate(records)
+                }
             for future in as_completed(futures):
                 if self.isInterruptionRequested():
                     cancel_flag.set()
@@ -506,7 +561,11 @@ class ScanWorker(QThread):
                     logger.warning("Scan cancelled by user during hashing pass")
                     self.failed.emit("Scan cancelled.")
                     return
-                idx, result = future.result()
+                idx, outcome = future.result()
+                # Thread path already routed inside _hash_one (outcome is
+                # the HashResult-or-None to store); process path returns the
+                # raw outcome to route here in the parent.
+                result = _route_outcome(records[idx], outcome) if use_process else outcome
                 if result is not None:
                     hash_results[idx] = result
                 done += 1

--- a/docs/features.md
+++ b/docs/features.md
@@ -54,6 +54,7 @@ for the chore plan.
 | [Scan dialog — collapse Advanced Settings](#scan-dialog--collapse-advanced-settings) | Scan |
 | [Scan dialog — exiftool workers (setting-only)](#scan-dialog--exiftool-workers-setting-only) | Scan |
 | [Scan dialog — folder list (no priority arrows)](#scan-dialog--folder-list-no-priority-arrows) | Scan |
+| [Scan dialog — hash pool mode (setting-only)](#scan-dialog--hash-pool-mode-setting-only) | Scan |
 | [Scan dialog — hash workers (NAS-aware default)](#scan-dialog--hash-workers-nas-aware-default) | Scan |
 | [Scan dialog — multi-source scan](#scan-dialog--multi-source-scan) | Scan |
 | [Scan flow — manifest summary in progress log](#scan-flow--manifest-summary-in-progress-log) | Scan |
@@ -453,6 +454,17 @@ for the chore plan.
 - **Conditions / variants:** No UI — operators raise the value via ``settings.json`` only. This is intentionally a *safe rollout knob* per the issue body, not a power-user control. Cancel posts one sentinel per consumer + joins all with a 5s timeout — no zombie exiftool processes.
 - **Related:** [#451](https://github.com/jackal998/photo-manager/issues/451); worker contract pinned by ``tests/test_scan_worker.py::TestScanWorkerExifWorkers``.
 - **Last verified:** 2026-05-28 (#451)
+
+---
+
+### Scan dialog — hash pool mode (setting-only)
+
+- **Entry point:** ``scan.hash_pool`` key in ``settings.json`` — read in [app/views/dialogs/scan_dialog.py](../app/views/dialogs/scan_dialog.py) at scan start and passed to ``ScanWorker``.
+- **Trigger:** Always — value is consumed on every Start Scan.
+- **Behaviour:** Selects the executor for the HASH stage. ``"thread"`` (default) runs the per-file hash compute across a ``ThreadPoolExecutor`` in-process (pre-PR2 behaviour). ``"process"`` runs the picklable ``run_hash_for_record`` across a ``ProcessPoolExecutor`` so CPU-bound hashing escapes the GIL across cores. The hash log line reports the active mode (``pool=thread`` / ``pool=process``). Outcome routing (corrupt-file skips, EXIF-queue handoff) is identical in both modes — in process mode the parent drains completed futures and routes, since the worker subprocess can't touch the thread-only cancel flag / queue.
+- **Conditions / variants:** No UI — operators set the value via ``settings.json`` only (the Advanced-settings checkbox + auto-calibration is a later PR). Default stays ``"thread"`` because the Windows ``spawn`` start method re-imports PIL/rawpy per worker (~150–300ms each), a cost only worth paying on large scans. Unknown values fall back to ``"thread"`` at ``ScanWorker`` construction. Cancellation in process mode stops submitting new work and lets ≤``workers`` in-flight files finish (``cancel_futures=True``) — same ~1-file user-visible latency as thread mode.
+- **Related:** [#486](https://github.com/jackal998/photo-manager/issues/486) (PR1 extracted the picklable compute path); worker contract pinned by ``tests/test_scan_worker.py::TestHashPoolSetting``. Real cross-process spawn is validated by real-world runs, not CI.
+- **Last verified:** 2026-05-31 (PR2)
 
 ---
 

--- a/news/497.feature
+++ b/news/497.feature
@@ -1,0 +1,1 @@
+Add a ``scan.hash_pool`` setting (``"thread"`` default | ``"process"``) that runs the HASH stage across a ProcessPoolExecutor to escape the GIL on CPU-bound hashing; default behaviour is unchanged and the knob is settings-only for now (#486).

--- a/tests/test_scan_worker.py
+++ b/tests/test_scan_worker.py
@@ -476,6 +476,121 @@ class TestScanWorkerExifWorkers:
         )
 
 
+class TestHashPoolSetting:
+    """#486-PR2 — the ``scan.hash_pool`` executor selector.
+
+    The HASH stage runs across a ThreadPoolExecutor by default and a
+    ProcessPoolExecutor when ``hash_pool="process"``. These tests cover
+    the construction-time validation and the executor-routing branch.
+
+    Routing is verified WITHOUT spawning real OS processes: the process
+    pool is monkeypatched to a ThreadPoolExecutor subclass that records
+    its instantiation. That exercises the real code path (process branch
+    chosen + parent-side outcome routing producing a manifest) while
+    staying CI-safe — the genuine cross-process spawn is validated by
+    real-world runs, not in CI.
+    """
+
+    def test_default_is_thread(self, qapp, tmp_path):
+        from app.views.workers.scan_worker import ScanWorker
+
+        w = ScanWorker(
+            sources={"s": str(tmp_path)},
+            output_path=str(tmp_path / "m.sqlite"),
+            recursive_map={"s": False},
+        )
+        assert w.hash_pool == "thread"
+
+    def test_process_value_kept(self, qapp, tmp_path):
+        from app.views.workers.scan_worker import ScanWorker
+
+        w = ScanWorker(
+            sources={"s": str(tmp_path)},
+            output_path=str(tmp_path / "m.sqlite"),
+            recursive_map={"s": False},
+            hash_pool="process",
+        )
+        assert w.hash_pool == "process"
+
+    def test_unknown_value_falls_back_to_thread(self, qapp, tmp_path):
+        """Catches: a typo'd / stale settings.json value silently selecting
+        a non-existent executor mode instead of the safe default."""
+        from app.views.workers.scan_worker import ScanWorker
+
+        w = ScanWorker(
+            sources={"s": str(tmp_path)},
+            output_path=str(tmp_path / "m.sqlite"),
+            recursive_map={"s": False},
+            hash_pool="garbage",
+        )
+        assert w.hash_pool == "thread"
+
+    def test_process_mode_routes_to_process_pool_and_writes_manifest(
+        self, qapp, tmp_path, monkeypatch
+    ):
+        """Catches: the process branch not being selected, OR the parent's
+        _route_outcome path dropping HashResults so the manifest comes out
+        empty. Asserts both the executor choice and end-to-end output."""
+        import concurrent.futures as _cf
+        from app.views.workers.scan_worker import ScanWorker
+
+        _write_jpeg(tmp_path / "only.jpg")
+        out = tmp_path / "manifest.sqlite"
+
+        instantiated: list[bool] = []
+        real_thread_pool = _cf.ThreadPoolExecutor
+
+        class SpyProcessPool(real_thread_pool):
+            # Delegates to a real ThreadPoolExecutor so run_hash_for_record
+            # runs in-thread (no OS spawn) while we record that the process
+            # branch instantiated it.
+            def __init__(self, *args, **kwargs):
+                instantiated.append(True)
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(_cf, "ProcessPoolExecutor", SpyProcessPool)
+
+        worker = ScanWorker(
+            sources={"solo": str(tmp_path)},
+            output_path=str(out),
+            recursive_map={"solo": False},
+            workers=1,
+            hash_pool="process",
+        )
+        worker.run()
+
+        assert instantiated == [True], "process mode must select ProcessPoolExecutor"
+        assert out.exists(), "parent-side outcome routing must still write the manifest"
+
+    def test_thread_mode_never_touches_process_pool(
+        self, qapp, tmp_path, monkeypatch
+    ):
+        """Catches: the default regressing so it accidentally instantiates
+        a ProcessPoolExecutor. Patches it to explode — a default scan must
+        complete without ever constructing it."""
+        import concurrent.futures as _cf
+        from app.views.workers.scan_worker import ScanWorker
+
+        _write_jpeg(tmp_path / "only.jpg")
+        out = tmp_path / "manifest.sqlite"
+
+        def _boom(*args, **kwargs):
+            raise AssertionError("thread mode must not construct a ProcessPoolExecutor")
+
+        monkeypatch.setattr(_cf, "ProcessPoolExecutor", _boom)
+
+        worker = ScanWorker(
+            sources={"solo": str(tmp_path)},
+            output_path=str(out),
+            recursive_map={"solo": False},
+            workers=1,
+            hash_pool="thread",
+        )
+        worker.run()
+
+        assert out.exists(), "default thread scan should write its manifest"
+
+
 class TestScanWorkerExifPipeline:
     """#450 — hash→exif pipeline overlap.
 


### PR DESCRIPTION
## What

Add a setting-only knob `scan.hash_pool` (`"thread"` default | `"process"`) that selects the executor for the scan pipeline's HASH stage. `"process"` runs the picklable `run_hash_for_record` (extracted in PR1, #487) across a `ProcessPoolExecutor` so CPU-bound hashing escapes the GIL across cores. No UI — read from `settings.json` at scan start, mirroring the `scan.exif_workers` precedent (#451).

## Why

The network/perf investigation found the scan bottleneck is single-process Python compute (GIL-bound hashing), not I/O — the NAS link sustains ~200 MB/s. PR1 made the per-file compute path picklable specifically to unblock this. This PR ships the **capability**; it does **not** change default behaviour (stays `thread`), because whether `process` actually wins is machine-dependent and must be measured on real data first (follow-up), with per-machine auto-calibration as a later PR.

## How

- Extract outcome-routing (`skipped` / `exif_queue` / `exif_total`) out of the `_hash_one` closure into a shared `_route_outcome` helper. **Thread path (default) keeps routing in-worker — byte-for-byte the same observable behaviour as before.** Process path submits `run_hash_for_record` directly and routes in the parent drain loop, since the subprocess can't touch the thread-only `cancel_flag` / `exif_queue`.
- Cancellation in process mode: stop submitting + `cancel_futures=True`; ≤`workers` in-flight files finish — same ~1-file user-visible latency as thread mode.
- `ScanWorker` validates the value at construction; unknown → `"thread"`.
- Hash log line now reports `pool=thread` / `pool=process` for traceability.

## Testing

`tests/test_scan_worker.py::TestHashPoolSetting` — construction validation + executor-routing. Routing is verified via a ThreadPool-delegating spy (no OS spawn in CI); real cross-process spawn is validated by real-world runs. All existing thread-path regressions (#46/#51/#56/#57/#49) stay green. Full suite: 1881 passed.

## Known tradeoff (for the real-world verification phase)

Process mode submits one future per file → per-task pickle of `FileRecord` in / `HashResult` out, plus Windows `spawn` re-importing PIL/rawpy per worker (~150-300ms each). On large scans of small files this overhead can offset the GIL savings; chunked submission is a clean follow-up if measurements show it. This is why the default stays `thread`.

Refs #486

[qa-not-needed: setting-only knob with no UI surface (same as scan.exif_workers, #451, which has no qa scenario); routing covered by TestHashPoolSetting unit tests]