### PR TITLE
fix(scanner): map .avi to video type so it isn't dropped from the manifest (#461)

### DIFF
--- a/news/506.bugfix
+++ b/news/506.bugfix
@@ -1,0 +1,1 @@
+Stop silently dropping ``.avi`` files from the scan manifest — ``.avi`` was walked and counted but had no file-type mapping, so it resolved to "skip" and never produced a row; it now maps to the video type and is hashed like other videos (#461).

--- a/scanner/media.py
+++ b/scanner/media.py
@@ -114,6 +114,12 @@ def get_file_type(path: Path) -> tuple[str, bool]:
         ".webp": "webp",
         ".mp4": "mp4", ".m4v": "mp4",
         ".mov": "mov",
+        # #461 — .avi is in MEDIA_EXTENSIONS/VIDEO_EXTENSIONS (so it's walked
+        # + counted), but was missing here, so get_file_type returned "skip"
+        # and walker.py dropped it before FileRecord creation — silent data
+        # loss. Map to "mp4" so it takes the video branch in compute_hashes
+        # (stream SHA-256, phash=None), same as the other video formats.
+        ".avi": "mp4",
     }
     declared = ext_type_map.get(ext, "skip")
 

--- a/scanner/scoring.py
+++ b/scanner/scoring.py
@@ -143,8 +143,11 @@ _BAD_PATH_SEGMENTS: frozenset[str] = frozenset({
     "messenger",
 })
 
-# Video suffixes used by the Live Photo peer detection.
-_VIDEO_SUFFIXES: frozenset[str] = frozenset({"mov", "mp4"})
+# Video suffixes — used by Live Photo peer detection AND by the EXIF-
+# completeness baseline (video rows are scored against the smaller video
+# tag census, not the image one). #461: ".avi" included so AVI rows (now
+# that they reach scoring) get the video treatment, not the image baseline.
+_VIDEO_SUFFIXES: frozenset[str] = frozenset({"mov", "mp4", "avi"})
 # HEIC suffixes used by the Live Photo peer detection.
 _HEIC_SUFFIXES: frozenset[str] = frozenset({"heic", "heif"})
 

--- a/tests/test_scanner_media.py
+++ b/tests/test_scanner_media.py
@@ -31,6 +31,10 @@ WEBP_MAGIC = b"RIFF\x00\x00\x00\x00WEBP"
 HEIC_MAGIC = b"\x00\x00\x00\x18ftypheic"
 MP4_MAGIC = b"\x00\x00\x00\x18ftypmp42"
 MOV_MAGIC = b"\x00\x00\x00\x18ftypqt  "
+# #461 — real AVI RIFF header. Video types aren't magic-checked by
+# get_file_type (only heic/raw/png/gif/webp are), so the bytes are
+# incidental here — the extension mapping is what's under test.
+AVI_MAGIC = b"RIFF\x00\x00\x00\x00AVI LIST"
 
 
 def _write(tmp_path: Path, name: str, data: bytes) -> Path:
@@ -74,6 +78,8 @@ class TestGetFileType:
             ("a.mp4", MP4_MAGIC, "mp4"),
             ("a.m4v", MP4_MAGIC, "mp4"),
             ("a.mov", MOV_MAGIC, "mov"),
+            # #461 — .avi must map to a video type ("mp4"), not "skip".
+            ("a.avi", AVI_MAGIC, "mp4"),
         ],
     )
     def test_extension_matches_magic(self, tmp_path, name, data, expected):
@@ -81,6 +87,30 @@ class TestGetFileType:
         kind, mismatch = get_file_type(path)
         assert kind == expected
         assert mismatch is False
+
+    def test_every_media_extension_maps_to_non_skip(self, tmp_path):
+        """#461 — every extension the walker accepts (MEDIA_EXTENSIONS) must
+        resolve to a real file_type, never "skip".
+
+        A "skip" mapping is the exact .avi bug: the walker counts the file
+        toward walk-progress and ``--limit`` but ``get_file_type`` returns
+        "skip", so ``walker.py`` drops it before ``FileRecord`` creation —
+        silently, with no manifest row and no error line. ``get_file_type``
+        only returns "skip" for an extension missing from ``ext_type_map``
+        (the magic-byte branch can reclassify to another real type but never
+        to "skip"), so dummy bytes are sufficient here. Guards the whole
+        class for any future format added to MEDIA_EXTENSIONS.
+        """
+        dropped = [
+            ext
+            for ext in sorted(MEDIA_EXTENSIONS)
+            if get_file_type(_write(tmp_path, f"probe{ext}", b"\x00" * 16))[0]
+            == "skip"
+        ]
+        assert not dropped, (
+            f"these MEDIA_EXTENSIONS resolve to 'skip' and would be silently "
+            f"dropped from the manifest (see #461): {dropped}"
+        )
 
     @pytest.mark.parametrize(
         "ext", [".dng", ".cr2", ".cr3", ".nef", ".arw", ".raf", ".rw2", ".tif", ".tiff"]


### PR DESCRIPTION
## What

`.avi` was in `MEDIA_EXTENSIONS` / `VIDEO_EXTENSIONS` (so the walker accepted it, counted it toward `--limit`, emitted walk-progress for each) but had **no `ext_type_map` entry** → `get_file_type()` returned `"skip"` → `walker.py` dropped it before `FileRecord` creation. AVI files were walked but never produced manifest rows — **silent data loss**, no error line, count mismatch.

## Why now

Priority-HIGH bug from the 2026-05-30 scanner-sweep. The gap has existed since the first scanner commit (#8 added `.avi` to the extension sets but never to `ext_type_map`). pr-review never caught it because no diff had reason to touch `media.py` lines 22 and 106 together.

## How

- **`media.py`** — add `".avi": "mp4"`. `"mp4"` is the correct value: it lands in `compute_hashes`' `("mp4","mov","gif","skip")` video branch (stream SHA-256, `phash=None`), so AVI produces a manifest row via SHA-256 exact-dup grouping — same path as the other video formats. (Mapping to a new string like `"avi"` would've required touching the hasher's video tuples too — a half-fix; `"mp4"` needs no other change.)
- **`scoring.py`** — add `"avi"` to `_VIDEO_SUFFIXES`. My fix is what first lets AVI reach scoring, so completing it: AVI rows are now scored against the video EXIF-completeness baseline (9 tags), not the image one (16) — consistent with mp4/mov. Also keeps Live-Photo/video-peer suffix checks consistent (harmless edges — AVI isn't an Apple Live-Photo format).
- **tests** — a direct `.avi → "mp4"` case, **plus an invariant test** asserting every `MEDIA_EXTENSIONS` entry resolves to a non-`"skip"` file_type. The invariant is the real guard — it kills this whole data-loss class for any future format.

## Verification

`get_file_type` only returns `"skip"` for an extension missing from `ext_type_map` — the magic-byte branch can reclassify to another real type but never to `"skip"` — so the invariant test's dummy bytes are sufficient and can't false-positive. Local: `tests/test_scanner_media.py` + `tests/test_hasher.py` green (77), full suite green, per-file floor clear.

Closes #461

[docs-not-needed: bug fix restoring already-nominal AVI support; features.md has no supported-formats entry to update]
[qa-not-needed: internal extension→type mapping fix, no new user-facing flow; the MEDIA_EXTENSIONS↔ext_type_map invariant unit test is the right-layer guard, and s11 already exercises the video scan path]