### PR TITLE
fix(execute): write delete audit CSV on UI Execute Action path (#505)

### DIFF
--- a/app/views/dialogs/execute_action_dialog.py
+++ b/app/views/dialogs/execute_action_dialog.py
@@ -1135,6 +1135,12 @@ class ExecuteActionDialog(QDialog):
         # (and _delete_file would hit "file not found" on the now-
         # deleted files).
         executed_in_scope: list[tuple] = []
+        # #505 — snapshot the running tallies so the audit log below
+        # records only THIS pass's deletions. deleted_paths /
+        # _failed_paths accumulate across repeated Execute clicks on a
+        # kept-open partial-execute dialog.
+        deleted_before = len(self.deleted_paths)
+        failed_before = len(self._failed_paths)
         for group in self._groups:
             for rec in getattr(group, "items", []):
                 if not in_scope(rec):
@@ -1149,6 +1155,11 @@ class ExecuteActionDialog(QDialog):
                 elif decision == REMOVE_FROM_LIST_DECISION:
                     deferred_remove_paths.append(rec.file_path)
                     executed_in_scope.append((group, rec))
+
+        # #505 — write the delete audit CSV for the files this pass
+        # actually removed. The UI delete path previously logged nothing,
+        # so the documented per-Execute-Action audit trail was missing.
+        self._write_delete_audit_log(deleted_before, failed_before)
 
         if self._manifest_path:
             all_done = self.deleted_paths + self.executed_paths
@@ -1224,6 +1235,34 @@ class ExecuteActionDialog(QDialog):
                 )
         self._decisions_changed = True
         self._refresh_ui_after_decision_change()
+
+    def _write_delete_audit_log(self, deleted_before: int, failed_before: int) -> None:
+        """Write the delete audit CSV for this Execute pass (#505).
+
+        Builds rows from the slice of ``deleted_paths`` / ``_failed_paths``
+        appended since ``*_before``, maps each path to its group number,
+        and delegates to the shared ``write_delete_log`` so the UI delete
+        path produces the same audit trail as ``DeleteService``.
+        """
+        new_deleted = self.deleted_paths[deleted_before:]
+        new_failed = self._failed_paths[failed_before:]
+        if not new_deleted and not new_failed:
+            return
+        path_to_group: dict[str, int] = {}
+        for group in self._groups:
+            for rec in getattr(group, "items", []):
+                path_to_group[getattr(rec, "file_path", "")] = group.group_number
+        rows: list[tuple[int, str, bool, str]] = [
+            (path_to_group.get(p, 0), p, True, "") for p in new_deleted
+        ]
+        rows += [
+            (path_to_group.get(p, 0), p, False, reason) for p, reason in new_failed
+        ]
+        try:
+            from infrastructure.logging import write_delete_log
+            write_delete_log(rows)
+        except Exception as exc:  # never let audit logging block execute
+            logger.warning("Failed to write delete audit log: {}", exc)
 
     def _delete_file(self, path: str) -> None:
         if not os.path.exists(path):

--- a/docs/features.md
+++ b/docs/features.md
@@ -284,7 +284,7 @@ for the chore plan.
 
 - **Entry point:** Main window menu → **Log** — labels in [translations/en.yml:36-41](../translations/en.yml#L36).
 - **Trigger:** User picks one of: **Open Latest Log**, **Open Latest Delete Log**, **Open Log Directory**, **Open Delete Log Directory**.
-- **Behaviour:** Opens the corresponding log file or directory in the OS default application / file manager. "Latest log" resolves to the most recently rotated `loguru` log file; "delete log" resolves to the audit CSV that `delete_service` writes on every Execute Action run.
+- **Behaviour:** Opens the corresponding log file or directory in the OS default application / file manager. "Latest log" resolves to the most recently rotated `loguru` log file; "delete log" resolves to the audit CSV (`delete_<timestamp>.csv`) written on every Execute Action run — both the regex/service delete path and the in-dialog Execute Action delete path go through the shared `infrastructure.logging.write_delete_log`, so a row (group, path, success, reason) is recorded for every file the run removed.
 - **Conditions / variants:** Log directory path comes from `infrastructure/logging.py` configuration. If no log file has been written yet (first run before any logging fires) the "Open Latest" entries open the directory instead.
 - **Related:** QA scenario [`qa/scenarios/s18_log_menu.py`](../qa/scenarios/s18_log_menu.py).
 - **Last verified:** 2026-05-21 (sweep for [#326](https://github.com/jackal998/photo-manager/issues/326))

--- a/infrastructure/delete_service.py
+++ b/infrastructure/delete_service.py
@@ -8,16 +8,14 @@ an audit CSV log.
 from __future__ import annotations
 
 from collections.abc import Callable, Iterable
-import csv
-from datetime import datetime
 import os
-from pathlib import Path
 
 from loguru import logger
 from send2trash import send2trash
 
 from core.models import PhotoGroup
 from core.services.interfaces import DeletePlan, DeletePlanGroupSummary, DeleteResult
+from infrastructure.logging import write_delete_log
 
 
 class DeleteService:
@@ -169,37 +167,20 @@ class DeleteService:
                 `%LOCALAPPDATA%/PhotoManager/delete_logs`.
         """
         result = self.delete_to_recycle(plan.delete_paths)
-        # Auto-write CSV log under %LOCALAPPDATA%/PhotoManager/delete_logs unless overridden
-        try:
-            base_dir = (
-                os.path.expandvars(log_dir)
-                if log_dir
-                else os.path.join(
-                    os.path.expandvars("%LOCALAPPDATA%"), "PhotoManager", "delete_logs"
-                )
-            )
-            Path(base_dir).mkdir(parents=True, exist_ok=True)
-            ts = datetime.now().strftime("%Y%m%d_%H%M%S")
-            log_path = os.path.join(base_dir, f"delete_{ts}.csv")
-            with open(log_path, "w", encoding="utf-8", newline="") as f:
-                writer = csv.writer(f)
-                writer.writerow(["GroupNumber", "FilePath", "Success", "Reason"])
-                # Build path -> group mapping for summary
-                path_to_group: dict[str, int] = {}
-                for g in groups:
-                    for r in g.items:
-                        path_to_group[r.file_path] = g.group_number
-                for p in result.success_paths:
-                    writer.writerow([path_to_group.get(p, 0), p, 1, ""])
-                for p, reason in result.failed:
-                    writer.writerow([path_to_group.get(p, 0), p, 0, reason])
+        # Build path -> group mapping, then delegate to the shared audit
+        # writer so this path and the Execute Action dialog (#505) emit
+        # one consistent delete_<ts>.csv format.
+        path_to_group: dict[str, int] = {}
+        for g in groups:
+            for r in g.items:
+                path_to_group[r.file_path] = g.group_number
+        rows: list[tuple[int, str, bool, str]] = [
+            (path_to_group.get(p, 0), p, True, "") for p in result.success_paths
+        ]
+        rows += [
+            (path_to_group.get(p, 0), p, False, reason) for p, reason in result.failed
+        ]
+        log_path = write_delete_log(rows, log_dir)
+        if log_path:
             result.log_path = log_path
-            logger.info(
-                "Delete log written: {} ({} success, {} failed)",
-                log_path,
-                len(result.success_paths),
-                len(result.failed),
-            )
-        except (OSError, ValueError) as ex:
-            logger.error("Write delete log failed: {}", ex)
         return result

--- a/infrastructure/logging.py
+++ b/infrastructure/logging.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+from collections.abc import Sequence
+import csv
+from datetime import datetime
 import os
 from pathlib import Path
 import subprocess
@@ -37,6 +40,34 @@ def get_log_directory() -> str:
 def get_delete_log_directory() -> str:
     """Get the delete log directory path."""
     return os.path.join(os.path.expandvars("%LOCALAPPDATA%"), "PhotoManager", "delete_logs")
+
+
+def write_delete_log(
+    rows: Sequence[tuple[int, str, bool, str]], log_dir: str | None = None
+) -> str | None:
+    """Write a delete audit CSV and return its path (``None`` on failure).
+
+    ``rows`` are ``(group_number, file_path, success, reason)`` tuples.
+    Shared by ``DeleteService.execute_delete`` and the Execute Action
+    dialog so every real deletion writes one consistent audit trail
+    under ``delete_<timestamp>.csv`` (photo-manager#505 — the UI delete
+    path previously logged nothing).
+    """
+    base_dir = os.path.expandvars(log_dir) if log_dir else get_delete_log_directory()
+    try:
+        Path(base_dir).mkdir(parents=True, exist_ok=True)
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        log_path = os.path.join(base_dir, f"delete_{ts}.csv")
+        with open(log_path, "w", encoding="utf-8", newline="") as f:
+            writer = csv.writer(f)
+            writer.writerow(["GroupNumber", "FilePath", "Success", "Reason"])
+            for group_number, file_path, success, reason in rows:
+                writer.writerow([group_number, file_path, 1 if success else 0, reason])
+        logger.info("Delete log written: {} ({} rows)", log_path, len(rows))
+        return log_path
+    except (OSError, ValueError) as ex:
+        logger.error("Write delete log failed: {}", ex)
+        return None
 
 
 def find_latest_log_file(log_dir: str | None = None) -> Path | None:

--- a/news/508.bugfix
+++ b/news/508.bugfix
@@ -1,0 +1,1 @@
+Write the delete audit CSV on the in-dialog Execute Action delete path so a real UI deletion is recorded (group, path, success, reason) like the regex/service path already was — previously only DeleteService wrote it, leaving UI deletes with no audit trail (#505).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,7 +74,7 @@ omit = [
   "main.py",                          # argparse + sys.exit shell; covered by qa-explore launching the real app
   "run_all_linters.py",               # dev tooling shell, not user-facing
   "infrastructure/image_service.py",  # requires running QApplication for decode; covered by qa-explore preview pane (s05)
-  "infrastructure/logging.py",        # module-level loguru sink setup; no executable surface beyond import
+  "infrastructure/logging.py",        # loguru sink setup + os.startfile/subprocess file-openers (no unit-testable surface); the pure write_delete_log helper IS covered via test_delete_service.py + test_execute_action_dialog.py
   # Files previously omitted as "the qa-explore territory of the
   # preview / dialog-dispatch stacks" — loaded into the layer-1
   # coverage report by two distinct triggers:

--- a/tests/test_execute_action_dialog.py
+++ b/tests/test_execute_action_dialog.py
@@ -503,6 +503,98 @@ class TestDeleteFile:
         assert str(f) in dlg.deleted_paths
 
 
+# ── #505 delete audit CSV on the UI delete path ────────────────────────────
+
+
+class TestDeleteAuditLog:
+    """#505 — the Execute Action delete path must write the same
+    ``delete_<ts>.csv`` audit trail that ``DeleteService`` does. Before
+    the fix the UI path wrote nothing, so an accidental mass-delete left
+    no CSV record (recovery had to fall back to the rotating app log)."""
+
+    def test_on_execute_writes_audit_csv_for_deleted_files(
+        self, qapp, tmp_path, monkeypatch
+    ):
+        import csv as _csv
+        from app.views.dialogs.execute_action_dialog import ExecuteActionDialog
+
+        f1 = tmp_path / "del1.jpg"
+        f1.write_bytes(b"x")
+        f2 = tmp_path / "del2.jpg"
+        f2.write_bytes(b"x")
+        groups = [_group(_rec(str(f1), "delete"), _rec(str(f2), "delete"), number=7)]
+        dlg = ExecuteActionDialog(groups, manifest_path=None)
+
+        log_dir = tmp_path / "delete_logs"
+        monkeypatch.setattr(
+            "infrastructure.logging.get_delete_log_directory", lambda: str(log_dir)
+        )
+        # send2trash mocked so the real fixtures aren't recycled on the
+        # test runner; the audit rows are built from deleted_paths, which
+        # is populated regardless of the boundary lib.
+        with patch("send2trash.send2trash"):
+            dlg._on_execute()
+
+        csvs = list(log_dir.glob("delete_*.csv"))
+        assert len(csvs) == 1, "UI Execute Action delete must write one audit CSV (#505)"
+        with open(csvs[0], encoding="utf-8", newline="") as fh:
+            rows = list(_csv.reader(fh))
+        assert rows[0] == ["GroupNumber", "FilePath", "Success", "Reason"]
+        logged = {r[1]: r for r in rows[1:]}
+        assert str(f1) in logged and str(f2) in logged
+        assert logged[str(f1)][0] == "7"  # group number mapped from self._groups
+        assert logged[str(f1)][2] == "1"  # success flag
+
+    def test_on_execute_audit_csv_records_failed_delete(
+        self, qapp, tmp_path, monkeypatch
+    ):
+        import csv as _csv
+        from app.views.dialogs.execute_action_dialog import ExecuteActionDialog
+
+        f = tmp_path / "boom.jpg"
+        f.write_bytes(b"x")
+        groups = [_group(_rec(str(f), "delete"), number=3)]
+        dlg = ExecuteActionDialog(groups, manifest_path=None)
+
+        log_dir = tmp_path / "delete_logs"
+        monkeypatch.setattr(
+            "infrastructure.logging.get_delete_log_directory", lambda: str(log_dir)
+        )
+        # Real failure mode: both the recycle-bin call and the os.remove
+        # fallback raise, so the path lands in _failed_paths.
+        with patch("send2trash.send2trash", side_effect=OSError("locked")):
+            with patch("os.remove", side_effect=OSError("locked")):
+                # _on_execute pops a QMessageBox for failed paths — silence it.
+                with patch("PySide6.QtWidgets.QMessageBox.warning"):
+                    dlg._on_execute()
+
+        csvs = list(log_dir.glob("delete_*.csv"))
+        assert len(csvs) == 1
+        with open(csvs[0], encoding="utf-8", newline="") as fh:
+            rows = list(_csv.reader(fh))
+        failed = [r for r in rows[1:] if r[1] == str(f)]
+        assert len(failed) == 1
+        assert failed[0][2] == "0"  # success flag false
+        assert failed[0][3]  # reason recorded
+
+    def test_on_execute_writes_no_csv_when_nothing_deleted(
+        self, qapp, tmp_path, monkeypatch
+    ):
+        """A keep-only / remove-only execute must not emit an empty audit
+        CSV — the log exists to record actual deletions."""
+        from app.views.constants import REMOVE_FROM_LIST_DECISION
+        from app.views.dialogs.execute_action_dialog import ExecuteActionDialog
+
+        groups = [_group(_rec("/keep.jpg", REMOVE_FROM_LIST_DECISION))]
+        dlg = ExecuteActionDialog(groups, manifest_path=None)
+        log_dir = tmp_path / "delete_logs"
+        monkeypatch.setattr(
+            "infrastructure.logging.get_delete_log_directory", lambda: str(log_dir)
+        )
+        dlg._on_execute()
+        assert not log_dir.exists() or list(log_dir.glob("delete_*.csv")) == []
+
+
 # ── Improvement 1: partial-execute via paths_filter ────────────────────────
 
 


### PR DESCRIPTION
## What

The in-dialog Execute Action delete path (`ExecuteActionDialog._delete_file` via `_on_execute`) sent files to the recycle bin and logged `Deleted file:` but **never wrote the `delete_*.csv` audit log** — only `DeleteService.execute_delete` did. A real UI delete therefore left no CSV, the documented per-Execute-Action audit / recovery aid (surfaced during an accidental-deletion recovery where the only record was the rotating app log).

## How

- Extract the CSV writer into a shared `infrastructure.logging.write_delete_log(rows, log_dir=None)` — one source of truth, same `delete_<ts>.csv` format and `GroupNumber,FilePath,Success,Reason` header.
- `DeleteService.execute_delete` now delegates to it (behaviour-preserving refactor; existing tests pass) and its now-unused `csv` / `datetime` / `Path` imports are removed.
- `ExecuteActionDialog._on_execute` snapshots the `deleted_paths` / `_failed_paths` tallies before the delete loop and writes the audit CSV for **only this pass's** removals via a new `_write_delete_audit_log` helper (index-slice avoids re-logging on repeated Execute clicks in a kept-open partial-execute dialog).
- `docs/features.md` Log-menu entry reworded; `pyproject.toml` omit comment for `logging.py` updated to note `write_delete_log` is test-covered.

## Tests

- `tests/test_execute_action_dialog.py::TestDeleteAuditLog` (3 real-behaviour tests): CSV written with group-mapped success rows; failed-delete recorded with `Success=0` + reason; no CSV emitted when nothing was deleted.
- `test_execute_action_dialog.py` + `test_delete_service.py` green; changed-source coverage 85% (`execute_action_dialog.py`) / 94% (`delete_service.py`).

[qa-not-needed: no user-facing flow changed — the delete dialog's buttons/labels/state transitions are identical; this only adds a background delete_*.csv audit-log side-effect, which is covered by layer-1 real-behaviour tests (TestDeleteAuditLog). Execute Action's actual delete path is already driven by qa scenarios s13/s36/s44.]

Closes #505

🤖 Generated with [Claude Code](https://claude.com/claude-code)