### PR TITLE
fix(scanner): dimension gate keeps tiny images out of pHash near-dup grouping (#522)

### DIFF
--- a/news/523.bugfix
+++ b/news/523.bugfix
@@ -1,0 +1,1 @@
+Stop tiny images (UI icons, thumbnails) below 128px from forming false perceptual near-duplicate groups; they still participate in exact-duplicate detection (#523).

--- a/scanner/dedup.py
+++ b/scanner/dedup.py
@@ -180,6 +180,7 @@ def classify(
     source_priority: dict[str, int] | None = None,
     min_phash_entropy_bits: int = 4,
     dhash_threshold: int = 10,
+    min_phash_dimension: int = 128,
 ) -> list[ManifestRow]:
     """Assign an action to every record and return ManifestRows.
 
@@ -200,6 +201,13 @@ def classify(
             vote. A pHash match whose dHash also agrees within this distance is
             flagged ``match_confidence="high"``, otherwise ``"low"``. Does NOT
             change which rows are grouped — only the confidence flag.
+        min_phash_dimension: dimension gate. An image whose smaller side is
+            below this many pixels is too low-detail for a 64-bit pHash to
+            discriminate — tiny UI icons / thumbnails flatten to a handful of
+            DCT coefficients, so unrelated small images collide and form false
+            near-dup groups. Such files are excluded from pHash near-dup
+            grouping (exact-SHA dedup still applies); images with unknown
+            dimensions (video / decode failure) pass through. ``0`` disables.
     """
     if source_priority is None:
         seen: dict[str, int] = {}
@@ -221,7 +229,7 @@ def classify(
     # Pass 2: pHash-based (cross-format + near-duplicate)
     _classify_phash(
         records, rows, threshold, source_priority, mean_color_threshold,
-        min_phash_entropy_bits, dhash_threshold,
+        min_phash_entropy_bits, dhash_threshold, min_phash_dimension,
     )
 
     # Pass 3: remaining unclassified files — all sources treated equally
@@ -305,6 +313,30 @@ def _phash_entropy_ok(phash: str, min_bits: int) -> bool:
     return min_bits <= bits <= nbits - min_bits
 
 
+def _phash_dimension_ok(hr: HashResult, min_dimension: int) -> bool:
+    """True if the image is large enough for a 64-bit pHash to discriminate.
+
+    A tiny image (UI icon, thumbnail, sprite) downsamples to a handful of DCT
+    coefficients, so a 64-bit pHash can't tell unrelated small images apart —
+    e.g. a 24×24 button icon and a 24×24 checkbox icon land within the
+    near-dup threshold and form a false group, *even though* their pHash isn't
+    degenerate and their dHash agrees (so #516 / #517 don't catch them). A
+    photo manager only ever wants to perceptually-group photo-sized images, so
+    an image whose smaller side is below ``min_dimension`` is kept out of
+    pHash grouping (exact-SHA dedup still applies).
+
+    ``min_dimension <= 0`` disables the gate. Unknown dimensions (video /
+    decode failure → ``pixel_width``/``pixel_height`` is ``None``) pass
+    through — the same None-tolerant handling as the other guards.
+    """
+    if min_dimension <= 0:
+        return True
+    w, h = hr.pixel_width, hr.pixel_height
+    if w is None or h is None:
+        return True
+    return min(w, h) >= min_dimension
+
+
 def _classify_phash(
     records: list[HashResult],
     rows: dict[str, ManifestRow],
@@ -313,21 +345,24 @@ def _classify_phash(
     mean_color_threshold: int = 30,
     min_phash_entropy_bits: int = 4,
     dhash_threshold: int = 10,
+    min_phash_dimension: int = 128,
 ) -> None:
     """Group by pHash; classify FORMAT_DUPLICATE and REVIEW_DUPLICATE.
 
-    Records whose pHash is degenerate (flat image — see
-    :func:`_phash_entropy_ok`, #516) are excluded from BOTH the
-    exact-pHash format-group path and the near-duplicate scan, so an
-    arbitrary set of flat icons sharing ``0000…`` never collapses into
-    one false group.
+    Records are excluded from BOTH the exact-pHash format-group path and the
+    near-duplicate scan when their pHash is degenerate (flat image — see
+    :func:`_phash_entropy_ok`, #516) OR the image is too small for a 64-bit
+    pHash to discriminate (:func:`_phash_dimension_ok` — tiny UI icons /
+    thumbnails). Both classes still get exact-SHA dedup.
     """
     # Only consider records not already classified, with a valid pHash,
-    # whose pHash carries enough structure to be trustworthy (#516).
+    # whose pHash is trustworthy (#516 entropy) and whose image is large
+    # enough to discriminate (dimension gate — kills tiny-icon false groups).
     candidates = [
         hr for hr in records
         if hr.phash
         and _phash_entropy_ok(hr.phash, min_phash_entropy_bits)
+        and _phash_dimension_ok(hr, min_phash_dimension)
         and str(hr.record.path) not in rows
     ]
 

--- a/tests/test_dedup.py
+++ b/tests/test_dedup.py
@@ -52,6 +52,8 @@ def _hr(
     pair_partner: Path | None = None,
     pair_cluster: tuple[Path, ...] | None = None,
     dhash: str | None = None,
+    pixel_width: int | None = 4000,
+    pixel_height: int | None = 3000,
 ) -> HashResult:
     return HashResult(
         record=_record(
@@ -63,6 +65,8 @@ def _hr(
         dhash=dhash,
         mean_color=mean_color,
         exif_date=exif_date,
+        pixel_width=pixel_width,
+        pixel_height=pixel_height,
     )
 
 
@@ -774,3 +778,62 @@ class TestMatchConfidence:
         rows = _rows(classify(recs, source_priority={"src_a": 0, "src_b": 1}))
         assert rows["/b/x.jpg"].action == "EXACT"
         assert rows["/b/x.jpg"].match_confidence == "high"  # byte-identical is certain
+
+
+# ---------------------------------------------------------------------------
+# Dimension gate — tiny-icon false grouping
+# ---------------------------------------------------------------------------
+
+class TestDimensionGate:
+    """Tiny images (UI icons / thumbnails) downsample to too few DCT
+    coefficients for a 64-bit pHash to tell apart, so unrelated small images
+    land within the near-dup threshold and form false groups — even though
+    their pHash isn't degenerate (#516) and their dHash agrees (#517). The
+    dimension gate keeps sub-photo-sized images out of pHash grouping.
+    """
+
+    # Non-degenerate pHashes 1 bit apart → a near-dup match if grouped.
+    _PA, _PB = "ffff0000ffff0000", "ffff0000ffff0001"
+
+    def _pair(self, w, h):
+        return [
+            _hr("/a.png", sha256="s1", phash=self._PA, file_type="png",
+                exif_date=_dt(), pixel_width=w, pixel_height=h),
+            _hr("/b.png", sha256="s2", phash=self._PB, file_type="png",
+                exif_date=_dt(), pixel_width=w, pixel_height=h),
+        ]
+
+    def test_tiny_images_not_grouped(self):
+        """24×24 icons below the 128px default gate are excluded from pHash
+        grouping → undecided, no group."""
+        rows = _rows(classify(self._pair(24, 24)))  # default min_phash_dimension=128
+        assert rows["/b.png"].action == ""
+        assert rows["/a.png"].group_id is None and rows["/b.png"].group_id is None
+
+    def test_tiny_images_grouped_when_gate_disabled(self):
+        """Reproduces the bug: with the gate off the same icons collapse."""
+        rows = _rows(classify(self._pair(24, 24), min_phash_dimension=0))
+        assert rows["/b.png"].action == "REVIEW_DUPLICATE"
+
+    def test_photo_sized_images_still_grouped(self):
+        """A real near-dup pair (well above the gate) still groups."""
+        rows = _rows(classify(self._pair(512, 512)))
+        assert rows["/b.png"].action == "REVIEW_DUPLICATE"
+        assert rows["/a.png"].group_id == rows["/b.png"].group_id
+
+    def test_exact_sha_tiny_still_flagged(self):
+        """The gate only affects the pHash path — a byte-identical tiny icon
+        is still flagged EXACT."""
+        recs = [
+            _hr("/a/i.png", sha256="same", file_type="png", source_label="src_a",
+                exif_date=_dt(), pixel_width=24, pixel_height=24),
+            _hr("/b/i.png", sha256="same", file_type="png", source_label="src_b",
+                exif_date=_dt(), pixel_width=24, pixel_height=24),
+        ]
+        rows = _rows(classify(recs, source_priority={"src_a": 0, "src_b": 1}))
+        assert rows["/b/i.png"].action == "EXACT"
+
+    def test_unknown_dimensions_pass_through(self):
+        """Unknown dims (None — video / decode failure) are not excluded."""
+        rows = _rows(classify(self._pair(None, None)))
+        assert rows["/b.png"].action == "REVIEW_DUPLICATE"


### PR DESCRIPTION
## What
The third and most decisive guard against the flat/tiny-image false-grouping class. After #516 (entropy guard) + #519 (dHash confidence), **tiny images still formed false near-dup groups** — measured on the 90 Qt Designer control icons (16–48px):

| pipeline | false groups | largest | REVIEW_DUPLICATE rows |
|---|---|---|---|
| current (#516 + #519) | **16** | **33** | **38** |
| + dimension gate | **0** | — | **0** |

They slip past the existing guards because their pHashes aren't degenerate (9–32 bits set → #516 passes) and their dHashes agree (similar gradients → #517 flags high-confidence). Root cause: a 64-bit pHash of a ≤48px image has too few DCT coefficients to discriminate.

## How
`_phash_dimension_ok()` in `scanner/dedup.py::_classify_phash` excludes any image whose **smaller side < `min_phash_dimension` (default 128px)** from both the format-dup and near-dup pHash paths (candidates filter, beside the #516 entropy guard).
- **Exact-SHA dedup untouched** — a byte-identical icon copied across `.venv` dirs is still flagged EXACT.
- Unknown dims (video / decode failure) pass through; `0` disables.
- Internal `classify()` param, no UI (mirrors the entropy guard).

## Tests
- 5 new `TestDimensionGate` tests: tiny not grouped, grouped when gate disabled (bug repro), photo-sized still grouped, exact-SHA tiny still flagged, unknown-dims pass through.
- Full suite green (89.28%), per-file floor ✓. The `_hr` test helper now defaults to photo-sized 4000×3000 so existing near-dup tests keep grouping.

## No qa-fixture regression
Near-dup scenarios (s07/s42/s52/s13/s60/s61/s64) use 480×640 fixtures (≥128). s24's 100×100 images group via **exact-SHA** (per its docstring), not pHash — unaffected by the gate.

Closes #522. Builds on #516 + #519.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
