### PR TITLE
fix(tree): stop auto-scrolling the main tree to the clicked column

### DIFF
--- a/app/views/components/tree_controller.py
+++ b/app/views/components/tree_controller.py
@@ -45,6 +45,16 @@ class TreeController:
         self.tree.setUniformRowHeights(True)
         self.tree.setSortingEnabled(True)
         self.tree.setSelectionMode(QTreeView.ExtendedSelection)
+        # Stop Qt auto-scrolling the viewport to the clicked cell on every
+        # selection change. With autoScroll on, clicking a row whose cells
+        # extend past the viewport made the view jerk horizontally to "align"
+        # the clicked column into view — disorienting on a wide table. This
+        # only gates the implicit scrollTo(current) inside currentChanged();
+        # our deliberate scrollTo() calls (re-select after manifest load /
+        # post-scan auto-select) still scroll the target into view. Trade-off:
+        # drag-select near a viewport edge no longer auto-scrolls, negligible
+        # for this fully-expanded ExtendedSelection tree.
+        self.tree.setAutoScroll(False)
         # Take over double-click handling — our dispatcher routes file rows
         # to the OS viewer (#143) and group rows to toggle expand. Leaving
         # Qt's default on would race our own setExpanded() call, producing

--- a/docs/features.md
+++ b/docs/features.md
@@ -46,6 +46,7 @@ for the chore plan.
 | [Main window — geometry + splitter persistence](#main-window--geometry--splitter-persistence) | Main window |
 | [Main window — keyboard navigation](#main-window--keyboard-navigation) | Main window |
 | [Main window — results tree double-click](#main-window--results-tree-double-click) | Main window |
+| [Main window — row selection (no horizontal auto-scroll)](#main-window--row-selection-no-horizontal-auto-scroll) | Main window |
 | [Main window — sort persistence within session](#main-window--sort-persistence-within-session) | Main window |
 | [Main window — status bar baseline](#main-window--status-bar-baseline) | Main window |
 | [Open Manifest — base flow](#open-manifest--base-flow) | File operations |
@@ -362,6 +363,17 @@ for the chore plan.
 - **Conditions / variants:** The OS-spawn branch for files is layer-1 covered only — spawning a real viewer has no deterministic close-trigger across image apps. The Open Folder cascade is shared with the context menu via [app/views/handlers/file_opener.py](../app/views/handlers/file_opener.py).
 - **Related:** [PR #198](https://github.com/jackal998/photo-manager/pull/198) (closes [#143](https://github.com/jackal998/photo-manager/issues/143)); QA scenario [`qa/scenarios/s40_results_tree_double_click.py`](../qa/scenarios/s40_results_tree_double_click.py).
 - **Last verified:** 2026-05-21 (sweep for [#326](https://github.com/jackal998/photo-manager/issues/326))
+
+---
+
+### Main window — row selection (no horizontal auto-scroll)
+
+- **Entry point:** `TreeController.setup_tree_properties` — [tree_controller.py](../app/views/components/tree_controller.py) calls `setAutoScroll(False)` on the main result tree.
+- **Trigger:** User clicks (or arrow-keys to) a row whose cells extend past the visible viewport on a horizontally-scrolled wide table.
+- **Behaviour:** Selecting a row no longer jerks the viewport sideways to "align" the clicked column into view. Qt's default `autoScroll` calls `scrollTo(current)` on every selection change inside `currentChanged`; disabling it keeps the horizontal scroll position fixed where the user left it. Deliberate scroll-into-view paths are unaffected — re-select after manifest load and the post-scan auto-select still call `scrollTo()` explicitly (those are independent of the `autoScroll` property).
+- **Conditions / variants:** Trade-off — drag-selecting near a viewport edge no longer auto-scrolls the contents. Negligible for this fully-expanded `ExtendedSelection` tree. Only the main tree is affected; the Execute Action and Scan dialog trees construct their own `QTreeView` and keep Qt defaults.
+- **Related:** QA scenario [`qa/scenarios/s26_keyboard_navigation.py`](../qa/scenarios/s26_keyboard_navigation.py) exercises row selection on the main tree; unit invariant in [`tests/test_tree_controller.py`](../tests/test_tree_controller.py) (`TestSetupTreeProperties::test_autoscroll_disabled`).
+- **Last verified:** 2026-06-02
 
 ---
 

--- a/news/527.feature
+++ b/news/527.feature
@@ -1,0 +1,1 @@
+Stop the main result tree from auto-scrolling sideways to the clicked column on row selection, so the horizontal scroll position stays where you left it (#527).

--- a/tests/test_tree_controller.py
+++ b/tests/test_tree_controller.py
@@ -68,6 +68,21 @@ def _build(qapp, groups=None):
     return controller, tree.model()
 
 
+# ── setup_tree_properties ──────────────────────────────────────────────────
+
+
+class TestSetupTreeProperties:
+    def test_autoscroll_disabled(self, qapp):
+        """Clicking a row must not jerk the viewport to align the clicked
+        column. setup_tree_properties turns Qt's implicit auto-scroll off;
+        if this regresses the wide-table horizontal jump returns."""
+        from app.views.components.tree_controller import TreeController
+
+        tree = QTreeView()
+        TreeController(tree).setup_tree_properties()
+        assert tree.hasAutoScroll() is False
+
+
 # ── get_selected_items ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Disable Qt's default `autoScroll` on the main result tree so selecting a row no longer jerks the viewport sideways to "align" the clicked column into view.

## Why

`QAbstractItemView.autoScroll` (on by default) calls `scrollTo(current)` on every selection change inside `currentChanged`. On a horizontally-scrolled wide table, clicking a row whose cells extend past the viewport snapped the view sideways — disorienting during review. User reported the horizontal jump and asked to turn it off.

## How

One line in `TreeController.setup_tree_properties`: `self.tree.setAutoScroll(False)`.

- Only gates the **implicit** scroll. The deliberate `scrollTo()` calls (re-select after manifest load `main_window.py:958`, post-scan auto-select `main_window.py:603`) are independent of the `autoScroll` property and still scroll their target into view.
- **Trade-off:** drag-selecting near a viewport edge no longer auto-scrolls the contents — negligible for this fully-expanded `ExtendedSelection` tree.
- **Scope:** main tree only. The Execute Action and Scan dialog trees build their own `QTreeView` and keep Qt defaults.

## Tests / docs

- `TestSetupTreeProperties::test_autoscroll_disabled` locks the invariant (full `test_tree_controller.py` green, 28 passed).
- `docs/features.md` — new "Main window — row selection (no horizontal auto-scroll)" entry + index row.

[qa-not-needed: autoScroll is a single QTreeView property toggle whose invariant is locked deterministically by tests/test_tree_controller.py::TestSetupTreeProperties::test_autoscroll_disabled. A layer-3 driver would have to assert the viewport's horizontal scroll offset stays fixed after a click — UIA scroll-offset reads are flaky and no existing sNN scenario asserts scroll position, so a driver here would be padding, not coverage.]

🤖 Generated with [Claude Code](https://claude.com/claude-code)