### PR TITLE
fix(main-window): restore Open Manifest — add missing clear_preview proxy

### DIFF
--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -1084,6 +1084,17 @@ class UIUpdaterImpl:
         """Show groups summary (legacy)."""
         self.window.show_groups_summary(groups)
 
+    def clear_preview(self) -> None:
+        """Drop preview-pane content (#431).
+
+        Proxies ``MainWindow.clear_preview``. The ``UIUpdateCallback``
+        Protocol declares this and ``_on_manifest_loaded`` calls it, but
+        the proxy was missing here — so every Open-Manifest load hit an
+        AttributeError inside the worker's ``finished`` slot and aborted
+        the app. See test_probe_uiupdater_impl_proxies_every_protocol_method.
+        """
+        self.window.clear_preview()
+
 
 class TreeDataProviderImpl:
     """Implementation of TreeDataProvider protocol."""

--- a/news/528.bugfix
+++ b/news/528.bugfix
@@ -1,0 +1,1 @@
+Fix the app aborting on every Open Manifest load — restore the missing `UIUpdaterImpl.clear_preview` proxy so the post-load preview reset no longer raises inside the loader thread (#528).

--- a/tests/test_ui_probes.py
+++ b/tests/test_ui_probes.py
@@ -40,6 +40,7 @@ DIALOG_HANDLER_PATH = REPO / "app" / "views" / "handlers" / "dialog_handler.py"
 MENU_CONTROLLER_PATH = REPO / "app" / "views" / "components" / "menu_controller.py"
 ACTION_HANDLERS_PATH = REPO / "app" / "views" / "handlers" / "action_handlers.py"
 CONTEXT_MENU_PATH = REPO / "app" / "views" / "handlers" / "context_menu.py"
+FILE_OPERATIONS_PATH = REPO / "app" / "views" / "handlers" / "file_operations.py"
 MAIN_WINDOW_PATH = REPO / "app" / "views" / "main_window.py"
 SCANNER_DEDUP_PATH = REPO / "scanner" / "dedup.py"
 EN_YAML = REPO / "translations" / "en.yml"
@@ -248,6 +249,39 @@ def test_probe_action_handlers_impl_proxies_every_protocol_method():
     # can carry helper methods that aren't part of the Protocol surface.
     # If a stale proxy ever needs to be removed, that's a code-review
     # concern, not a structural invariant.
+
+
+def test_probe_uiupdater_impl_proxies_every_protocol_method():
+    """Every method on the ``UIUpdateCallback`` Protocol (the contract
+    ``FileOperationsHandler`` invokes against) MUST be present on
+    ``UIUpdaterImpl`` (the manual proxy bridge to MainWindow).
+
+    Catches: the same bridge-pattern hole as the ActionHandlers probe
+    above, but for the file-operations → MainWindow direction. #431 added
+    ``clear_preview`` to the Protocol, to ``MainWindow``, and to the
+    ``_on_manifest_loaded`` callsite — but forgot the proxy here. Because
+    the call fires from a QThread ``finished`` slot, the resulting
+    AttributeError aborted the whole app on every Open-Manifest load
+    rather than surfacing in a unit test (the handler tests pass a Mock
+    ui_updater, which auto-creates any attribute). This static probe is
+    the enforcement the advisory Protocol can't give us.
+    """
+    protocol_methods = _ast_class_method_names(
+        FILE_OPERATIONS_PATH, "UIUpdateCallback"
+    )
+    impl_methods = _ast_class_method_names(
+        MAIN_WINDOW_PATH, "UIUpdaterImpl"
+    )
+
+    missing = protocol_methods - impl_methods
+    assert not missing, (
+        f"UIUpdaterImpl is missing proxies for UIUpdateCallback "
+        f"Protocol methods: {sorted(missing)}. FileOperationsHandler "
+        f"calls these via self.ui_updater — a missing one raises "
+        f"AttributeError inside a QThread finished slot and aborts the "
+        f"app (manifest-load crash). Background: "
+        f"feedback_action_handlers_bridge in memory."
+    )
 
 
 def test_probe_manifest_dependent_menu_actions_are_gated():


### PR DESCRIPTION
## What

Add the `clear_preview` proxy to `UIUpdaterImpl` so loading a manifest no longer crashes the app.

## Why — this is a live crash on master

`#431` added `clear_preview` to the `UIUpdateCallback` Protocol, to `MainWindow`, and to the `_on_manifest_loaded` callsite — but never added the proxy to `UIUpdaterImpl`, the object actually wired as `FileOperationsHandler.ui_updater`. So **every Open-Manifest load** raised `AttributeError: 'UIUpdaterImpl' object has no attribute 'clear_preview'` inside the load worker's `finished` slot, which PySide6 turns into a process abort — the app dies the instant a manifest finishes loading.

```
File "app/views/handlers/file_operations.py", line 313, in _on_manifest_loaded
    self.ui_updater.clear_preview()
AttributeError: 'UIUpdaterImpl' object has no attribute 'clear_preview'
```

Why it shipped: handler unit tests inject a `Mock` ui_updater (auto-creates any attribute), and no qa scenario exercises the threaded `finished`-slot load path.

## How

- Add `UIUpdaterImpl.clear_preview` → proxies `self.window.clear_preview()`, mirroring the existing `refresh_tree` / `show_group_counts` / `show_groups_summary` proxies.
- Add `test_probe_uiupdater_impl_proxies_every_protocol_method` — a static AST probe mirroring the existing ActionHandlers bridge probe. **Verified red** without the fix (`MISSING pre-fix: ['clear_preview']`), green with it. Catches this whole class of bridge gap going forward, not just this one method.

Background: `feedback_action_handlers_bridge` — the manual proxy-bridge pattern silently no-ops (or here, crashes) when a Protocol method lacks its proxy. Same root cause as #175 / #182.

## Tests

`tests/test_ui_probes.py` — 14 passed (both bridge probes green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)