### PR TITLE
fix(prune-dialog): stop keep-all reentrance crash (stack overflow)

### DIFF
--- a/app/views/dialogs/singleton_prune_confirm_dialog.py
+++ b/app/views/dialogs/singleton_prune_confirm_dialog.py
@@ -163,9 +163,14 @@ class SingletonPruneConfirmDialog(QDialog):
         layout.addWidget(button_box)
 
         self._remove_btn.clicked.connect(self._on_remove)
-        self._keep_btn.clicked.connect(self._on_keep)
-        # Esc / window close → KEEP (the safe default, matching #182's
-        # CANCEL-on-close pattern). User must explicitly click Remove.
+        # The keep button routes through the dialog's reject() — the safe
+        # pattern locked_rows_confirm_dialog uses. reject() emits `rejected`,
+        # which fires `_on_keep` to record the verdict; that single wire ALSO
+        # covers Esc / window close (the safe default, #182's CANCEL-on-close
+        # pattern). `_on_keep` must NOT call done()/reject() itself — doing so
+        # re-emitted `rejected` → `_on_keep` → … unbounded reentrance → the
+        # keep-all stack-overflow crash.
+        self._keep_btn.clicked.connect(self.reject)
         self.rejected.connect(self._on_keep)
 
         self._keep_btn.setDefault(True)
@@ -176,12 +181,18 @@ class SingletonPruneConfirmDialog(QDialog):
         self.accept()
 
     def _on_keep(self) -> None:
+        # Invoked ONLY from the `rejected` signal (keep button RejectRole /
+        # Esc / window close), so the dialog is already being rejected — just
+        # record the verdict. Do NOT call done()/reject() again.
+        #
+        # The previous guard `if self.result() == 0: self.done(QDialog.Rejected)`
+        # was broken and crashed the app: `QDialog.Rejected == 0`, so the guard
+        # could never tell "still open" from "rejected", and re-calling
+        # `done(Rejected)` re-emitted `rejected` → `_on_keep` → `done` → …
+        # unbounded reentrance → C++ stack overflow / segfault when the user
+        # clicked "Keep all" (#544-followup).
         self._verdict = self.KEEP
         self._remember = self._remember_checkbox.isChecked()
-        # Only call done() if the dialog is still open (rejected signal
-        # can fire after explicit reject as well).
-        if self.result() == 0:
-            self.done(QDialog.Rejected)
 
     @property
     def verdict(self) -> int:

--- a/news/547.bugfix
+++ b/news/547.bugfix
@@ -1,0 +1,1 @@
+Fixed a crash when clicking "Keep all" in the prune-singletons confirmation dialog (the prompt shown after Remove from List collapses a group down to a single item). The keep button re-entered its own close handler without bound, overflowing the stack and taking the app down; it now closes cleanly and keeps the singletons as intended (#547).

--- a/tests/test_singleton_prune_confirm_dialog.py
+++ b/tests/test_singleton_prune_confirm_dialog.py
@@ -1,0 +1,82 @@
+"""Tests for SingletonPruneConfirmDialog — focused on the keep-all reentrance
+crash (#544-followup) plus the verdict resolution the caller relies on.
+
+The crash: clicking "Keep all" reentered unboundedly. The keep button has
+``QDialogButtonBox.RejectRole`` (so the button box routes its click through
+``reject() → rejected``), AND ``_on_keep`` was also wired to ``clicked`` AND
+called ``self.done(QDialog.Rejected)``. Because ``QDialog.Rejected == 0``, the
+guard ``if self.result() == 0`` could never tell "open" from "rejected", so
+``done(Rejected)`` re-emitted ``rejected`` → ``_on_keep`` → ``done`` → … until
+the C++ signal stack overflowed (segfault / 閃退). The fix: ``_on_keep`` is
+reached only via ``rejected`` and merely records the verdict — it never calls
+``done()`` again, and the redundant ``clicked`` wire is gone.
+"""
+from __future__ import annotations
+
+from app.views.dialogs.singleton_prune_confirm_dialog import (
+    PruneVerdict,
+    SingletonPruneConfirmDialog,
+)
+
+
+def test_keep_all_click_does_not_reenter(qapp):
+    """Regression: clicking 'Keep all' fires `rejected` exactly once (no
+    reentrant done() loop) and resolves to a keep-all verdict. Before the fix
+    this recursed 300+ deep → RecursionError / segfault."""
+    dlg = SingletonPruneConfirmDialog(None, count_plain=1, count_actioned=0)
+    rejected_emissions: list[int] = []
+    dlg.rejected.connect(lambda: rejected_emissions.append(1))
+
+    # Programmatic click fires the same cascade as a real click: the RejectRole
+    # button → button box → dialog.reject() → done(Rejected) → emit rejected.
+    dlg._keep_btn.click()
+
+    assert len(rejected_emissions) == 1, (
+        f"`rejected` emitted {len(rejected_emissions)}x — `_on_keep` re-called "
+        f"done() and reentered (the keep-all crash). Expected exactly 1."
+    )
+    assert dlg.to_prune_verdict() == PruneVerdict.keep_all()
+
+
+def test_keep_click_actually_closes_via_reject(qapp):
+    """The keep button must route through the dialog's reject() so the dialog
+    actually CLOSES (result == Rejected) with a keep-all verdict — guards the
+    failure mode where dropping the wire leaves the button connected to
+    nothing and the dialog never closes."""
+    from PySide6.QtWidgets import QDialog
+
+    dlg = SingletonPruneConfirmDialog(None, count_plain=1, count_actioned=0)
+    dlg._keep_btn.click()
+    assert dlg.result() == QDialog.Rejected
+    assert dlg.to_prune_verdict() == PruneVerdict.keep_all()
+
+
+def test_escape_window_close_resolves_to_keep_all(qapp):
+    """Esc / window-close → reject() → `rejected` → keep-all (the safe default,
+    #182 CANCEL-on-close pattern). Must also not reenter."""
+    dlg = SingletonPruneConfirmDialog(None, count_plain=3, count_actioned=2)
+    rejected_emissions: list[int] = []
+    dlg.rejected.connect(lambda: rejected_emissions.append(1))
+    dlg.reject()
+    assert len(rejected_emissions) == 1
+    v = dlg.to_prune_verdict()
+    assert v.prune_plain is False and v.prune_actioned is False
+
+
+def test_remove_click_resolves_to_prune_plain(qapp):
+    """Guard the unaffected path: clicking Remove (plain-only, no actioned
+    checkbox) prunes the plain bucket and leaves actioned untouched."""
+    dlg = SingletonPruneConfirmDialog(None, count_plain=2, count_actioned=0)
+    dlg._remove_btn.click()
+    v = dlg.to_prune_verdict()
+    assert v.prune_plain is True and v.prune_actioned is False
+
+
+def test_remove_with_actioned_optin(qapp):
+    """Mixed bucket: Remove with the actioned checkbox ticked prunes both."""
+    dlg = SingletonPruneConfirmDialog(None, count_plain=1, count_actioned=1)
+    assert dlg._actioned_checkbox is not None
+    dlg._actioned_checkbox.setChecked(True)
+    dlg._remove_btn.click()
+    v = dlg.to_prune_verdict()
+    assert v.prune_plain is True and v.prune_actioned is True


### PR DESCRIPTION
## What

Clicking **"Keep all"** in `SingletonPruneConfirmDialog` (the confirm shown when
a Remove-from-List collapses a group to a single item) crashed the app (閃退).

## Why

The keep path looped. `_on_keep` was wired to the `rejected` signal **and**
called `self.done(QDialog.Rejected)`, which re-emits `rejected` → `_on_keep` →
`done` → … unbounded reentrance → **C++ signal-stack overflow / segfault**. The
guard `if self.result() == 0` never broke the loop because **`QDialog.Rejected == 0`**
— it could not distinguish "still open" from "already rejected". Reproduced
headless: 333 reentrant `_on_keep`/`done` calls before Python's recursion limit.

(Also corrected a wrong assumption along the way: `QDialogButtonBox` does **not**
auto-route a RejectRole button to the dialog's `reject()` — its `rejected` signal
was never connected, so the explicit wiring was load-bearing.)

## How

Wire the keep button to the dialog's `reject()` (the safe pattern
`locked_rows_confirm_dialog` uses). `reject()` emits `rejected`, which fires
`_on_keep` **once** to record the verdict — `_on_keep` no longer calls
`done()`/`reject()` itself, and the redundant `_keep_btn.clicked → _on_keep`
wire is gone. The Remove path is untouched.

## Tests

- `tests/test_singleton_prune_confirm_dialog.py` (5 cases): keep-click closes via
  reject with **exactly one** `rejected` emission (no reentrance) + keep-all
  verdict; keep-click actually closes (`result == Rejected`); Esc → keep-all;
  Remove plain-only; Remove with actioned opt-in.
- **Live GUI validated:** `qa/scenarios/s61` Variant C clicks the real "Keep all"
  button and now passes (no crash) — it would crash on regression.
- Full suite green; per-file + global coverage gates pass.

[docs-not-needed: crash fix only — the dialog's keep-all/remove behaviour is unchanged and already documented in docs/features.md]
[qa-not-needed: the keep-all path is already exercised live by qa/scenarios/s61 Variant C (now passing), plus 5 new deterministic unit tests for the dialog wiring]
