### PR TITLE
fix(scanner): bound exif_queue + cancel-safe producer (#564)

### DIFF
--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -858,7 +858,13 @@ class ScanWorker(QThread):
                 except _queue.Empty:
                     break
 
-        exif_queue: _queue.Queue = _queue.Queue()
+        # #564 — bound the exif_queue so hash-stage producers can't grow it
+        # unboundedly in RAM while a slow exiftool consumer falls behind.
+        # Capacity = 2 full batches per consumer keeps the #450 hash/exif
+        # overlap intact (the producer never has to block under normal load)
+        # while capping RAM to a predictable ceiling.
+        _EXIF_QUEUE_MAXSIZE = 2 * chunk_size * self.exif_workers
+        exif_queue: _queue.Queue = _queue.Queue(maxsize=_EXIF_QUEUE_MAXSIZE)
         extracts: dict = {}
         exif_tracker = _StageTracker(STAGE_EXIFTOOL)
         exif_done = [0]
@@ -881,15 +887,17 @@ class ScanWorker(QThread):
             """Route one compute outcome into the shared dispatch state and
             return the ``HashResult`` to store (or ``None`` to skip).
 
-            #486-PR2 — extracted from ``_hash_one`` so both executor paths
-            share ONE routing implementation. The thread path runs this
-            inside the worker (via ``_hash_one``); the process path runs it
-            in the parent drain loop after the picklable
-            ``run_hash_for_record`` returns across the process boundary.
-            Both contexts are safe: ``skipped.append`` is GIL-atomic,
-            ``exif_queue`` is thread-safe, and the ``exif_total`` bump is
-            taken under ``exif_total_lock`` for the consumers' cross-thread
-            read.
+            #486-PR2 — extracted so both executor paths share ONE routing
+            implementation. Both the process path (parent drain loop) and
+            the thread path (``out_q`` drain loop) call this in the single
+            parent drain loop after the compute stage returns.
+            ``skipped.append`` is GIL-atomic, ``exif_queue`` is thread-safe,
+            and the ``exif_total`` bump is taken under ``exif_total_lock``
+            for the consumers' cross-thread read.
+
+            #564 — the put is cancel-safe: uses a cooperative bounded-put
+            loop so a slow exiftool consumer with a full queue doesn't
+            deadlock the producer on cancel.
             """
             if isinstance(outcome, HashFailure):
                 # Both raised exceptions and silent decode failures
@@ -904,7 +912,15 @@ class ScanWorker(QThread):
             # a skip-type record (the exiftool pass excludes "skip"
             # anyway pre-#450).
             if record.file_type != "skip":
-                exif_queue.put(outcome)
+                # #564 — cooperative bounded put: mirrors the _read_drain
+                # pattern so a full exif_queue (slow exiftool consumer) can't
+                # wedge the producer forever on cancel.
+                while not cancel_flag.is_set():
+                    try:
+                        exif_queue.put(outcome, timeout=0.05)
+                        break
+                    except _queue.Full:
+                        pass
                 with exif_total_lock:
                     exif_total[0] += 1
             return outcome
@@ -1063,6 +1079,11 @@ class ScanWorker(QThread):
                         # otherwise the join below waits out the whole batch
                         # and the abandoned consumer orphans its process.
                         _kill_exif_procs()
+                        # #564 — drain the bounded exif_queue so any producer
+                        # wedged in a cooperative put() unblocks and can exit
+                        # on the cancel_flag check (mirrors hash_in_q drain in
+                        # the thread branch).
+                        _drain_queue_nowait(exif_queue)
                         # Tell each consumer to stop — one sentinel per
                         # consumer so each gets exactly one ``None`` off the
                         # queue. With exiftool killed + the 0.5s get(timeout)
@@ -1240,6 +1261,11 @@ class ScanWorker(QThread):
                                 wait=False, cancel_futures=True
                             )
                             _kill_exif_procs()
+                            # #564 — drain the bounded exif_queue so any
+                            # producer wedged in a cooperative put() unblocks
+                            # and can exit on the cancel_flag check (mirrors
+                            # hash_in_q drain above).
+                            _drain_queue_nowait(exif_queue)
                             for _ in consumer_threads:
                                 exif_queue.put(None)
                             for t in consumer_threads:

--- a/news/575.bugfix
+++ b/news/575.bugfix
@@ -1,0 +1,1 @@
+Bound the exiftool queue and make its producer cancel-safe, capping scan-time RAM growth and closing a cancel-deadlock hazard on large scans. (#575)

--- a/tests/test_scan_worker.py
+++ b/tests/test_scan_worker.py
@@ -2355,3 +2355,82 @@ class TestPipelineIndexOrderDeterminism:
         assert len(rows) == len(records), (
             f"classify must produce one row per isolated record; got {len(rows)}"
         )
+
+
+# ---------------------------------------------------------------------------
+# #564 gate tests — bounded exif_queue cancel safety
+# ---------------------------------------------------------------------------
+
+
+class TestBoundedExifQueueCancelSafety:
+    """#564 — cancelling while the bounded exif_queue is full must not deadlock
+    the producer.
+
+    The pre-#564 bug: exif_queue was unbounded (queue.Queue()), so a slow
+    exiftool consumer never applied back-pressure. After bounding the queue, a
+    producer running _route_outcome's cooperative put loop could wedge forever
+    if cancel arrived while the queue was full AND no drain was called before
+    the sentinel puts. This class tests the cooperative-put escape path.
+    """
+
+    def test_bounded_exif_queue_cancel_does_not_deadlock(self):
+        """A bounded exif_queue full of items + cancel_flag set must allow the
+        producer thread to exit within 5 s — NOT stay stuck in put().
+
+        Failure mode: if the producer does a bare ``q.put(item)`` (blocking
+        forever) or the cooperative loop isn't checking cancel_flag, the
+        thread never exits — exactly the deadlock the #564 fix prevents.
+
+        This reproduces the exact bounded-put loop from ``_route_outcome``:
+            while not cancel_flag.is_set():
+                try:
+                    exif_queue.put(outcome, timeout=0.05)
+                    break
+                except queue.Full:
+                    pass
+        """
+        import queue
+        import threading
+        import time
+
+        MAXSIZE = 8
+        cancel_flag = threading.Event()
+        q: queue.Queue = queue.Queue(maxsize=MAXSIZE)
+
+        # Pre-fill the queue to capacity so the FIRST put() in the producer
+        # raises queue.Full — matching the real failure scenario where a slow
+        # exiftool consumer causes the queue to fill up completely.
+        for _ in range(MAXSIZE):
+            q.put(object())
+
+        def producer():
+            """Cooperative bounded put — matches the _route_outcome pattern."""
+            outcome = object()  # simulated HashResult (no bytes — just a ref)
+            while not cancel_flag.is_set():
+                try:
+                    q.put(outcome, timeout=0.05)
+                    break
+                except queue.Full:
+                    pass
+            # Falls through when cancel_flag is set (never breaks out of put).
+
+        t = threading.Thread(target=producer, daemon=True)
+        t.start()
+
+        # Let the producer hit the full queue and enter the cooperative retry.
+        time.sleep(0.1)
+        assert t.is_alive(), (
+            "producer thread must be blocked in the cooperative put loop before "
+            "cancel_flag is set — pre-fill wasn't sufficient"
+        )
+
+        # Trip the cancel — cooperative producer must wake and exit.
+        cancel_flag.set()
+
+        t.join(timeout=5)
+        assert not t.is_alive(), (
+            "producer thread still alive after cancel_flag set — deadlock! "
+            "The cooperative bounded-put loop must check cancel_flag to avoid "
+            "wedging on a full exif_queue (the #564 bug class). A bare "
+            "exif_queue.put(outcome) would hang here forever."
+        )


### PR DESCRIPTION
## What
`exif_queue` was an unbounded `queue.Queue()` — hash-stage producers never
blocked on a slow exiftool consumer, so the queue could grow without bound in
RAM during a large scan.

## Why
Two costs: unbounded RAM growth on large scans, and a latent cancel-deadlock
risk once the queue is bounded (a blocking producer `put()` on a full queue
wedges forever if consumers stop on cancel — the #492/#495/#507/#561 scar
class). This is the **settled-safe CORE** of #564. The other half of the
issue — *raising* the exif consumer count — is split out to **#574** because a
flat 2→4 raise reintroduces the exact HDD seek-thrash the #559 single-reader
cap fights; doing it safely needs net-new device-aware logic.

## How
- Bound `exif_queue` to `maxsize = 2 * chunk_size * exif_workers` (≥ 2 full
  batches per consumer — preserves the #450 hash/exif overlap, caps RAM at a
  predictable ceiling). `HashResult` verified to carry no raw image bytes, so
  the cap math holds.
- Make the single producer put **cooperative** (`put(timeout=0.05)` +
  `cancel_flag` recheck), cloning the established `_read_drain` shape.
- `_drain_queue_nowait(exif_queue)` on cancel in **both** pipeline branches,
  before the sentinel puts, so a producer wedged in the cooperative put
  unblocks (ordering: kill consumers → drain → sentinels).
- Left the happy-path post-HASH `join()` **unbounded** — a timeout there would
  silently truncate exif extraction and drop dates/GPS for the last batches.

Internal RAM/cancellation hardening — no user-visible behaviour change.

## Test
`TestBoundedExifQueueCancelSafety` — fills a bounded queue, wedges a producer
in the cooperative loop, sets `cancel_flag`, asserts the producer exits (the
real deadlock hazard). Mirrors the project-blessed `TestBoundedPipelineDeadlockSafety`
(#566) shape. Full `tests/test_scan_worker.py` green (58 passed).

Closes #564

[qa-not-needed: internal exif-queue RAM bounding + cancel-safety hardening; no user-visible flow change (no button/dialog/menu/status-bar behaviour); the one real hazard — cancel during a full bounded queue — is unit-covered by TestBoundedExifQueueCancelSafety]
