### PR TITLE
test(scanner): make device_key NAS resolution hermetic in tests (#565)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,3 +11,30 @@ def qapp():
     from PySide6.QtWidgets import QApplication
     app = QApplication.instance() or QApplication([])
     yield app
+
+
+@pytest.fixture(autouse=True)
+def _isolate_unc_resolution(monkeypatch):
+    """Keep ``device_key``'s NAS-server grouping (#565) deterministic in tests.
+
+    ``device_key`` memoises drive-letter→UNC-server in a module-level
+    ``_unc_cache`` and, by default, resolves via the real
+    ``WNetGetConnectionW``. On a dev machine where a test drive letter (e.g.
+    ``J:``) is a live NAS mapping, the real call leaks the actual server
+    (``\\\\LINXIAOYUN``) into the bucket key, and the memo persists across
+    tests — so a later test that mocks ``is_remote_drive`` only for ``"J:"``
+    sees a ``\\\\LINXIAOYUN`` key it doesn't recognise and the per-device
+    worker count regresses 8→4. CI never hit this (no mapped drives there),
+    so the suite passed in CI but failed on the dev machine in full-file runs.
+
+    Force the default resolver to a no-op and clear the cache around every
+    test, so grouping resolves to the bare drive letter — matching CI. Tests
+    that exercise the resolution logic itself inject their own resolver via
+    ``device_key(unc_resolver=...)`` and are unaffected by this patch.
+    """
+    import scanner.workers as _workers
+
+    _workers._unc_cache.clear()
+    monkeypatch.setattr(_workers, "_resolve_unc_via_win32", lambda letter: None)
+    yield
+    _workers._unc_cache.clear()


### PR DESCRIPTION
## What
An autouse `conftest.py` fixture clears `scanner.workers._unc_cache` and stubs
the default `_resolve_unc_via_win32` resolver to `None` around every test, so
`device_key`'s NAS-server grouping (#565) resolves deterministically to the bare
drive letter in tests — matching CI.

## Why
Post-#565, `device_key` resolves a remote drive letter to its UNC server via the
real `WNetGetConnectionW` and **memoises it in a module global**. On a dev
machine where `J:` is a live NAS mapping, the real server (`\LINXIAOYUN`)
leaked into the device bucket key, and the memo **persisted across tests**. So
`TestScanWorkerPerDeviceHashPools` (which mocks `is_remote_drive` only for
`"J:"`) saw the `\LINXIAOYUN` key go unrecognised and `J:` got **4 readers
instead of 8** — but only in full-file runs on a machine with `J:` mapped. CI
never hit it (no mapped drives), so the suite was green in CI and red locally.
The product is correct; the **tests weren't hermetic** (they reached real Win32
+ a leaky module cache).

## How
- `tests/conftest.py`: a function-scoped `autouse` fixture that, around every
  test, clears `_unc_cache` and monkeypatches `_resolve_unc_via_win32 → None`.
  This makes `device_key` resolve to the drive letter on any machine (CI parity)
  and prevents one test's resolution from polluting another.
- Tests that exercise the resolution logic itself inject their own resolver via
  `device_key(unc_resolver=...)` and are **unaffected** — they override the
  module default.

Verified: the two previously-failing `TestScanWorkerPerDeviceHashPools` tests
now pass in full-file runs on a machine with `J:` mapped, and
`tests/test_scanner_workers.py` resolution tests still pass.

Follow-up to #565 (#576); test-infrastructure only, no product change.

[skip-news: test-only isolation fixture; no user-facing or API change]
