### PR TITLE
feat(scanner): wire in-pipeline read-knee ramp into scan worker (#551 Phase 2)

### DIFF
--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -417,6 +417,13 @@ class ScanWorker(QThread):
     # right after calibration (before the long hash pass) so the measurement
     # survives even if the user cancels the scan.
     hash_pool_measured = Signal(dict)
+    # #551 Phase 2 — emitted once per device after its read-knee ramp freezes
+    # with a clean (sole-ramping) measurement, carrying ReadKneeRamp.summary()
+    # augmented with the device_key. The dialog (#551 Phase 3) persists it via
+    # scanner.autotune.store_read_knee keyed by device_key, so the next scan of
+    # that device starts at the cached knee with no ramp. No persistence slot is
+    # wired in this PR — the signal exists and fires; the dialog connects it next.
+    read_knee_measured = Signal(dict)
 
     def __init__(
         self,
@@ -434,6 +441,8 @@ class ScanWorker(QThread):
         hash_pool_rates: dict | None = None,
         auto_select_enabled: bool = False,
         auto_select_aggressive_delete: bool = False,
+        autotune_read_knee: bool = False,
+        autotune_knees: dict | None = None,
     ) -> None:
         super().__init__()
         self.sources = {k: Path(v) for k, v in sources.items() if v.strip()}
@@ -490,6 +499,19 @@ class ScanWorker(QThread):
         # classify() uses the module default (thread/process scans, or auto
         # scans whose cached rates predate the grouping micro-rates).
         self._calibrated_bktree_floor: int | None = None
+        # #551 Phase 2 — in-pipeline read-knee ramp, DEFAULT-OFF. When False the
+        # thread branch builds reader pools at the static hash_workers_for_root
+        # count exactly as before (byte-identical path). When True, each device's
+        # reader pool is still sized at that static MAX but a per-device Semaphore
+        # caps active reads, ramped 1→2→4→8 to a measured files/s knee (or started
+        # at a cached knee). Stays default-off until the first-scan ramp tax is
+        # bounded on a mis-fit device (#551 Phase 4 flips the default).
+        self._autotune_read_knee = autotune_read_knee
+        # Pre-cached per-device knees {device_key: {"knee": int, "recipe": str}}
+        # read from scan.read_knee_cache by the dialog (#551 Phase 3). A valid
+        # entry skips the ramp for that device — its Semaphore starts at the
+        # cached knee. Empty by default; ignored unless _autotune_read_knee.
+        self.autotune_knees = autotune_knees or {}
 
     def run(self) -> None:
         try:
@@ -686,6 +708,12 @@ class ScanWorker(QThread):
         from scanner.manifest import write_manifest, print_summary
         from scanner.scoring import apply_scoring_to_rows
         from scanner.workers import device_key, hash_workers_for_root
+        from scanner.autotune import (
+            READ_KNEE_LADDER,
+            ReadKneeRamp,
+            _RAMP_FILES_PER_LEVEL,
+            _valid_read_knee,
+        )
         import io
         from contextlib import redirect_stdout
 
@@ -1145,6 +1173,40 @@ class ScanWorker(QThread):
             device_workers = {
                 dev: hash_workers_for_root(dev) for dev in device_records
             }
+            # #551 Phase 2 — read-knee ramp setup (default-OFF). reader pools are
+            # ALWAYS sized at device_workers[dev] (the static MAX); the ramp only
+            # caps *active* reads via a per-device Semaphore. When the flag is off
+            # read_permits stays None and the reader path below is byte-identical
+            # to the pre-#551 thread branch. Per device, on the flag-on path:
+            #   • valid cached knee  → Semaphore(knee), no ramp (lifetime cache hit)
+            #   • HDD (MAX 1) / too few image files → Semaphore(MAX), no ramp
+            #   • otherwise          → Semaphore(1) + a ReadKneeRamp that widens to MAX
+            read_permits: "dict | None" = None
+            ramps: dict = {}
+            _last_permits: dict = {}
+            _knee_emitted: set = set()
+            if self._autotune_read_knee:
+                read_permits = {}
+                for dev in device_records:
+                    max_c = device_workers[dev]
+                    cached = self.autotune_knees.get(dev)
+                    if _valid_read_knee(cached):
+                        read_permits[dev] = threading.Semaphore(cached["knee"])
+                        continue
+                    ladder = [c for c in READ_KNEE_LADDER if c <= max_c]
+                    eligible = sum(
+                        1
+                        for _i, _r in device_records[dev]
+                        if _r.file_type not in ("mp4", "mov", "gif", "skip")
+                    )
+                    if max_c <= 1 or eligible < len(ladder) * _RAMP_FILES_PER_LEVEL:
+                        # Single-rung HDD, or a scan too short to fill the ladder
+                        # without noise → run at the static MAX, no ramp.
+                        read_permits[dev] = threading.Semaphore(max_c)
+                        continue
+                    read_permits[dev] = threading.Semaphore(1)
+                    ramps[dev] = ReadKneeRamp(max_c)
+                    _last_permits[dev] = 1
             self._emit(
                 f"Hashing {len(records):,} files across"
                 f" {len(device_records)} device(s): "
@@ -1177,25 +1239,96 @@ class ScanWorker(QThread):
             # back to the parent drain loop.
             out_q: _queue.Queue = _queue.Queue()
 
+            def _gated_read(dev, idx, r):
+                """#551 Phase 2 — reader worker wrapped with the per-device permit.
+
+                Cooperative acquire (mirrors the #570 compute_inflight loop): block
+                on the device's Semaphore but wake on cancel within 50 ms. The
+                ``acquired`` guard means a cancel-before-acquire path takes NO
+                release (releasing an un-acquired permit would silently raise the
+                active-read cap). The permit is released in a ``finally`` on ANY
+                read_for_record return (bytes / None / ReadFailure) — without that
+                release a Semaphore that only ever decreases would deadlock on the
+                first read at concurrency 1.
+
+                Returns ``(read_result, dev, level_tag, t_end)`` where read_result is
+                the ``(idx, record, data)`` tuple _compute_dispatch expects (or None
+                when cancelled before acquiring). ``level_tag`` is the permit budget
+                captured at acquire time — the concurrency the read ran AT — for a
+                ramping device, else None.
+                """
+                acquired = False
+                while not cancel_flag.is_set():
+                    if read_permits[dev].acquire(timeout=0.05):
+                        acquired = True
+                        break
+                if not acquired:
+                    return None, dev, None, None
+                ramp = ramps.get(dev)
+                level_tag = ramp.current_permits() if ramp is not None else None
+                try:
+                    read_result = read_for_record(idx, r)
+                finally:
+                    read_permits[dev].release()
+                return read_result, dev, level_tag, time.monotonic()
+
             def _read_drain() -> None:
                 """Drive read futures into hash_in_q; put a None sentinel when done."""
+                gated = read_permits is not None
                 reader_futures = []
                 for dev, items in device_records.items():
                     for _idx, _r in items:
-                        reader_futures.append(
-                            reader_pools[dev].submit(read_for_record, _idx, _r)
-                        )
+                        if gated:
+                            reader_futures.append(
+                                reader_pools[dev].submit(_gated_read, dev, _idx, _r)
+                            )
+                        else:
+                            reader_futures.append(
+                                reader_pools[dev].submit(read_for_record, _idx, _r)
+                            )
                 for fut in as_completed(reader_futures):
                     if cancel_flag.is_set():
                         break
                     try:
-                        # Cooperative bounded put: retry with a short timeout so
-                        # a cancel_flag check doesn't leave us stuck forever when
+                        if gated:
+                            read_result, _dev, level_tag, t_end = fut.result()
+                            if read_result is None:
+                                continue  # cancelled before this read acquired
+                            ramp = ramps.get(_dev)
+                            if ramp is not None:
+                                _data = read_result[2]
+                                _nbytes = len(_data) if isinstance(_data, bytes) else 0
+                                ramp.record(_nbytes, t_end, level_tag=level_tag)
+                                _new = ramp.advance_if_level_done()
+                                if _new > _last_permits[_dev]:
+                                    # Widen the cap: hand out the delta permits the
+                                    # level-close raised the budget by (monotone — we
+                                    # never narrow a live Semaphore, see #551 Open
+                                    # risk 7).
+                                    read_permits[_dev].release(_new - _last_permits[_dev])
+                                    _last_permits[_dev] = _new
+                                if (not ramp.is_ramping()) and _dev not in _knee_emitted:
+                                    _knee_emitted.add(_dev)
+                                    # Knee-acceptance gate: only a sole-ramping
+                                    # device's measurement is clean enough to cache.
+                                    # len(ramps)==1 is exactly "sole actively-ramping"
+                                    # for the dominant topologies (single device;
+                                    # HDD+NAS where the HDD never ramps). The monotone
+                                    # condition is implied by the gain rule, which only
+                                    # freezes after strictly-rising rungs.
+                                    if len(ramps) == 1 and ramp.knee() is not None:
+                                        _summary = ramp.summary()
+                                        _summary["device"] = _dev
+                                        _summary["sole_ramping"] = True
+                                        self.read_knee_measured.emit(_summary)
+                        else:
+                            read_result = fut.result()
+                        # Cooperative bounded put: retry with a short timeout so a
+                        # cancel_flag check doesn't leave us stuck forever when
                         # compute is stopped and the queue is full.
-                        result = fut.result()
                         while not cancel_flag.is_set():
                             try:
-                                hash_in_q.put(result, timeout=0.05)
+                                hash_in_q.put(read_result, timeout=0.05)
                                 break
                             except _queue.Full:
                                 pass

--- a/news/580.feature
+++ b/news/580.feature
@@ -1,0 +1,1 @@
+Wire the #551 in-pipeline read-knee ramp into the scan worker (Phase 2): a per-device semaphore caps active reads and ramps to a measured files/s knee, behind a default-off setting with no user-facing surface yet. (#580)

--- a/scanner/autotune.py
+++ b/scanner/autotune.py
@@ -312,3 +312,45 @@ class ReadKneeRamp:
         self._level_ts = []
         self._level_tmin = float("inf")
         self._level_tmax = float("-inf")
+
+
+# -- read-knee cache (keyed per device_key alone) --------------------------
+#
+# The read knee is a DEVICE property (SMB channel count / RTT for a NAS, queue
+# depth for an SSD), not a property of which folders are scanned. So the cache
+# is keyed by device_key ALONE plus AUTOTUNE_RECIPE_VERSION — NOT by a
+# source-path fingerprint — so a knee learned scanning one library is reused for
+# every later scan of any library on the same physical device (#551 Phase 2).
+
+
+def store_read_knee(settings, device_key: str, knee: int) -> None:
+    """Persist a measured read-knee into ``scan.read_knee_cache``.
+
+    Kept a plain function (not a dialog method) so the round-trip is
+    unit-testable against a real ``JsonSettings`` without a Qt dialog —
+    ``settings`` is any object exposing ``get``/``set``/``save`` (mirrors
+    ``store_hash_pool_rates``). Each entry stamps the recipe version so a probe
+    algorithm change invalidates every cached knee.
+    """
+    cache = settings.get("scan.read_knee_cache", {}) or {}
+    cache[device_key] = {"knee": int(knee), "recipe": AUTOTUNE_RECIPE_VERSION}
+    settings.set("scan.read_knee_cache", cache)
+    settings.save()
+
+
+def _valid_read_knee(entry) -> bool:
+    """True iff ``entry`` is a usable cached read-knee for the CURRENT recipe.
+
+    ``settings.json`` is hand-editable and the recipe can change between
+    releases, so a corrupt / partial / stale-recipe entry must be a cache MISS
+    (re-probe), never a crash — boundary validation per the project's
+    input-at-boundaries rule. ``bool`` is rejected even though it is an ``int``
+    subclass, so a hand-edited ``true`` is not mistaken for a knee of 1.
+    """
+    return (
+        isinstance(entry, dict)
+        and isinstance(entry.get("knee"), int)
+        and not isinstance(entry.get("knee"), bool)
+        and entry.get("knee") > 0
+        and entry.get("recipe") == AUTOTUNE_RECIPE_VERSION
+    )

--- a/tests/test_autotune.py
+++ b/tests/test_autotune.py
@@ -284,3 +284,74 @@ class TestReadKneeRampRobustness:
         assert ramp.advance_if_level_done() == 1
         assert ramp.knee() == 1
         assert ramp.summary()["levels"] == {}
+
+
+class TestReadKneeCache:
+    """store_read_knee / _valid_read_knee — the device_key-keyed lifetime cache."""
+
+    def test_store_read_knee_round_trips_through_settings(self, tmp_path):
+        # Real JsonSettings round-trip (no Qt) — a knee written under a device_key
+        # survives write+reload so the next scan of that device reads it back.
+        import json
+
+        from infrastructure.settings import JsonSettings
+        from scanner.autotune import AUTOTUNE_RECIPE_VERSION, store_read_knee
+
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text(json.dumps({"sources": {}}), encoding="utf-8")
+        settings = JsonSettings(settings_path)
+
+        store_read_knee(settings, r"\\LINXIAOYUN", 2)
+
+        entry = settings.get("scan.read_knee_cache")[r"\\LINXIAOYUN"]
+        assert entry == {"knee": 2, "recipe": AUTOTUNE_RECIPE_VERSION}
+        reloaded = JsonSettings(settings_path)  # next session reads from disk
+        assert reloaded.get("scan.read_knee_cache")[r"\\LINXIAOYUN"]["knee"] == 2
+
+    def test_store_read_knee_is_per_device_not_per_source_set(self, tmp_path):
+        # The whole point of dropping the source-path fingerprint: two devices'
+        # knees coexist under their own keys, and re-measuring one device updates
+        # it in place without disturbing the other — independent of which folders
+        # were scanned to produce them (no fingerprint in the key).
+        import json
+
+        from infrastructure.settings import JsonSettings
+        from scanner.autotune import store_read_knee
+
+        settings_path = tmp_path / "settings.json"
+        settings_path.write_text(json.dumps({}), encoding="utf-8")
+        settings = JsonSettings(settings_path)
+
+        store_read_knee(settings, r"\\NAS", 2)
+        store_read_knee(settings, "D:", 1)
+        store_read_knee(settings, r"\\NAS", 4)  # re-measured on a later, different scan
+
+        cache = settings.get("scan.read_knee_cache")
+        assert cache[r"\\NAS"]["knee"] == 4
+        assert cache["D:"]["knee"] == 1
+
+    def test_valid_read_knee_accepts_current_recipe(self):
+        from scanner.autotune import AUTOTUNE_RECIPE_VERSION, _valid_read_knee
+
+        assert _valid_read_knee({"knee": 2, "recipe": AUTOTUNE_RECIPE_VERSION})
+
+    def test_valid_read_knee_rejects_stale_recipe(self):
+        # A knee measured under an older probe algorithm must be re-probed — this
+        # is the ONLY invalidation lever now the source-path fingerprint is gone.
+        from scanner.autotune import _valid_read_knee
+
+        assert not _valid_read_knee({"knee": 2, "recipe": "999-old"})
+
+    def test_valid_read_knee_rejects_malformed_entries(self):
+        # Hand-editable settings.json → a corrupt/partial entry is a cache miss,
+        # never a crash. bool is rejected though it's an int subclass; a
+        # non-positive knee is rejected (a stalled-device 0 is not a real knee).
+        from scanner.autotune import AUTOTUNE_RECIPE_VERSION as V
+        from scanner.autotune import _valid_read_knee
+
+        assert not _valid_read_knee(None)
+        assert not _valid_read_knee({"recipe": V})              # no knee
+        assert not _valid_read_knee({"knee": 2})                # no recipe
+        assert not _valid_read_knee({"knee": "x", "recipe": V})  # non-int knee
+        assert not _valid_read_knee({"knee": True, "recipe": V})  # bool, not a knee
+        assert not _valid_read_knee({"knee": 0, "recipe": V})    # non-positive

--- a/tests/test_scan_worker.py
+++ b/tests/test_scan_worker.py
@@ -2434,3 +2434,296 @@ class TestBoundedExifQueueCancelSafety:
             "wedging on a full exif_queue (the #564 bug class). A bare "
             "exif_queue.put(outcome) would hang here forever."
         )
+
+
+class TestScanWorkerReadKneeRamp:
+    """#551 Phase 2 — the in-pipeline read-knee ramp wiring (thread branch).
+
+    Default-OFF: when ``autotune_read_knee`` is unset the reader path is
+    byte-identical to the pre-#551 thread branch (guarded by the existing
+    ``TestScanWorkerPerDeviceHashPools`` tests). These tests drive the flag-ON
+    path with synthetic records. The ramp's own knee math is unit-tested in
+    ``tests/test_autotune.py``; here we verify the *integration*: pools stay at
+    MAX, the per-device Semaphore is sized right, the cache path short-circuits,
+    the gated path completes without the GUARD permit-release deadlock and keeps
+    idx order, and the record→advance→widen→freeze→emit protocol is driven.
+    """
+
+    def _records(self, drive, n, *, file_type="jpeg"):
+        from scanner.walker import FileRecord
+
+        return [
+            FileRecord(
+                path=Path(rf"{drive}\img_{i}.jpg"),
+                source_label="src",
+                file_type=file_type,
+            )
+            for i in range(n)
+        ]
+
+    def _install(self, monkeypatch, records, *, remote_drive, seek_penalty=None,
+                 data=b"x" * 16):
+        """Synthetic pipeline reaching the thread branch; ``read_for_record``
+        returns real ``data`` bytes so a ramp sees ``nbytes > 0``."""
+        import scanner.dedup as _dedup
+        import scanner.hasher as _hasher
+        import scanner.walker as _walker
+        import scanner.workers as _workers
+        from scanner.dedup import HashResult
+
+        def fake_scan_sources(sources, **kwargs):
+            cb = kwargs.get("progress_callback")
+            if cb:
+                for _ in records:
+                    cb()
+            return list(records)
+
+        def fake_read(idx, record):
+            return idx, record, data
+
+        def fake_compute(idx, record, d):
+            return idx, HashResult(
+                record=record, sha256=f"sha-{idx}", phash=None, exif_date=None
+            )
+
+        captured = {"hash_results": None}
+
+        def fake_classify(hash_results, **kwargs):
+            captured["hash_results"] = list(hash_results)
+            return []
+
+        monkeypatch.setattr(_walker, "scan_sources", fake_scan_sources)
+        monkeypatch.setattr(_hasher, "read_for_record", fake_read)
+        monkeypatch.setattr(_hasher, "compute_from_bytes", fake_compute)
+        monkeypatch.setattr(_workers, "is_remote_drive", lambda root: remote_drive(root))
+        monkeypatch.setattr(
+            _workers, "disk_incurs_seek_penalty", seek_penalty or (lambda root: False)
+        )
+        monkeypatch.setattr(_dedup, "classify", fake_classify)
+        return captured
+
+    def _spy_thread_pools(self, monkeypatch):
+        import concurrent.futures as _cf
+
+        constructed: list[int] = []
+        real = _cf.ThreadPoolExecutor
+
+        class SpyThreadPool(real):
+            def __init__(self, *args, **kwargs):
+                constructed.append(kwargs.get("max_workers"))
+                super().__init__(*args, **kwargs)
+
+        monkeypatch.setattr(_cf, "ThreadPoolExecutor", SpyThreadPool)
+        return constructed
+
+    def _spy_semaphores(self, monkeypatch):
+        """Record the initial value of every threading.Semaphore constructed."""
+        import threading as _t
+
+        values: list[int] = []
+        real = _t.Semaphore
+
+        def spy(value=1):
+            values.append(value)
+            return real(value)
+
+        monkeypatch.setattr(_t, "Semaphore", spy)
+        return values
+
+    def _run_with_watchdog(self, worker, timeout=20):
+        """Run worker.run() in a thread so a permit-release deadlock regression
+        fails cleanly on timeout instead of hanging the whole suite."""
+        import threading
+
+        done = threading.Event()
+
+        def _go():
+            worker.run()
+            done.set()
+
+        threading.Thread(target=_go, daemon=True).start()
+        assert done.wait(timeout=timeout), (
+            "gated scan did not complete — _gated_read must release its permit in "
+            "a finally on every read, or the per-device Semaphore deadlocks"
+        )
+
+    def test_flag_on_keeps_reader_pools_at_static_max(self, qapp, tmp_path, monkeypatch):
+        # Flag ON must NOT shrink the reader pools — they stay sized at the static
+        # MAX (hash_workers_for_root); the ramp caps *active* reads via a Semaphore,
+        # not via pool size. Skip records → no ramp, but the gated path still runs.
+        import os as _os
+
+        from app.views.workers.scan_worker import ScanWorker
+
+        records = self._records("J:", 4, file_type="skip") + self._records(
+            "D:", 4, file_type="skip"
+        )
+        self._install(monkeypatch, records, remote_drive=lambda r: str(r).upper() == "J:")
+        constructed = self._spy_thread_pools(monkeypatch)
+
+        worker = ScanWorker(
+            sources={"src": str(tmp_path)},
+            output_path=str(tmp_path / "m.sqlite"),
+            recursive_map={"src": False},
+            workers=2,
+            autotune_read_knee=True,
+        )
+        worker.run()
+
+        cpu = _os.cpu_count() or 4
+        local = min(4, cpu)
+        # J: first (record 0) → reader pools [J=8, D=local] + compute [cpu].
+        assert constructed == [8, local, cpu], (
+            f"flag-on must keep reader pools at static MAX; got {constructed!r}"
+        )
+
+    def test_flag_off_builds_no_read_permit_semaphore(self, qapp, tmp_path, monkeypatch):
+        # Default-OFF: no per-device read Semaphore is constructed — only the #570
+        # compute_inflight(128). A read-permit for J: would be Semaphore(8).
+        from app.views.workers.scan_worker import ScanWorker
+
+        records = self._records("J:", 4, file_type="skip")
+        self._install(monkeypatch, records, remote_drive=lambda r: str(r).upper() == "J:")
+        sem_values = self._spy_semaphores(monkeypatch)
+
+        worker = ScanWorker(
+            sources={"src": str(tmp_path)},
+            output_path=str(tmp_path / "m.sqlite"),
+            recursive_map={"src": False},
+            workers=2,
+        )  # autotune_read_knee defaults False
+        worker.run()
+
+        assert 128 in sem_values, "compute_inflight(128) should still be built"
+        assert 8 not in sem_values, "flag-off must not build a per-device read Semaphore"
+
+    def test_cached_knee_starts_semaphore_at_knee(self, qapp, tmp_path, monkeypatch):
+        # Flag ON + a valid cached knee for the NAS → its reader Semaphore starts
+        # at the cached knee (2), skipping the ramp (no Semaphore(1), no MAX=8).
+        from app.views.workers.scan_worker import ScanWorker
+        from scanner.autotune import AUTOTUNE_RECIPE_VERSION
+
+        records = self._records("J:", 5)
+        self._install(monkeypatch, records, remote_drive=lambda r: str(r).upper() == "J:")
+        sem_values = self._spy_semaphores(monkeypatch)
+
+        worker = ScanWorker(
+            sources={"src": str(tmp_path)},
+            output_path=str(tmp_path / "m.sqlite"),
+            recursive_map={"src": False},
+            workers=2,
+            autotune_read_knee=True,
+            autotune_knees={"J:": {"knee": 2, "recipe": AUTOTUNE_RECIPE_VERSION}},
+        )
+        worker.run()
+
+        assert 2 in sem_values, "cached knee must start the NAS read Semaphore at 2"
+        assert 1 not in sem_values, "a cache hit must skip the ramp (no Semaphore(1))"
+
+    def test_gated_scan_completes_and_preserves_order(self, qapp, tmp_path, monkeypatch):
+        # GUARD deadlock guard + determinism. Flag ON, local device a spinning HDD
+        # → reader Semaphore is 1 (no ramp). _gated_read MUST release the permit in
+        # its finally on every read, or Semaphore(1) deadlocks on read #2. The scan
+        # must complete and hash_results must stay in original idx order.
+        from app.views.workers.scan_worker import ScanWorker
+
+        records = self._records("D:", 6)
+        captured = self._install(
+            monkeypatch,
+            records,
+            remote_drive=lambda r: False,
+            seek_penalty=lambda r: str(r).upper() == "D:",  # spinning HDD → Semaphore(1)
+        )
+
+        worker = ScanWorker(
+            sources={"src": str(tmp_path)},
+            output_path=str(tmp_path / "m.sqlite"),
+            recursive_map={"src": False},
+            workers=2,
+            autotune_read_knee=True,
+        )
+        self._run_with_watchdog(worker)
+
+        hrs = captured["hash_results"]
+        assert hrs is not None and len(hrs) == 6
+        assert [hr.sha256 for hr in hrs] == [f"sha-{i}" for i in range(6)], (
+            "idx-passthrough order must survive the per-device gating (determinism)"
+        )
+
+    def test_active_ramp_records_and_emits_on_sole_ramping_freeze(
+        self, qapp, tmp_path, monkeypatch
+    ):
+        # Drive the full ramp protocol deterministically via a fake ramp: the
+        # worker must record(nbytes>0, level_tag=acquire-budget), widen the
+        # Semaphore on a level close, and — for a SOLE-ramping device — reach the
+        # emit (augmenting summary() with device + sole_ramping) once it freezes.
+        import scanner.autotune as _at
+        from app.views.workers.scan_worker import ScanWorker
+
+        seen = {"records": []}
+
+        class _FakeRamp:
+            def __init__(self, max_c):
+                self._permits = 1
+                self._n = 0
+                self.summary_dict = {
+                    "ladder": [1, 2, 4, 8],
+                    "levels": {1: 100.0, 2: 110.0},
+                    "knee": 2,
+                    "current_permits": 2,
+                    "frozen": True,
+                }
+
+            def current_permits(self):
+                return self._permits
+
+            def record(self, nbytes, now, *, level_tag):
+                seen["records"].append((nbytes, level_tag))
+                self._n += 1
+
+            def advance_if_level_done(self):
+                if self._n >= 2:
+                    self._permits = 2  # widen after the first level closes
+                return self._permits
+
+            def is_ramping(self):
+                return self._n < 4  # freeze after 4 records
+
+            def knee(self):
+                return 2
+
+            def summary(self):
+                return self.summary_dict
+
+        fakes: list = []
+        real_init = _FakeRamp.__init__
+
+        def _capturing_init(self, max_c):
+            real_init(self, max_c)
+            fakes.append(self)
+
+        monkeypatch.setattr(_FakeRamp, "__init__", _capturing_init)
+        monkeypatch.setattr(_at, "ReadKneeRamp", _FakeRamp)
+        monkeypatch.setattr(_at, "_RAMP_FILES_PER_LEVEL", 2)  # gate: 4 rungs * 2 = 8
+
+        records = self._records("J:", 10)  # 10 image files > 8 gate → ramp on J:
+        self._install(monkeypatch, records, remote_drive=lambda r: str(r).upper() == "J:")
+
+        worker = ScanWorker(
+            sources={"src": str(tmp_path)},
+            output_path=str(tmp_path / "m.sqlite"),
+            recursive_map={"src": False},
+            workers=2,
+            autotune_read_knee=True,
+        )
+        self._run_with_watchdog(worker)
+
+        assert len(fakes) == 1, "exactly one ramp should be built (single NAS device)"
+        assert seen["records"], "ramp.record was never called on the gated path"
+        assert all(nb > 0 for nb, _tag in seen["records"]), "image reads carry nbytes>0"
+        assert all(tag in (1, 2) for _nb, tag in seen["records"]), (
+            "level_tag must be the live permit budget captured at acquire"
+        )
+        # Sole-ramping freeze → the worker reached the emit and augmented summary().
+        assert fakes[0].summary_dict.get("device") == "J:"
+        assert fakes[0].summary_dict.get("sole_ramping") is True


### PR DESCRIPTION
## What

Phase 2 (PR B) of #551's in-pipeline read-knee ramp — wires the **merged Phase-1 logic** (`knee_from_throughput` + `ReadKneeRamp`, from #579) into the #566 thread branch of `app/views/workers/scan_worker.py`, **behind a still-OFF setting**. Default-OFF → the reader path is byte-identical to today.

- **ctor:** `+autotune_read_knee` (default `False`) + an `autotune_knees` cache passthrough; `+read_knee_measured = Signal(dict)`.
- **injection** at the `device_workers` pick (after the #554 guard): reader pools stay sized at the static **MAX**; a per-device `threading.Semaphore` caps *active* reads —
  - valid cached knee → `Semaphore(knee)`, no ramp (lifetime cache hit);
  - HDD / short-scan → `Semaphore(MAX)`, no ramp;
  - otherwise → `Semaphore(1)` + a `ReadKneeRamp` that widens to the knee.
- **`_gated_read`:** cooperative acquire (wakes on cancel within 50 ms) + `acquired`-guard + a **per-read `finally`-release** (the GUARD deadlock fix — a Semaphore that only ever decreases deadlocks). Captures the acquire-time permit budget as the level tag.
- **`_read_drain` consumer** (single thread): records `(nbytes, t_end, level_tag)` into the ramp, widens the Semaphore by the level-close delta (never narrows live, see #551 Open risk 7), emits `read_knee_measured` for a sole-ramping freeze, then **strips the internal tuple back to `(idx, record, data)` before `hash_in_q.put`** so `_compute_dispatch`'s contract is unchanged. Cancel branch + `finally` **unchanged** (no new teardown surface).
- **`scanner/autotune.py`:** `+store_read_knee` / `_valid_read_knee`, keyed by `device_key` **alone** (+ recipe stamp) — a knee learned on one library is reused for every later scan of any library on that device.

No Scan Dialog setting / UI toggle and no `s66` determinism scenario — those are **Phase 3**, which is also where the dev-rig manual checkpoint runs (the flag can't be enabled from the UI until then).

## Why

#551 replaces the static reader-count guess (`hash_workers_for_root`: NAS→8 / HDD→1 / else `min(4,cpu)`) with an in-situ measurement. Phase 1 (#579) landed the pure decision layer; this PR is the integration glue that makes it run inside the real pipeline — kept default-OFF so it can't regress the common path while the first-scan ramp tax is bounded (the Phase 4 default-ON flip is gated on that).

## How

- The ramp caps *active* reads via the Semaphore; pool **sizes** are untouched (still per-device MAX), so a flag-off scan is byte-identical and a flag-on scan never over-subscribes during measurement.
- Determinism is unaffected: `idx` is threaded through `_gated_read` → `_read_drain` → `hash_in_q` → `_compute_dispatch` → `hash_results[idx]` exactly as before (the #526/#538 lex-min `group_id` invariant).
- Tests (real-bug only): `test_autotune.py` — cache round-trip, per-device (not per-source-set) keying, stale-recipe + malformed rejection. `test_scan_worker.py::TestScanWorkerReadKneeRamp` — flag-on keeps pools at MAX, flag-off builds no read permit, cached knee starts the Semaphore at the knee, gated scan completes in idx order without the permit deadlock (watchdog), and the record→widen→freeze→emit protocol via a deterministic fake ramp. `autotune.py` 100% per-file, `scan_worker.py` 90%, full local suite green.

Refs #551 (Phase 2 of 4 — does not close the ticket; the default-ON flip is Phase 4).

[qa-not-needed: default-off internal pipeline tuning with no user-facing surface until Phase 3; the determinism qa scenario (s66) lands with the Phase 3 dialog wiring]
[docs-not-needed: default-off internal ramp wiring, no user-visible behaviour until the Phase 3 dialog toggle; covered at the test layer]
