### PR TITLE
fix(scanner): decode RAW from in-memory bytes via imread(BytesIO) (#591)

### DIFF
--- a/docs/audits/scan-591-raw-read-adversarial-review-2026-06-06.md
+++ b/docs/audits/scan-591-raw-read-adversarial-review-2026-06-06.md
@@ -1,0 +1,88 @@
+# #591 RAW in-memory read — adversarial-review decision record (2026-06-06)
+
+**Status:** CONVERGED (0 unrebutted load-bearing objections). Root cause + best
+solution verified against ground truth. Implemented in this PR.
+
+**Method:** [`adversarial-review`](../../.claude/skills/adversarial-review/SKILL.md)
+— two independent peers (Opus + Sonnet, with Bash + the real DNG files) attacked
+the *candidate fix*, round 1 blind, round 2 cross-attack; LEAD judged each
+objection on real runs. Transcript: workflow `wf_854795cb-a5d`.
+
+---
+
+## The artifact
+
+The proposed fix for #591: on rawpy 0.26.1 the module-level `rawpy.open_buffer`
+does not exist, so the RAW in-memory decode path in `scanner/hasher.py` dead-ends
+on `AttributeError` and falls back to `rawpy.imread(str(path))` — re-reading the
+file from disk (3 touches per RAW). Candidate: replace the dead `open_buffer(data)`
+calls with `rawpy.imread(io.BytesIO(data))` (rawpy's `imread` accepts a file
+object), reusing the bytes already read for SHA-256.
+
+## The reframe (the debate's main result)
+
+**#591 is NOT a performance fix.** The ticket's "RAW read 3× over SMB → slower
+scans" premise is largely false:
+
+- SHA-256 **requires** the full bytes, so `read_bytes()` always runs first
+  (`hasher.py`) — which **warms the OS/SMB page cache**. The two redundant
+  `imread(path)` re-reads therefore hit warm cache (~1–6 ms), **not the wire**.
+- Measured (both peers + LEAD): at matched cache state `imread(path)` ≈
+  `imread(BytesIO)` within ~1–17 ms; a cold first-touch costs 0.26–1.1 s over SMB
+  but `read_bytes` absorbs it. The headline "0.677s vs 0.392s" was a
+  measurement-order/cache confound (whichever runs second wins).
+
+So this is a **correctness + dead-code + false-docstring** fix at `priority: low`,
+with a small NAS side-benefit — not a throughput win.
+
+## Verified findings (LEAD re-ran each load-bearing claim)
+
+- **Bug real:** `hasattr(rawpy, "open_buffer") == False`; the in-memory path
+  returns None live and the code silently re-reads from disk.
+- **Fix correct:** `imread(io.BytesIO(data))` yields a **bit-identical phash**
+  (and sensor dims) vs `imread(path)` on both the **thumbnail** path and the
+  **postprocess** path (pixel-exact, `np.array_equal`) across multiple DNGs →
+  **no `HASH_RECIPE_VERSION` bump**, no grouping drift.
+- **#75 preserved:** a non-camera TIFF raises `LibRawFileUnsupportedError`
+  (a `LibRawError` subclass) on the BytesIO path too → caught → skips, not crash.
+- **#587 RAM-neutral (refuted scare):** `io.BytesIO(data)` over immutable bytes
+  does **not** copy (`getvalue() is data`, +0 MB heap, object is 80 bytes), so the
+  byte-budget's `len(data)` accounting is unaffected. (Round-1 "3× transient RAM"
+  objection refuted in round 2 + by LEAD.)
+- **postprocess colour-drift (refuted scare):** decoded RGB byte-for-byte
+  identical between path and BytesIO.
+
+## Implementation constraints the fix respects
+
+- **Fresh `io.BytesIO(data)` per call site** — a reused/non-zero-position buffer
+  raises `LibRawIOError` (a `LibRawError` subclass) and would silently degrade to
+  a disk re-read. Both sites (`_load_raw_preview_from_bytes` and the dims branch
+  of `_hashes_from_data`) construct a fresh buffer.
+- **Literal `io.BytesIO(data)`, never `imread(data)`** — passing raw `bytes`
+  raises a `SystemError` (an `Exception` subclass → caught by the broad handler →
+  a loud per-RAW `HashFailure`, not silent). The new test guards this.
+- **Single-read claim scoped to valid camera RAW** — non-camera TIFFs routed to
+  `raw` still hit the `_load_raw_preview(path)` fallback, which is what preserves
+  #75 skip-not-crash.
+
+## Decision
+
+Ship the **simple per-site substitution**; **decline the "collapse two opens into
+one" refactor** — it buys ~0 measured wall-time and adds a #187 dims-source
+landmine (the test DNGs cannot distinguish `raw.sizes` from thumbnail dims) plus
+the seek/reuse hazard. Alternatives (A) upgrade rawpy (gated, phash-drift risk)
+and (B) `imread(path)` for both (still a disk re-read) are inferior.
+
+**Test gap closed:** the existing RAW tests mock `rawpy` entirely, so the
+in-memory path shipped untested (that is *why* the dead-end slipped through). This
+PR adds a real, non-mocked test driving `rawpy.imread(io.BytesIO(data))` on a
+non-camera TIFF (asserts SHA-only / no crash) — verified to fail on the
+`imread(data)` typo.
+
+## Convergence gate
+
+Objections raised: **14** · load-bearing: **11** · unrebutted: **0** ⇒ converged.
+Independence: Opus vs Sonnet. Refuted: the 3×-RAM claim and the postprocess
+colour-drift fear. Residual (low, non-blocking): cross-format phash identity
+beyond DNG (.arw/.cr2/.nef untestable here) and a true no-thumbnail postprocess
+flow — mechanism (same LibRaw, identical bytes) makes drift very unlikely.

--- a/news/593.bugfix
+++ b/news/593.bugfix
@@ -1,0 +1,1 @@
+Fix RAW/DNG files being needlessly re-read from disk during hashing (rawpy 0.26.1 had dropped the in-memory `open_buffer` API the code relied on); they are now decoded directly from the bytes already read for the checksum (#591).

--- a/scanner/hasher.py
+++ b/scanner/hasher.py
@@ -6,13 +6,22 @@ Memory-footprint audit (#453)
 The hashing path holds the entire file in Python heap for image
 formats (JPEG / PNG / HEIC / WebP / RAW) because all three downstream
 operations — ``hashlib.sha256``, ``PIL.Image.open`` and
-``rawpy.open_buffer`` — want a ``bytes`` buffer. This is intentional:
-the single ``path.read_bytes()`` in ``compute_hashes`` was the #446
-fix that eliminated a double-read of every image and roughly halved
-NAS scan time. Backing it out for RAW (e.g. mmap the SHA pass,
+``rawpy.imread(io.BytesIO(...))`` — want a ``bytes`` buffer. This is
+intentional: the single ``path.read_bytes()`` in ``compute_hashes`` was
+the #446 fix that eliminated a double-read of every image and roughly
+halved NAS scan time. Backing it out for RAW (e.g. mmap the SHA pass,
 re-read for decode) would regress #446's gain — verified during the
 #453 audit: ``rawpy`` has no zero-copy decode path and a fresh
 ``bytes(mm)`` materialisation costs the same RAM as ``read_bytes()``.
+
+#591: the in-memory RAW path decodes those bytes via
+``rawpy.imread(io.BytesIO(data))`` — rawpy 0.26.1 dropped the
+module-level ``rawpy.open_buffer`` the older code called, so that call
+dead-ended on ``AttributeError`` and silently re-read the file from disk
+(3 touches per RAW). The single-read guarantee therefore holds for valid
+camera RAW; a non-camera TIFF routed to the ``raw`` branch (#75) still
+falls back to a path re-read in ``_load_raw_preview`` so it skips
+cleanly rather than crashing.
 
 The video path (``mp4`` / ``mov``) already streams via 64 KB chunks
 in ``compute_sha256`` — peak heap is ~64 KB regardless of file size.
@@ -128,13 +137,17 @@ def _hashes_from_data(
     if file_type == "raw":
         img = _load_raw_preview_from_bytes(data)
         if img is None:
-            # rawpy.open_buffer not available in this version; re-use path-based loader.
+            # In-memory decode failed (genuine LibRaw error / non-camera TIFF
+            # routed to 'raw', #75) — fall back to the path-based loader so the
+            # file still skips cleanly.
             img = _load_raw_preview(path)
         # True sensor dimensions come from rawpy metadata, not the embedded thumbnail.
         # Thumbnails are typically low-res previews (e.g. 1024×768 for a 12 MP DNG).
         if _RAWPY_AVAILABLE:
             try:
-                with rawpy.open_buffer(data) as raw:
+                # #591 — decode the already-read bytes via a fresh io.BytesIO
+                # (rawpy 0.26.1 has no module-level open_buffer); no disk re-read.
+                with rawpy.imread(io.BytesIO(data)) as raw:
                     px_w, px_h = raw.sizes.width, raw.sizes.height
             except (OSError, ValueError, AttributeError, rawpy.LibRawError):
                 try:
@@ -439,15 +452,24 @@ def _load_raw_preview(path: Path) -> Optional[Image.Image]:
 
 
 def _load_raw_preview_from_bytes(data: bytes) -> Optional[Image.Image]:
-    """Load a PIL Image from RAW bytes using rawpy.open_buffer (no second file read).
+    """Load a PIL Image from RAW bytes via ``rawpy.imread(io.BytesIO(data))`` (no second file read).
 
-    Returns None if rawpy.open_buffer is unavailable (older rawpy versions);
-    the caller falls back to _load_raw_preview() in that case.
+    #591 — feeds the already-read bytes straight to ``rawpy.imread`` through a
+    fresh ``io.BytesIO`` (a file-like object, which ``imread`` accepts). This
+    replaces the dead ``rawpy.open_buffer`` call: rawpy 0.26.1 has no
+    module-level ``open_buffer``, so the old code raised ``AttributeError`` and
+    the caller silently re-read the file from disk. Decode is bit-identical to
+    the path-based loader (same LibRaw, same bytes).
+
+    Returns None on any decode failure (genuine ``LibRawError`` / non-camera
+    TIFF, #75); the caller falls back to ``_load_raw_preview(path)`` then.
     """
     if not _RAWPY_AVAILABLE:
         return None
     try:
-        with rawpy.open_buffer(data) as raw:
+        # Fresh io.BytesIO per call — a reused/non-zero-position buffer would
+        # raise LibRawIOError and silently degrade to a path re-read.
+        with rawpy.imread(io.BytesIO(data)) as raw:
             try:
                 thumb = raw.extract_thumb()
                 if thumb.format == rawpy.ThumbFormat.JPEG:
@@ -459,5 +481,6 @@ def _load_raw_preview_from_bytes(data: bytes) -> Optional[Image.Image]:
             rgb = raw.postprocess(use_auto_wb=True, output_bps=8)
             return Image.fromarray(rgb).convert("RGB")
     except (OSError, ValueError, AttributeError, rawpy.LibRawError):
-        # AttributeError → rawpy.open_buffer not available in this rawpy build.
+        # Any LibRaw decode failure (incl. LibRawFileUnsupportedError for a
+        # non-camera TIFF, #75) → None so the caller's path fallback runs.
         return None

--- a/tests/test_hasher.py
+++ b/tests/test_hasher.py
@@ -277,7 +277,8 @@ class TestComputeHashes:
             # Preserve the real exception class so isinstance/except matches.
             mock_rawpy.LibRawError = _rawpy.LibRawError
             mock_rawpy.LibRawNoThumbnailError = _rawpy.LibRawNoThumbnailError
-            mock_rawpy.open_buffer.side_effect = unsupported
+            # #591 — the RAW in-memory path now calls rawpy.imread(io.BytesIO(data))
+            # (not the dropped rawpy.open_buffer); the path fallback also uses imread.
             mock_rawpy.imread.side_effect = unsupported
 
             sha, ph, dh, ch, dt, w, h = compute_hashes(f, "raw")  # +dhash at index 2
@@ -319,6 +320,32 @@ class TestRealDecodeFailures:
         bad.write_bytes(full.read_bytes()[:512])
         full.unlink()
         assert compute_phash(bad, "jpeg") is None
+
+    def test_raw_in_memory_path_skips_non_camera_tiff_unmocked(self, tmp_path):
+        """#591 — the REAL in-memory RAW path (``rawpy.imread(io.BytesIO(data))``)
+        must skip a non-camera TIFF cleanly: SHA present, all decode fields None,
+        no crash.
+
+        This is NOT mocked — it drives the actual rawpy 0.26.1 decode that every
+        other RAW test stubs out (test_raw_unsupported_format_returns_sha_only
+        patches ``rawpy`` entirely), which is exactly why the dead
+        ``rawpy.open_buffer`` dead-end shipped untested. A regression that drops
+        the ``io.BytesIO`` wrapper (passing raw ``bytes`` to ``imread`` raises an
+        uncaught ``SystemError``) or breaks the LibRaw except chain fails here.
+        """
+        from scanner.hasher import compute_hashes, compute_sha256
+
+        f = tmp_path / "scanner_output.tif"
+        # TIFF magic but not a real camera RAW → LibRaw rejects it
+        # (LibRawFileUnsupportedError) on both the io.BytesIO decode and the
+        # path fallback — the #75 non-camera-TIFF class, routed to "raw".
+        f.write_bytes(b"II*\x00" + b"\x00" * 256)
+
+        sha, ph, dh, ch, dt, w, h = compute_hashes(f, "raw")
+
+        assert sha == compute_sha256(f)
+        assert ph is None and dh is None and ch is None
+        assert dt is None and w is None and h is None
 
 
 # ---------------------------------------------------------------------------
@@ -559,11 +586,13 @@ class TestComputeFromBytes:
         assert outcome.exc_type == "ImageDecodeError"
 
     def test_uses_provided_bytes_not_re_reading_file(self, tmp_path):
-        """RAW path must use the provided data (open_buffer(data)) — not
-        re-read the file from disk — to preserve the single-read guarantee.
+        """compute_from_bytes must hash the PROVIDED data, not re-read the file
+        from disk — preserving the single-read guarantee.
 
-        We verify this by passing bytes that differ from the on-disk content:
-        compute_from_bytes must hash the PASSED bytes, not the file.
+        Demonstrated on the JPEG path by passing bytes that differ from the
+        on-disk content: the SHA must match the PASSED bytes, not the file.
+        (The RAW in-memory path's single-read property is covered separately by
+        the #591 fix and TestRealDecodeFailures.)
         """
         from scanner.hasher import compute_from_bytes
 


### PR DESCRIPTION
## What
rawpy 0.26.1 dropped the module-level `rawpy.open_buffer` that the RAW
in-memory decode path called, so `_load_raw_preview_from_bytes` and the dims
branch of `_hashes_from_data` dead-ended on `AttributeError` and silently
re-read each RAW from disk (3 touches per file). The header docstring's
"single read" claim was therefore false for RAW.

Fix: feed the already-read bytes to `rawpy.imread` via a **fresh `io.BytesIO`**
at both sites (`imread` accepts a file object). Replaces the dead `open_buffer`
calls and fixes ~6 stale `open_buffer` docstrings/comments.

## Why
The in-memory RAW path has been **dead code** on this rawpy build, falling back
to a disk re-read every time. It's also a correctness/documentation defect: the
module docstring advertises a single read that doesn't happen for RAW.

**Not a performance fix** (despite the original ticket framing). SHA-256 forces
`read_bytes()` first, which warms the OS/SMB page cache, so the redundant
`imread(path)` re-reads hit warm cache (~ms), not the wire — at matched cache
state `imread(path)` ≈ `imread(BytesIO)`. This is a correctness + dead-code +
docstring cleanup at `priority: low`, hardened via `/adversarial-review`
(converged, 0 unrebutted; full transcript +
verifications in `docs/audits/scan-591-raw-read-adversarial-review-2026-06-06.md`).

## How
- Replace both `rawpy.open_buffer(data)` call sites with
  `rawpy.imread(io.BytesIO(data))` (fresh buffer per site — a reused/non-zero
  buffer raises `LibRawIOError` and would silently degrade to a disk re-read).
- Decode is **bit-identical** to the path loader on both the thumbnail and the
  postprocess paths (phash + sensor dims byte-for-byte equal, verified on
  multiple DNGs) → **no `HASH_RECIPE_VERSION` bump**, no grouping drift.
- Non-camera TIFFs still raise `LibRawFileUnsupportedError` → caught → path
  fallback, preserving #75 skip-not-crash. The single-read claim is scoped to
  valid camera RAW.
- Add a **real, non-mocked** test driving `imread(io.BytesIO(data))` on a
  non-camera TIFF (sha-only / no crash) — the existing RAW tests mock `rawpy`
  entirely, which is why this dead-end shipped untested; verified to fail on the
  `imread(data)` typo. Drop the now-dead `open_buffer` mock from
  `test_raw_unsupported_format`.

Local: 2101 passed / 3 skipped; `scanner/hasher.py` 80%, global 89.94%.

## Out of scope
The "collapse two opens into one" refactor was **declined** (adversarial-review
verdict): ~0 measured gain, plus a #187 dims-source landmine and the seek/reuse
hazard.

Closes #591

[docs-not-needed: internal RAW-decode correctness fix; scan output is identical (phash byte-for-byte unchanged), no user-visible behaviour change]
[qa-not-needed: backend RAW-decode fix, no user-facing flow; covered at layer 1 by tests/test_hasher.py incl. a real non-mocked decode test]
