### PR TITLE
fix(scanner): cancel scan on dialog-close when exif_queue is full (#594)

### DIFF
--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -927,7 +927,10 @@ class ScanWorker(QThread):
 
             #564 — the put is cancel-safe: uses a cooperative bounded-put
             loop so a slow exiftool consumer with a full queue doesn't
-            deadlock the producer on cancel.
+            deadlock the producer on cancel. #594 — the loop also watches
+            ``isInterruptionRequested()`` so a dialog-close (which sets the
+            Qt interruption flag, not ``cancel_flag``) can't wedge the parent
+            drain thread here.
             """
             if isinstance(outcome, HashFailure):
                 # Both raised exceptions and silent decode failures
@@ -945,7 +948,16 @@ class ScanWorker(QThread):
                 # #564 — cooperative bounded put: mirrors the _read_drain
                 # pattern so a full exif_queue (slow exiftool consumer) can't
                 # wedge the producer forever on cancel.
-                while not cancel_flag.is_set():
+                # #594 — ALSO break on isInterruptionRequested(). This runs in
+                # the parent drain thread, and cancel_flag is set ONLY by that
+                # same thread's interrupt branch downstream. Watching cancel_flag
+                # alone, a full queue here wedges the parent BEFORE it can reach
+                # that branch — so requestInterruption() (dialog close) could
+                # never tear the worker down (orphaned QThread + the interpreter-
+                # shutdown RuntimeError, #594). Breaking on the Qt interruption
+                # flag lets the parent escape and run the cancel teardown that
+                # then sets cancel_flag for the daemon threads.
+                while not cancel_flag.is_set() and not self.isInterruptionRequested():
                     try:
                         exif_queue.put(outcome, timeout=0.05)
                         break
@@ -1404,9 +1416,20 @@ class ScanWorker(QThread):
                         byte_budget.release(_n)
                         out_q.put(f.result())
 
-                    compute_pool.submit(
-                        compute_from_bytes, c_idx, c_record, c_data
-                    ).add_done_callback(_cb)
+                    try:
+                        compute_pool.submit(
+                            compute_from_bytes, c_idx, c_record, c_data
+                        ).add_done_callback(_cb)
+                    except RuntimeError:
+                        # #594 — shutdown race: the parent cancel branch may have
+                        # called compute_pool.shutdown(cancel_futures=True) (or the
+                        # interpreter is tearing down) between this loop's
+                        # cancel_flag check and the submit. Stop dispatching — the
+                        # cancel branch drains hash_in_q and abandons the budget on
+                        # teardown. Without this guard the daemon thread raises
+                        # "cannot schedule new futures after ... shutdown" — the
+                        # user-visible CMD traceback.
+                        break
 
             import threading as _threading
             read_drain_thread = _threading.Thread(

--- a/news/595.bugfix
+++ b/news/595.bugfix
@@ -1,0 +1,1 @@
+Fix the Scan dialog not stopping the scan when closed mid-scan — closing now reliably cancels the worker instead of leaving it running, and no longer prints a "cannot schedule new futures" error on exit (#594).

--- a/tests/test_scan_worker.py
+++ b/tests/test_scan_worker.py
@@ -1918,6 +1918,122 @@ class TestScanWorkerPerDeviceHashPools:
             f" expected [{local}, {cpu}], got {constructed!r}"
         )
 
+    def test_close_unblocks_route_outcome_on_full_exif_queue(
+        self, qapp, tmp_path, monkeypatch
+    ):
+        """#594 — requestInterruption() (dialog close) must tear the worker down
+        even when the parent drain thread is wedged in ``_route_outcome``'s
+        cooperative ``exif_queue.put`` loop because the queue is full.
+
+        The real hang: that put loop watched ``cancel_flag`` ONLY, but
+        ``cancel_flag`` is set exclusively by the parent's own interrupt branch —
+        which the parent cannot reach while blocked here. A title-bar-X close calls
+        ``requestInterruption()`` (the Qt interruption flag, NOT ``cancel_flag``),
+        so on pre-#594 code the parent never escapes, ``wait(3000)`` times out, the
+        QThread orphans (reads keep running), and ``_compute_dispatch`` later
+        raises ``RuntimeError: cannot schedule new futures after interpreter
+        shutdown`` — the user's CMD traceback.
+
+        We wedge the lone exiftool consumer in ``__enter__`` so it never drains the
+        bounded ``exif_queue``; with > MAXSIZE non-skip records the parent fills the
+        queue and blocks in the put loop. Then we flip ``isInterruptionRequested``
+        and assert ``run()`` returns + emits ['Scan cancelled.'] within seconds. On
+        pre-#594 code ``run()`` never returns and the join below times out.
+        """
+        import threading
+        import time
+        import scanner.exif as _exif
+        from PySide6.QtCore import Qt
+        from app.views.workers.scan_worker import ScanWorker
+        from scanner.walker import FileRecord
+
+        # exif_workers=1 → _EXIF_QUEUE_MAXSIZE = 2 * chunk_size(500) * 1 = 1000.
+        # Need > MAXSIZE NON-skip records so the (MAXSIZE+1)th put blocks (skip
+        # records never reach the exif_queue put — see _route_outcome).
+        records = [
+            FileRecord(path=Path(rf"J:\nas\img_{i}.jpg"), source_label="s",
+                       file_type="jpeg")
+            for i in range(1100)
+        ]
+        self._install_synthetic_pipeline(
+            monkeypatch, records, remote_drive=lambda root: str(root).upper() == "J:"
+        )
+
+        # Wedge the lone exiftool consumer in __enter__ so it NEVER drains the
+        # queue → the queue fills and the parent blocks in _route_outcome's put.
+        # kill() (the #561 cancel path) releases it so teardown completes.
+        released = threading.Event()
+
+        class _BlockingExif:
+            def __enter__(self):
+                released.wait()
+                return self
+
+            def __exit__(self, *_a):
+                return False
+
+            def kill(self):
+                released.set()
+
+        monkeypatch.setattr(_exif, "ExiftoolProcess", _BlockingExif)
+        # Once released on cancel, the consumer may drain+flush — make the flush a
+        # no-op so teardown can't touch a fake exiftool process.
+        monkeypatch.setattr(_exif, "batch_read_extracts", lambda *a, **k: {})
+
+        worker = ScanWorker(
+            sources={"src": str(tmp_path)},
+            output_path=str(tmp_path / "manifest.sqlite"),
+            recursive_map={"src": False},
+            workers=2,
+            exif_workers=1,
+            hash_pool="thread",  # force the thread branch (where _route_outcome runs)
+        )
+
+        # Flip the Qt interruption flag only AFTER the parent is blocked inside
+        # _route_outcome (queue full). The synthetic read+compute are instant so
+        # the queue fills in well under the delay; flipping then exercises the
+        # #594 break (vs the drain-loop top-check catching it first).
+        interrupted = {"v": False}
+        monkeypatch.setattr(
+            worker, "isInterruptionRequested", lambda: interrupted["v"]
+        )
+
+        def trip():
+            time.sleep(0.8)
+            interrupted["v"] = True
+
+        failed: list[str] = []
+        # DirectConnection: run() executes in a sub-thread below so the test can
+        # time-bound a hang, but the worker's affinity is the main (test) thread.
+        # Under the default AutoConnection a cross-thread failed.emit() would queue
+        # to a main-thread event loop that isn't running here, and the capture would
+        # be lost — force Direct so the slot fires inline in the run() thread.
+        worker.failed.connect(failed.append, Qt.ConnectionType.DirectConnection)
+
+        done = threading.Event()
+
+        def run_worker():
+            try:
+                worker.run()
+            finally:
+                released.set()  # never leave the consumer wedged
+                done.set()
+
+        threading.Thread(target=trip, daemon=True).start()
+        threading.Thread(target=run_worker, daemon=True).start()
+
+        finished = done.wait(timeout=10)
+        released.set()  # belt-and-suspenders before asserting
+        assert finished, (
+            "#594 regression: worker.run() did not return within 10s after "
+            "requestInterruption() — the parent is wedged in _route_outcome's "
+            "cooperative put loop (pre-#594 it watched cancel_flag only, never the "
+            "Qt interruption flag). This is the dialog-close hang/orphan."
+        )
+        assert failed == ["Scan cancelled."], (
+            f"a mid-HASH interruption must emit ['Scan cancelled.']; got {failed!r}"
+        )
+
 
 class TestStratifiedSample:
     """#548 — _stratified_sample spreads the auto-calibration sample across


### PR DESCRIPTION
## What
Closing the Scan dialog mid-scan now reliably stops the worker even when the
bounded `exif_queue` is full (slow exiftool on large files). Previously the
parent drain thread could wedge in `_route_outcome`'s cooperative
`exif_queue.put` loop, which watched `cancel_flag` only — and `cancel_flag` is
set exclusively by the parent's own interrupt branch, unreachable while it is
blocked there. So `closeEvent`'s `requestInterruption()` + `wait(3000)` timed
out, the QThread orphaned (reads kept running = "scan won't stop"), and the
looping `_compute_dispatch` later raised
`RuntimeError: cannot schedule new futures after interpreter shutdown`
(the user's CMD traceback).

## Why
User-facing hang/orphan on a normal action (closing mid-scan). Same
cancel-checkpoint bug class as #492 / #495 / #507 / #561; residual of the `#564`
cooperative bounded-put (correct for `cancel_flag`, but missing the Qt
interruption checkpoint).

## How
- `_route_outcome` (shared by the thread and process drain paths): the
  cooperative put loop also breaks on `self.isInterruptionRequested()`, so a
  dialog-close lets the parent escape and run the existing cancel teardown that
  sets `cancel_flag` for the daemon threads.
- `_compute_dispatch`: wrap `compute_pool.submit(...)` in
  `try/except RuntimeError` to absorb the shutdown race (parent
  `compute_pool.shutdown()` / interpreter teardown landing between the loop's
  `cancel_flag` check and the submit) — the direct source of the user-visible
  traceback.
- Regression test `test_close_unblocks_route_outcome_on_full_exif_queue` drives
  the real `ScanWorker` with the lone exiftool consumer wedged so `exif_queue`
  fills, then flips the interruption flag; `run()` returns and emits
  `["Scan cancelled."]` in ~1.2s. Verified it deadlocks/times out at 10s without
  the `_route_outcome` fix — a genuine regression test, not padding.

Determinism unaffected (no change to idx ordering or `classify`). Full suite
green locally; global coverage 89.9%, all files clear the 70% per-file floor.

Closes #594

[docs-not-needed: bug fix restoring the already-documented cancel-on-close behaviour; no new control/label/dialog/setting/shortcut]
[qa-not-needed: cancel-on-close has layer-3 coverage (s03_cancel_scan); this specific full-exif_queue timing race is covered deterministically at layer-1 by test_close_unblocks_route_outcome_on_full_exif_queue — a UIA scenario can't reliably force the queue-full condition]
