### PR TITLE
chore(gitignore): ignore .claude/tmp-* scratch and persisted workflows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -123,6 +123,19 @@ settings.local.json
 # locally to spot dropped task assignments.
 .claude/team_idle.log
 
+# Local-only scratch under .claude/. Convention: anything prefixed
+# `tmp-` (file or directory) is per-session scratch — drafts from
+# skills (e.g. build-goal-prompt), perf-investigation artifacts
+# (CSVs, ad-hoc scripts), monitor dumps. Never tracked.
+.claude/tmp-*
+
+# Workflow scripts persisted by the Workflow tool to
+# .claude/workflows/<name>.js. Default local-only — they capture an
+# ad-hoc fan-out a session ran, not a reusable contract. To promote
+# one to a shared workflow, move/rename it into a tracked location
+# or `git add -f` deliberately.
+.claude/workflows/
+
 # Window geometry / splitter state — written by MainWindow.closeEvent on
 # every clean exit. Anchored under PHOTO_MANAGER_HOME (or repo root) so
 # the QA scenario can isolate from the user's real install; never


### PR DESCRIPTION
## What
Add two patterns to `.gitignore` under `.claude/`:
- `.claude/tmp-*` — any `tmp-` prefixed file or directory (scratch)
- `.claude/workflows/` — Workflow tool persisted scripts

## Why
Untracked scratch under `.claude/` (build-goal-prompt drafts,
perf-investigation CSVs + ad-hoc scripts under `tmp-monitor/`, and the
`workflows/scanner-sweep.js` the Workflow tool persisted) kept showing
up in `git status` every session. Establishing a naming convention —
`tmp-` prefix = per-session scratch, `workflows/` = Workflow tool
persistence — means future scratch is auto-ignored without re-editing
`.gitignore` each time.

## How
- Append two ignore blocks after the existing `.claude/team_idle.log`
  entry, each with a comment explaining the convention.
- `.claude/skills/<name>/` (tracked project skills) and
  `.claude/skills/personal/` (already ignored) are untouched — the
  existing project-vs-personal skill split is preserved.
- To promote a workflow into something shared, move it out of
  `.claude/workflows/` or `git add -f` deliberately.

[docs-not-needed: gitignore-only change, no user-facing behaviour]
[qa-not-needed: no UI / scenario surface]
[skip-news: developer-only repo hygiene, no user-facing change]
