### PR TITLE
fix(scanner): per-device byte budget so a slow device can't starve a fast one (#596)

### DIFF
--- a/app/views/workers/scan_worker.py
+++ b/app/views/workers/scan_worker.py
@@ -715,7 +715,7 @@ class ScanWorker(QThread):
             _RAMP_MIN_SCAN_FILES,
             _valid_read_knee,
         )
-        from scanner.byte_budget import ByteBudget, default_budget_bytes
+        from scanner.byte_budget import default_budget_bytes, per_device_budgets
         import io
         from contextlib import redirect_stdout
 
@@ -1250,7 +1250,17 @@ class ScanWorker(QThread):
             # Future._result — and released in the compute done-callback.
             # hash_in_q maxsize=_HASH_QUEUE_MAXSIZE remains a secondary
             # queue-DEPTH cap.
-            byte_budget = ByteBudget(default_budget_bytes(), cancel_flag.is_set)
+            # #596 — ONE budget PER DEVICE, not one global budget. A single global
+            # ceiling let a slow big-file device (D: HDD full of 100-130 MB ProRAW
+            # DNGs) consume it all and starve a fast device's reader at acquire
+            # (measured: budget 100% full during 100% of NAS-idle samples). The
+            # equal split keeps #587's OOM bound (sum of slices <= total); a
+            # single-device scan still gets the whole budget. Each reader acquires
+            # from ITS device's budget and the compute callback releases from the
+            # same one (the device is threaded through hash_in_q).
+            byte_budgets = per_device_budgets(
+                default_budget_bytes(), list(device_records.keys()), cancel_flag.is_set
+            )
             # out_q carries (idx, outcome) tuples from compute callbacks
             # back to the parent drain loop.
             out_q: _queue.Queue = _queue.Queue()
@@ -1298,20 +1308,22 @@ class ScanWorker(QThread):
                 # ReadFailure) is a no-op; on cancel acquire returns False and we
                 # still return the result — the drain loop drops it on its cancel check.
                 _data = read_result[2]
-                byte_budget.acquire(len(_data) if isinstance(_data, bytes) else 0)
+                byte_budgets[dev].acquire(len(_data) if isinstance(_data, bytes) else 0)
                 return read_result, dev, level_tag, t_end
 
-            def _budgeted_read(idx, r):
+            def _budgeted_read(dev, idx, r):
                 """#587 — ungated reader (autotune off) with byte-budget backpressure.
 
                 Mirrors _gated_read's post-read acquire so the reader pool can't
                 outrun compute and accumulate read bytes in Future._result. The
-                budget is released in the compute done-callback.
+                budget is released in the compute done-callback. #596 — acquires
+                from the per-device budget and returns ``dev`` so the drain loop can
+                thread it through hash_in_q for the matching release.
                 """
                 read_result = read_for_record(idx, r)
                 _data = read_result[2]
-                byte_budget.acquire(len(_data) if isinstance(_data, bytes) else 0)
-                return read_result
+                byte_budgets[dev].acquire(len(_data) if isinstance(_data, bytes) else 0)
+                return read_result, dev
 
             def _read_drain() -> None:
                 """Drive read futures into hash_in_q; put a None sentinel when done."""
@@ -1333,7 +1345,7 @@ class ScanWorker(QThread):
                             )
                         else:
                             reader_futures.add(
-                                reader_pools[dev].submit(_budgeted_read, _idx, _r)
+                                reader_pools[dev].submit(_budgeted_read, dev, _idx, _r)
                             )
                 for fut in as_completed(reader_futures):
                     if cancel_flag.is_set():
@@ -1376,15 +1388,17 @@ class ScanWorker(QThread):
                                         _summary["sole_ramping"] = True
                                         self.read_knee_measured.emit(_summary)
                         else:
-                            read_result = fut.result()
+                            read_result, _dev = fut.result()
                             # Drop the strong reference so the bytes can be GC'd.
                             reader_futures.discard(fut)
                         # Cooperative bounded put: retry with a short timeout so a
                         # cancel_flag check doesn't leave us stuck forever when
                         # compute is stopped and the queue is full.
+                        # #596 — carry the device key alongside the read so the
+                        # compute callback releases from the same per-device budget.
                         while not cancel_flag.is_set():
                             try:
-                                hash_in_q.put(read_result, timeout=0.05)
+                                hash_in_q.put((*read_result, _dev), timeout=0.05)
                                 break
                             except _queue.Full:
                                 pass
@@ -1401,7 +1415,7 @@ class ScanWorker(QThread):
                         continue
                     if item is None:
                         break
-                    c_idx, c_record, c_data = item
+                    c_idx, c_record, c_data, c_dev = item
 
                     # #587 — the byte budget is acquired in the READER worker
                     # (_gated_read / _budgeted_read), so dispatch just submits.
@@ -1409,11 +1423,12 @@ class ScanWorker(QThread):
                     # 0 for video / None / ReadFailure (acquire was a no-op there).
                     n = len(c_data) if isinstance(c_data, bytes) else 0
 
-                    def _cb(f, _idx=c_idx, _n=n):
+                    def _cb(f, _dev=c_dev, _n=n):
                         # release() never raises (#587 invariant) so out_q.put
                         # always runs; releasing here (compute done) is what wakes
-                        # a reader blocked on the byte budget.
-                        byte_budget.release(_n)
+                        # a reader blocked on the byte budget. #596 — release from
+                        # the SAME per-device budget the reader acquired from.
+                        byte_budgets[_dev].release(_n)
                         out_q.put(f.result())
 
                     try:

--- a/docs/audits/scan-nas-starvation-2026-06-06.md
+++ b/docs/audits/scan-nas-starvation-2026-06-06.md
@@ -1,0 +1,70 @@
+# Scan NAS-starvation by the global ByteBudget — decision record (2026-06-06)
+
+Issue #596 · fix PR for #596 · sibling cancel-deadlock #594/PR#595.
+
+## Trigger
+User: a real multi-device scan (D: Takeout HDD + H:/J: NAS `\\LINXIAOYUN`,
+32 GB RAM) showed "忽高忽低" throughput that "doesn't look like the hardware is
+maxed out." We live-monitored a faithful headless run of the real `ScanWorker`
+(CPU / RAM / D: disk / network at 3 s; harness in `.claude/tmp-monitor/`,
+deleted after) and instrumented `byte_budget._inflight` directly.
+
+## Method
+`/adversarial-review` (two independent peers, Opus + Sonnet; LEAD judge) on the
+first diagnosis → **NOT converged**: it caught that the first read of the data was
+wrong (I claimed "8 NAS threads idle" and blamed byte-budget *coupling* without
+measuring `_inflight`; whole-OS RAM cannot see a 2 GB in-flight swing). Settled by
+two cheap controls:
+
+1. **NAS-only run** (drop D:): if stalls vanish → client-side, not NAS-server.
+2. **Direct `_inflight` logging** (harness `ByteBudget.__init__` monkeypatch — no
+   product change): is the budget actually the gate?
+
+## Findings (all measured)
+- HASH is **read-supply-limited**, NOT CPU- or RAM-bound (CPU median 14 %, >80 %
+  only 3.9 %; RAM steady 19–20 GB / 32; the #587/#590 OOM fix holds).
+- The NAS ran at **knee=1** (cached `read_knee_cache["\\LINXIAOYUN"]={knee:1}`),
+  i.e. one active read at a time — yet alone it is healthy: **137 MB/s mean, zero
+  stalls** (NAS-only control).
+- With D: present the NAS is **idle ~46 % of HASH** (stalls up to 137 s). The
+  decisive measurement:
+
+  | metric | NAS-only control | 3-source (real) |
+  |---|---|---|
+  | `_inflight` fill mean | 0.2 % | **86.5 %** |
+  | `_inflight` during NAS-idle | — | **100 % in 53/53 idle samples** |
+  | NAS net mean | 137 MB/s | 47 MB/s |
+  | longest stall | 0 s | 137 s |
+
+- **Gate = the single GLOBAL 2 GiB `ByteBudget`.** D:'s clustered 100–130 MB iPhone
+  ProRAW DNGs fill the one shared ceiling; the NAS reader then blocks at
+  `byte_budget.acquire` despite its own small files and an idle link. `#587` added
+  the global budget to stop the OOM — correct, but one ceiling shared across
+  devices lets the slow big-file device starve the fast one.
+
+Refuted alternatives: NAS-server-side pause (removing D: removed the stalls);
+compute-pool drain (NAS-only `_inflight` 2.5 % ⇒ compute kept up); the first
+"byte-budget coupling / 8 idle threads" framing (wrong: knee=1, and unmeasured).
+
+## Decision — per-device byte budget
+Split the total ceiling into **one `ByteBudget` per device**
+(`scanner/byte_budget.py:per_device_budgets`, equal split). Each reader acquires
+from its device's budget; the device is threaded through `hash_in_q` so the compute
+done-callback releases from the same one. Properties:
+
+- **OOM bound preserved:** sum of per-device budgets ≤ total (`n*(total//n) ≤
+  total`) — the global peak in-flight is unchanged.
+- **Single-device unchanged:** one device keeps the whole budget.
+- **No deadlock:** each per-device budget keeps admit-one-over-budget.
+- **Determinism unchanged:** `idx` still threads through; `classify` sees walk
+  order.
+
+Rejected: raising the global cap (blunt; re-opens #587 OOM on bigger libraries).
+Orthogonal/out of scope: a dynamic working-set budget; the low cached NAS knee=1
+(already does 137 MB/s, so a minor follow-up, not the lever here).
+
+## Verification
+Unit test `tests/test_byte_budget.py::TestPerDeviceBudgets` — equal split preserves
+the OOM bound, single device keeps full, **a full device budget does NOT block
+another device** (the isolation that is the fix). Full suite green; the existing
+byte-budget pipeline-bound + cancel + per-device-pool tests still pass.

--- a/news/598.bugfix
+++ b/news/598.bugfix
@@ -1,0 +1,1 @@
+Fix multi-device scans stalling reads from a fast source (e.g. a NAS) when another drive is busy with large RAW/DNG files — the HASH-stage read memory budget is now split per device instead of shared globally (#596).

--- a/scanner/byte_budget.py
+++ b/scanner/byte_budget.py
@@ -162,6 +162,39 @@ def default_budget_bytes() -> int:
     return max(_256_MIB, min(_2_GIB, total_ram // 2))
 
 
+def per_device_budgets(
+    total_bytes: int,
+    device_keys: list[str],
+    cancel_check: Callable[[], bool],
+) -> dict[str, ByteBudget]:
+    """Split ``total_bytes`` into one :class:`ByteBudget` per device (#596).
+
+    A single GLOBAL ByteBudget shared across devices lets a slow, large-file
+    device (e.g. an HDD full of 100-130 MB ProRAW DNGs) consume the whole ceiling
+    and starve a fast device's reader at ``acquire`` — even though that device's
+    own files are small and its link is idle. Giving each device its own slice
+    isolates them so one device's in-flight bytes can't block another's reader.
+
+    The split is EQUAL, which preserves #587's OOM bound: the sum of the
+    per-device budgets never exceeds ``total_bytes`` (``n * (total // n) <=
+    total``). A single device therefore keeps the full budget — byte-identical to
+    the pre-#596 global behaviour. Each per-device ByteBudget keeps the
+    admit-one-over-budget rule, so a file larger than its slice is still admitted
+    alone rather than deadlocking.
+
+    Args:
+        total_bytes: the global ceiling (e.g. from ``default_budget_bytes``).
+        device_keys: the active HASH-stage per-device bucket keys.
+        cancel_check: forwarded to each ByteBudget (``cancel_flag.is_set``).
+
+    Returns:
+        ``{device_key: ByteBudget}`` — one bounded budget per device.
+    """
+    n = max(1, len(device_keys))
+    per_device = max(1, total_bytes // n)
+    return {key: ByteBudget(per_device, cancel_check) for key in device_keys}
+
+
 def _probe_total_ram() -> int | None:
     """Return total physical RAM in bytes, or None on any failure.
 

--- a/tests/test_byte_budget.py
+++ b/tests/test_byte_budget.py
@@ -14,7 +14,11 @@ import threading
 import time
 
 import scanner.byte_budget as bb_mod
-from scanner.byte_budget import ByteBudget, default_budget_bytes
+from scanner.byte_budget import (
+    ByteBudget,
+    default_budget_bytes,
+    per_device_budgets,
+)
 
 
 class TestByteBudgetAccounting:
@@ -178,3 +182,48 @@ class TestDefaultBudgetSizing:
         budget = default_budget_bytes()
         assert budget == 1 * 1024 ** 3
         assert budget <= 2 * 1024 ** 3
+
+
+class TestPerDeviceBudgets:
+    """#596 — split the global ceiling into one budget per device so a slow
+    big-file device (D: HDD ProRAW DNGs) can't starve a fast device's reader."""
+
+    def test_equal_split_preserves_oom_bound(self):
+        total = 2 * 1024 ** 3
+        budgets = per_device_budgets(total, ["D", "NAS"], lambda: False)
+        assert set(budgets) == {"D", "NAS"}
+        # #587's OOM bound must survive: the sum of slices never exceeds total.
+        assert sum(b._budget for b in budgets.values()) <= total
+        assert all(b._budget == total // 2 for b in budgets.values())
+
+    def test_single_device_keeps_full_budget(self):
+        # One device → the whole budget, byte-identical to the pre-#596 global
+        # behaviour (no regression for single-device users).
+        total = 2 * 1024 ** 3
+        budgets = per_device_budgets(total, ["only"], lambda: False)
+        assert budgets["only"]._budget == total
+
+    def test_one_device_full_does_not_block_another(self):
+        # THE fix: a device whose budget is saturated must NOT block another
+        # device's reader. Pre-#596 (one shared global budget) D: filling the
+        # ceiling blocked the NAS reader at acquire — the measured starvation
+        # (budget 100% full during 100% of NAS-idle samples).
+        total = 2 * 1024 ** 3
+        budgets = per_device_budgets(total, ["D", "NAS"], lambda: False)
+        # Fill D: entirely (mimics clustered 100-130 MB DNGs held in flight).
+        assert budgets["D"].acquire(budgets["D"]._budget) is True
+        # A further D: acquire would now block — but NAS is a SEPARATE budget and
+        # must admit immediately. A shared global budget would block here.
+        out: dict = {}
+
+        def nas_reader():
+            out["r"] = budgets["NAS"].acquire(100 * 1024 * 1024)
+
+        t = threading.Thread(target=nas_reader)
+        t.start()
+        t.join(timeout=2)
+        assert not t.is_alive(), (
+            "NAS reader blocked even though D: filled only ITS OWN budget — "
+            "per-device isolation regressed to a shared budget (#596)"
+        )
+        assert out["r"] is True


### PR DESCRIPTION
## What
On a multi-device scan, a slow large-file device (D: HDD full of 100–130 MB iPhone
ProRAW DNGs) saturates the single **global** 2 GiB `ByteBudget` (added in `#587` to
stop the HASH-stage OOM) and blocks a fast device's reader at `byte_budget.acquire`
— even though that device's own files are small and its link/CPU are idle.

Measured (live perf + direct `byte_budget._inflight` instrumentation, 2026-06-06):
the NAS sat **idle ~46 % of HASH** (stalls up to 137 s) with `_inflight` **100 %
full during 100 % of NAS-idle samples (53/53)**. A NAS-only control (D: removed)
had **zero stalls** and `_inflight` max **2.5 %**. Not CPU/RAM-bound.

## Why
One ceiling shared across devices lets the slow big-file device consume it all and
starve the others — roughly doubling multi-device scan wall-clock on the reporter's
library. The cross-device starvation is the cost of a *global* cap, not its size.

## How
Split the ceiling into **one `ByteBudget` per device**
(`scanner/byte_budget.py::per_device_budgets`, equal split):
- each reader acquires from **its** device's budget;
- the device is threaded through `hash_in_q` so the compute done-callback releases
  from the same budget.

Invariants preserved:
- **OOM bound:** sum of per-device slices ≤ total (`n*(total//n) ≤ total`) — the
  global peak in-flight is unchanged (the existing pipeline-bound test still passes).
- **Single-device:** keeps the full budget — byte-identical to pre-#596.
- **No deadlock:** each per-device budget keeps admit-one-over-budget.
- **Determinism:** `idx` still threads through; `classify` sees walk order.

Rejected: raising the global cap (blunt, re-opens `#587` OOM on bigger libraries).
Out of scope: a dynamic working-set budget; the low cached NAS knee=1 (already
137 MB/s alone — minor follow-up, not this lever).

## Test
`tests/test_byte_budget.py::TestPerDeviceBudgets` — equal split preserves the OOM
bound, single device keeps full, and **a full device budget does NOT block another
device's acquire** (the isolation that is the fix). Full suite green; global
coverage 89.9 %, all files clear the 70 % per-file floor. Decision record:
`docs/audits/scan-nas-starvation-2026-06-06.md`.

Closes #596

[docs-not-needed: internal HASH-stage memory-budget change; no user-visible behaviour — no new control/label/dialog/setting/shortcut]
[qa-not-needed: internal perf/memory change, no user-facing flow; the per-device budget contract is covered at layer-1 by tests/test_byte_budget.py::TestPerDeviceBudgets and the existing thread-branch tests — a UIA scenario can't observe per-device in-flight bytes]
