### PR TITLE
revert: back out #583 durable volume-GUID device key (#605) — HDD reader-pool seek-thrash regression

### DIFF
--- a/news/605.misc
+++ b/news/605.misc
@@ -1,1 +1,0 @@
-Key the read-knee autotune cache by durable local volume identity so a re-lettered or swapped disk can't inherit another device's cached knee. (#583)

--- a/news/606.bugfix
+++ b/news/606.bugfix
@@ -1,0 +1,1 @@
+Revert the durable volume-GUID device key (#605/#583) — it broke the spinning-HDD reader cap (4 readers instead of 1), causing seek-thrash on local HDD scans. (#606)

--- a/scanner/workers.py
+++ b/scanner/workers.py
@@ -22,12 +22,6 @@ from typing import Callable, Iterable
 # shares, mapped network drives, and DFS roots.
 _DRIVE_REMOTE = 4
 
-# DRIVE_FIXED per WinBase.h — a non-removable local volume (internal SSD/HDD).
-# Only fixed disks earn a durable volume-{GUID} device key (#583): a removable's
-# volume GUID can change per insertion (→ read-knee re-probe churn), and a
-# remote drive has no volume GUID (it resolves to its \\SERVER key first).
-_DRIVE_FIXED = 3
-
 # Per-device hash-stage worker counts.
 #   NAS  → 8: SMB request latency dominates, more concurrent reads pay off.
 #   HDD  → 1: single sequential reader on a spinning disk (#552 anti-thrash
@@ -57,11 +51,6 @@ _PROPERTY_STANDARD_QUERY = 0
 # Populated lazily by device_key; one real Win32 call per distinct letter.
 _unc_cache: dict[str, str | None] = {}
 
-# Memoization cache for local drive-letter → durable volume-{GUID} resolution
-# (GetVolumeNameForVolumeMountPointW). device_key runs in several per-record
-# loops, so without this each record would re-do the Win32 call (#583).
-_volid_cache: dict[str, str | None] = {}
-
 
 def _resolve_unc_via_win32(letter: str) -> str | None:
     """Return the UNC path for a drive letter, or None on any failure.
@@ -87,82 +76,6 @@ def _resolve_unc_via_win32(letter: str) -> str | None:
         return None
     except (OSError, AttributeError, ValueError):  # pragma: no cover
         return None
-
-
-def _resolve_volume_id_via_win32(letter: str) -> str | None:
-    """Return a durable ``{GUID}`` token for the volume mounted at ``letter``
-    (a LOCAL FIXED disk), or None for anything else.
-
-    Real Win32 boundary (GetDriveTypeW + GetVolumeNameForVolumeMountPointW),
-    excluded from coverage like ``_resolve_unc_via_win32`` — it can't run on the
-    Linux CI runner, and mocking ctypes is banned as coverage padding. The
-    testable logic (fixed-only gate, GUID normalisation, memoisation, fail-open)
-    is exercised via the injected ``guid_resolver`` in :func:`device_key`.
-
-    Restricted to ``_DRIVE_FIXED`` (#583): removable volume GUIDs can change per
-    insertion, and remote drives have no volume GUID (they take the UNC path
-    before reaching here). The returned token is the BARE ``{GUID}`` — the raw
-    volume mount-point name starts with a double backslash, and
-    :func:`is_remote_drive` treats any such string as remote, which would
-    misclassify every local fixed disk and corrupt device bucketing.
-    """
-    if sys.platform != "win32":
-        return None
-    try:  # pragma: no cover
-        import ctypes
-        from ctypes import wintypes
-
-        k = ctypes.windll.kernel32
-        k.GetDriveTypeW.argtypes = [ctypes.c_wchar_p]
-        k.GetDriveTypeW.restype = ctypes.c_uint
-        k.GetVolumeNameForVolumeMountPointW.argtypes = [
-            wintypes.LPCWSTR,
-            wintypes.LPWSTR,
-            wintypes.DWORD,
-        ]
-        k.GetVolumeNameForVolumeMountPointW.restype = wintypes.BOOL
-
-        root = letter + "\\"
-        if k.GetDriveTypeW(root) != _DRIVE_FIXED:
-            return None
-        buf = ctypes.create_unicode_buffer(64)
-        # The mount point needs the trailing backslash; without it the call
-        # returns BOOL False (not an exception) — hence the bool() gate, not an
-        # error-code check.
-        if not bool(k.GetVolumeNameForVolumeMountPointW(root, buf, 64)):
-            return None
-        name = buf.value
-        start = name.find("{")
-        end = name.find("}")
-        if start != -1 and end > start:
-            return name[start : end + 1].upper()
-        return None
-    except (OSError, AttributeError, ValueError):  # pragma: no cover
-        return None
-
-
-def _volume_id_for_letter(
-    letter: str,
-    guid_resolver: Callable[[str], str | None] | None,
-) -> str | None:
-    """Resolve a local drive letter to its durable ``{GUID}`` key, or None to
-    fall back to the bare letter.
-
-    Memoises in ``_volid_cache`` (one Win32 call per distinct letter per
-    process). Fail-open: any resolver exception or a None result → None, so the
-    caller keeps the bare letter (today's behaviour). #583.
-    """
-    if letter in _volid_cache:
-        return _volid_cache[letter]
-    resolver = (
-        guid_resolver if guid_resolver is not None else _resolve_volume_id_via_win32
-    )
-    try:
-        vol = resolver(letter)
-    except Exception:  # noqa: BLE001 — fail-open; device_key must never raise
-        vol = None
-    _volid_cache[letter] = vol
-    return vol
 
 
 def is_remote_drive(path: Path | str) -> bool:
@@ -294,7 +207,6 @@ def device_key(
     path: Path | str,
     *,
     unc_resolver: Callable[[str], str | None] | None = None,
-    guid_resolver: Callable[[str], str | None] | None = None,
 ) -> str:
     """Physical-device grouping key for ``path``.
 
@@ -327,20 +239,6 @@ def device_key(
     ``_resolve_unc_via_win32`` at call time — the real Win32 boundary which
     is behind ``# pragma: no cover``.
 
-    **Durable local identity (#583):** a LOCAL fixed-disk drive letter (not a
-    remote share) resolves to its volume ``{GUID}`` token via
-    ``_volume_id_for_letter`` — durable across drive-letter reassignment, reboot,
-    and Disk-Management relabel — so a cached read-knee (#551) is never inherited
-    by a different physical disk that later reuses the letter. Fail-open: when the
-    volume id is unavailable (non-Windows, removable, any Win32 error) the bare
-    upper-cased letter is returned, exactly as before. A volume mounted as a
-    folder without its own drive letter still collapses to the host letter's
-    GUID (pre-existing, bounded — a stale knee is only ever stale-LOW). The
-    ``{GUID}`` token has no leading ``\\\\`` so ``is_remote_drive`` never
-    mistakes a local disk for a NAS. ``guid_resolver`` is injected like
-    ``unc_resolver`` for Win32-free unit tests; ``None`` uses
-    ``_resolve_volume_id_via_win32`` (behind ``# pragma: no cover``).
-
     #548 — used by the HASH stage to run one ThreadPoolExecutor per physical
     device concurrently, so NAS-latency-bound reads overlap HDD-seek-bound
     reads instead of queueing behind them in one flat pool.
@@ -356,16 +254,6 @@ def device_key(
             # e.g. \\LINXIAOYUN\HOME → split on 3rd backslash → \\LINXIAOYUN
             parts = raw.split("\\", 3)  # ['', '', 'SERVER', 'SHARE...']
             return "\\\\" + parts[2]
-        # #583 — a LOCAL fixed-disk letter resolves to its durable volume
-        # ``{GUID}`` so a cached read-knee (#551) survives drive-letter
-        # reassignment / Disk-Management relabel and is NOT inherited by a
-        # different physical disk that later reuses the letter. Fail-open to the
-        # bare letter when the volume id is unavailable (non-Windows, removable,
-        # any Win32 error). Remote letters are handled above and never reach here.
-        if len(raw) == 2 and raw[1] == ":":
-            vol = _volume_id_for_letter(raw, guid_resolver)
-            if vol:
-                return vol
     except Exception:  # noqa: BLE001 — fail-open; device_key must never raise
         pass
     return raw

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,33 +15,26 @@ def qapp():
 
 @pytest.fixture(autouse=True)
 def _isolate_unc_resolution(monkeypatch):
-    """Keep ``device_key``'s device-identity grouping deterministic in tests.
+    """Keep ``device_key``'s NAS-server grouping (#565) deterministic in tests.
 
-    ``device_key`` memoises two real-Win32 resolutions in module-level caches and
-    resolves via the real OS by default:
-    * NAS-server grouping (#565) — ``_unc_cache`` / ``WNetGetConnectionW``.
-    * Durable local volume id (#583) — ``_volid_cache`` /
-      ``GetVolumeNameForVolumeMountPointW``.
+    ``device_key`` memoises drive-letter→UNC-server in a module-level
+    ``_unc_cache`` and, by default, resolves via the real
+    ``WNetGetConnectionW``. On a dev machine where a test drive letter (e.g.
+    ``J:``) is a live NAS mapping, the real call leaks the actual server
+    (``\\\\LINXIAOYUN``) into the bucket key, and the memo persists across
+    tests — so a later test that mocks ``is_remote_drive`` only for ``"J:"``
+    sees a ``\\\\LINXIAOYUN`` key it doesn't recognise and the per-device
+    worker count regresses 8→4. CI never hit this (no mapped drives there),
+    so the suite passed in CI but failed on the dev machine in full-file runs.
 
-    On a dev machine where a test drive letter (e.g. ``J:``) is a live NAS
-    mapping, the real UNC call leaks the actual server (``\\\\LINXIAOYUN``) into
-    the bucket key; likewise the real volume call leaks a local drive's
-    ``{GUID}`` instead of the bare letter. Either memo persists across tests, so
-    the suite passes in CI (no mapped drives, Linux has no Win32) but fails on
-    the dev machine in full-file runs (the PR #578 failure mode).
-
-    Force BOTH default resolvers to a no-op and clear BOTH caches around every
-    test, so grouping resolves to the bare drive letter — matching CI. Tests that
-    exercise the resolution logic itself inject their own resolver via
-    ``device_key(unc_resolver=...)`` / ``device_key(guid_resolver=...)`` and are
-    unaffected by this patch.
+    Force the default resolver to a no-op and clear the cache around every
+    test, so grouping resolves to the bare drive letter — matching CI. Tests
+    that exercise the resolution logic itself inject their own resolver via
+    ``device_key(unc_resolver=...)`` and are unaffected by this patch.
     """
     import scanner.workers as _workers
 
     _workers._unc_cache.clear()
-    _workers._volid_cache.clear()
     monkeypatch.setattr(_workers, "_resolve_unc_via_win32", lambda letter: None)
-    monkeypatch.setattr(_workers, "_resolve_volume_id_via_win32", lambda letter: None)
     yield
     _workers._unc_cache.clear()
-    _workers._volid_cache.clear()

--- a/tests/test_scanner_workers.py
+++ b/tests/test_scanner_workers.py
@@ -93,15 +93,10 @@ def test_device_key_drive_letter_uppercased(monkeypatch):
 
     monkeypatch.setattr(wm, "is_remote_drive", lambda p: False)
     wm._unc_cache.clear()
-    wm._volid_cache.clear()
 
-    # guid_resolver returning None forces the #583 fail-open fallback to the
-    # bare letter, so the assertion is deterministic on any platform (without it
-    # a Windows dev box would resolve C:/D: to their real volume {GUID}). The
-    # GUID success path is covered by test_device_key_local_volume_id_* below.
-    assert wm.device_key(r"D:\photos\a.jpg", guid_resolver=lambda _l: None) == "D:"
-    assert wm.device_key(r"d:\photos\b.jpg", guid_resolver=lambda _l: None) == "D:"
-    assert wm.device_key(r"J:\nas\c.heic", guid_resolver=lambda _l: None) == "J:"
+    assert wm.device_key(r"D:\photos\a.jpg") == "D:"
+    assert wm.device_key(r"d:\photos\b.jpg") == "D:"
+    assert wm.device_key(r"J:\nas\c.heic") == "J:"
 
 
 @pytest.mark.skipif(sys.platform != "win32", reason="UNC splitdrive is Windows-only")
@@ -328,97 +323,9 @@ def test_device_key_local_drive_unchanged(monkeypatch):
 
     monkeypatch.setattr(wm, "is_remote_drive", lambda p: False)
     wm._unc_cache.clear()
-    wm._volid_cache.clear()
 
-    # guid_resolver None → #583 fail-open to the bare letter (deterministic on
-    # Windows too; the GUID success path has its own test below).
-    assert wm.device_key("C:\\Users\\J\\photos\\a.jpg", guid_resolver=lambda _l: None) == "C:"
-    assert wm.device_key(r"c:\documents\b.jpg", guid_resolver=lambda _l: None) == "C:"
-
-
-def test_device_key_local_volume_id_success(monkeypatch):
-    """#583 — a local fixed-disk letter resolves to its durable volume {GUID}
-    so a re-lettered or swapped disk can't inherit the wrong cached read-knee.
-    The injected guid_resolver stands in for the Win32 boundary.
-    """
-    from scanner import workers as wm
-
-    monkeypatch.setattr(wm, "is_remote_drive", lambda p: False)
-    wm._unc_cache.clear()
-    wm._volid_cache.clear()
-
-    key = wm.device_key(r"D:\photos\a.jpg", guid_resolver=lambda _l: "{VOL-ABC}")
-    assert key == "{VOL-ABC}"
-    # The {GUID} token must NOT look remote, or NAS-mix detection / pool sizing
-    # would misclassify the local disk (the ship-blocker the normalisation fixes).
-    assert wm.is_remote_drive(key) is False
-
-
-def test_device_key_volume_id_memoized(monkeypatch):
-    """The volume-GUID resolver is called at most once per distinct letter —
-    device_key runs in several per-record loops.
-    """
-    from scanner import workers as wm
-
-    monkeypatch.setattr(wm, "is_remote_drive", lambda p: False)
-    wm._unc_cache.clear()
-    wm._volid_cache.clear()
-
-    calls = {"n": 0}
-
-    def _counting(_letter):
-        calls["n"] += 1
-        return "{VOL-XYZ}"
-
-    k1 = wm.device_key(r"D:\a.jpg", guid_resolver=_counting)
-    k2 = wm.device_key(r"D:\b.jpg", guid_resolver=_counting)
-    assert k1 == k2 == "{VOL-XYZ}"
-    assert calls["n"] == 1  # second call hit _volid_cache
-
-
-def test_device_key_volume_id_fail_open(monkeypatch):
-    """A None result OR a raising volume-GUID resolver falls back to the bare
-    letter — device_key must never raise (#583 fail-open contract).
-    """
-    from scanner import workers as wm
-
-    monkeypatch.setattr(wm, "is_remote_drive", lambda p: False)
-    wm._unc_cache.clear()
-
-    wm._volid_cache.clear()
-    assert wm.device_key(r"D:\a.jpg", guid_resolver=lambda _l: None) == "D:"
-
-    wm._volid_cache.clear()
-
-    def _raises(_letter):
-        raise OSError("volume probe failed")
-
-    assert wm.device_key(r"D:\a.jpg", guid_resolver=_raises) == "D:"
-
-
-def test_device_key_remote_skips_volume_id(monkeypatch):
-    """A remote drive letter resolves to its UNC server key and NEVER consults
-    the volume-GUID resolver (a remote share has no local volume identity).
-    """
-    from scanner import workers as wm
-
-    monkeypatch.setattr(wm, "is_remote_drive", lambda p: str(p).upper() == "H:")
-    wm._unc_cache.clear()
-    wm._volid_cache.clear()
-
-    guid_calls = {"n": 0}
-
-    def _guid(_letter):
-        guid_calls["n"] += 1
-        return "{SHOULD-NOT-BE-USED}"
-
-    key = wm.device_key(
-        "H:\\photos\\a.jpg",
-        unc_resolver=lambda l: "\\\\LINXIAOYUN\\home",
-        guid_resolver=_guid,
-    )
-    assert key == "\\\\LINXIAOYUN"
-    assert guid_calls["n"] == 0  # remote path short-circuits before the GUID block
+    assert wm.device_key("C:\\Users\\J\\photos\\a.jpg") == "C:"
+    assert wm.device_key(r"c:\documents\b.jpg") == "C:"
 
 
 def test_device_key_resolver_cache_hit(monkeypatch):


### PR DESCRIPTION
## What
Reverts PR #605 / commit 77326a8 (#583, "key local devices by durable volume GUID for read-knee cache").

## Why — it's a confirmed regression
#605 changed a LOCAL drive's `device_key` from `"D:"` to its volume `"{GUID}"`. But `scan_worker.py:1187` sizes each device's reader pool as `hash_workers_for_root(device_key)`, and `disk_incurs_seek_penalty` only recognises a 2-char `"X:"` drive letter — given a `"{GUID}"` it returns `None` → falls back to the SSD default (4 readers) instead of the spinning-HDD cap of **1**.

Confirmed on the real machine: `hash_workers_for_root(device_key("D:\..."))` returned **4** (post-#605) vs **1** (correct). On a real spinning HDD that is 4-way seek-thrash → ~20 MB/s instead of ~120 MB/s. The `device_key` was silently doubling as both the bucket key AND the seek-detection root; they were equal (`"D:"`) for local drives by coincidence, and #583 changed the first without realising the second depended on it being a drive letter.

After revert (verified live): `device_key("D:\...")` = `"D:"` → `hash_workers_for_root` = **1**. Full suite: 2105 passed / 3 skipped.

## Why revert (not patch)
The durable-identity feature is low-value (it protected the read-knee autotune cache, and the autotune's real-world benefit is itself now unverified — the #604 A/B that assessed it ran on THIS broken code). Reverting restores known-good behaviour at zero risk; re-doing #583 correctly (size the pool from the real drive root, not the device_key) can be reconsidered later if the durable identity is ever actually needed.

Refs #583, #605. The seek-detection-from-device_key coupling + the #604 confound are being re-audited separately.

[docs-not-needed: revert restores the pre-#605 state; no user-visible behaviour or doc change.]
[qa-not-needed: scanner-internal; restored behaviour is covered by the existing per-device worker-count unit tests.]
