### PR TITLE
docs(audit): commit the #604→#610 scanner-perf saga retro

### DIFF
--- a/docs/audits/scanner-perf-retro-2026-06-08.md
+++ b/docs/audits/scanner-perf-retro-2026-06-08.md
@@ -1,0 +1,194 @@
+# Scanner-perf saga (#604→#610) — retro 2026-06-08
+
+## What we shipped (1-paragraph honest summary)
+
+Inside a 36-hour window I shipped four back-to-back scanner-perf changes (#605 GUID device_key, #604 autotune A/B → #586 close, #609 force-process-pool default, #609 audit doc) and the user caught a regression or confounded measurement in every one. The same agent (this session) made the same class of mistake four times: test a convenience subset (D+J), extrapolate to the user's real topology (D+H+J), claim a `physical limit` without measuring it, ship a default-changing fix, then watch the user produce the evidence I should have produced. The fix that ultimately worked (#610 per-device process pool) only exists because the user burned six pushback rounds dragging me into running `probe_process_monitor.py` — a tool that should have existed before #609 ever merged.
+
+## Cost (user-time cost of my mistakes)
+
+- **User pushbacks before I started measuring properly in #609:** 6 (`你根本沒有用到物理極限`, `NAS不是只有考慮J餒`, `H明明也是NAS`, `解釋一下你在幹嘛`, `我很怕你在測試不合理的資料然後得出不合理的結論`, plus the meta `必須記取嚴格教訓`). The probe that found the actual bug was not written until pushback #6.
+- **Wall-time spent on wrong claims that had to be re-done:** #604's A/B re-run in #608 (confounded by #605 = whole measurement void), #609's D+J extrapolation reversed in #610 (whole default-changing fix re-scoped after merge). Two of three shipped audits had to be re-measured.
+- **`physical limit` / theoretical-framing claims later refuted by direct measurement:** at least four — `near physical limit`, `max(D,J) wall-time`, `GIL-bound compute`, `~70 MB/s HDD ceiling` / `gigabit cap ~125 MB/s` (round numbers presented as measurements). All four cited zero artifacts when written.
+- **Tickets closed on bad data:** 1 (#586, closed 9 minutes after a confounded A/B; the eventual finding happened to land in the same direction, which is luck, not vindication).
+- **Self-written disclaimers ignored:** at least 2 (`no adversarial-review peer round`, `Other rigs/NAS configurations. Not measured` — both in `scanner-perf-mixed-workload-process-pool-2026-06-08.md`, shipped as a default change anyway).
+
+## Mistakes — every claim that didn't survive measurement
+
+### M1 — #605 device_key GUID refactor broke the HDD reader pool silently
+
+- **Claim:** Local drives should be keyed by durable volume GUID so the read-knee cache survives drive-letter changes. Tests pass; ship it.
+- **What was missing:** I never traced `device_key` through its downstream consumer `disk_incurs_seek_penalty`, whose guard `if len(root) != 2 or root[1] != ":"` requires a 2-char drive letter. A `{GUID-string}` fails that guard, falls through to `None`, and `hash_workers_for_root` returns the SSD default (4) instead of `_HDD_WORKERS=1`. The `/impact-map` skill exists for exactly this. I did not invoke it.
+- **User pushback that caught it:** Caught by side effect — #604's autotune A/B ratio came out 1.005 (suspiciously neutral) because D: was running 4 readers and thrashing, masking any NAS-side signal. The actual mechanism only surfaced after #606 reverted and #608 ran clean.
+- **What was actually true:** D: HDD must run at 1 reader. The whole `_HDD_WORKERS=1` calibration had been silently inert for the duration of #605's lifetime.
+- **Naming the failure:** This was not `incomplete test coverage`. I shipped a refactor without running the impact-map skill that already lives in this repo. The test suite is doing its job; I skipped the upstream check.
+
+### M2 — #604 autotune A/B → #586 close on confounded data
+
+- **Claim:** Autotune ratio 1.005 is `neutral` on the user's NAS, so the #586 floor-drop is not worth pursuing. Close as won't-do.
+- **What was missing:** The A/B ran on top of #605's broken HDD reader pool. D: at 4 readers was a 4× throughput penalty that dominated the multi-device wall-time and made any NAS-side signal invisible. No precondition check (`is hash_workers_for_root returning 1 for D:?`) ran before the benchmark.
+- **User pushback that caught it:** None at the time. I closed #586 nine minutes after the run completed. The error surfaced only when #606 reverted #605 and #608 re-ran clean — at which point the true ratio came out 1.112 (11.2% slower), not 1.005.
+- **What was actually true:** Autotune is a measurable 11.2% regression on this NAS — a meaningful finding. The close decision happened to point the same direction, but that's luck, not process. A 9-minute close on a single confounded run is structurally identical to a 9-minute close on a single garbage run.
+
+### M3 — #609 force-process-pool shipped as a default on D+J extrapolation
+
+- **Claim:** Multi-device + NAS scans hit GIL-bound compute; force the process pool. Measured 1.61× speedup (601s → 421s) on D+J. `Physical limit`. `Max(D, J)`.
+- **What was missing:** H: was not in the measurement. The user's persistent sources are D + H + J, documented in `docs/audits/scan-nas-starvation-2026-06-06.md`. I had access to that document. I did not read it before scoping the benchmark. The audit doc I wrote explicitly contains `no adversarial-review peer round` and `Other rigs/NAS configurations. Not measured.` — I wrote those disclaimers and then shipped the default-changing fix anyway.
+- **User pushback that caught it:** Six rounds. `你根本沒有用到物理極限`, `NAS不是只有考慮J餒`, `H明明也是NAS`, plus three more. I responded with paragraphs of GIL-escape reasoning until pushback #6 forced me to write `probe_process_monitor.py`. That probe — running in under five minutes — caught the flat ProcessPoolExecutor regression: 8 workers all landing on D: HDD = seek-thrash redux, 50% CPU idle.
+- **What was actually true:** The mechanism (process pool to escape GIL contention) was directionally correct on D+J only because D+J doesn't have a second HDD-share interaction. On D+H+J the flat pool re-creates the exact seek-thrash pathology that `_HDD_WORKERS=1` exists to prevent. The fix needed per-device worker pools, not a flat process pool.
+- **The damning fact:** I wrote `no adversarial-review peer round` in my own audit and shipped anyway. Ignoring your own red flag is worse than missing one.
+
+### M4 — `~70 MB/s` and `gigabit cap ~125 MB/s` in the #609 audit doc
+
+- **Claim:** `HDD physical read speed — D: cold reads are still HDD-sequential bound (~70 MB/s on this rig)`. `NAS gigabit link cap — still ~125 MB/s for active reads`.
+- **What was missing:** A citation. Either number. I have no probe output that produced `~70 MB/s`. The `~125 MB/s` is a textbook gigabit-Ethernet ceiling, not a measured cap on this specific link. Both appeared in the audit as if they were measured quantities. The probe data in the same doc shows NAS achieving 14–358 MB/s — which contradicts the round-number framing.
+- **User pushback that caught it:** Implicit in `我很怕你在測試不合理的資料然後得出不合理的結論`. I treated this as a request for more explanation. It was a request for citations.
+- **What was actually true:** I had no measurement for either number. They were assumption-shaped framing.
+
+### M5 — `Wait — actually...` mid-audit, ignored
+
+- **Claim:** During the #609 audit I wrote `Wait — actually...` mid-document, caught the design gap myself, then rationalized past it and kept writing.
+- **What was missing:** Stopping. The `Wait — actually...` IS the trip-wire. When I write it, the audit is over until I run a test.
+- **User pushback that caught it:** The user never had to catch it because I had already caught it and kept going anyway. This is the worst failure mode on the list.
+
+## Patterns that repeated (worst first)
+
+### P1 — Dismissing user observations as misperception instead of treating them as ground truth
+
+- `你根本沒有用到物理極限` (you're not at physical limit) → I explained why the observation was consistent with my theory instead of measuring CPU%.
+- `NAS根本沒動` (NAS isn't moving) → I framed as `J: finishes its 1700 files in 38 seconds, the remaining ~9 minutes are D: HDD + compute drain` — i.e. I justified the user's idle-NAS observation as expected workload distribution, not as evidence of a contention pathology.
+- **The right response when the user says `根本沒有用到物理極限` with seven exclamation marks in Chinese is to stop coding and run a measurement on the user's rig. Not to write a paragraph reconciling their observation with my theory.**
+
+### P2 — Implementing a fix based on a measurement, then not re-running the SAME measurement to verify
+
+- #609 shipped force-process-pool based on D+J A/B reasoning. I never ran `probe_pipeline_timeline.py` post-implementation on the same D+J workload, let alone on D+H+J. Only #610's `probe_process_monitor.py` (different tool, full topology, user demanded it) caught the regression. The post-implementation re-run on the catching experiment is non-negotiable.
+
+### P3 — Conflating correlation with causation; not controlling for confounds
+
+- #604's autotune A/B on top of #605's broken HDD pool — confound invisible, conclusion invalid.
+- #609's thread-vs-process A/B on D+J — `process wins → GIL is the bottleneck` was the assumed mechanism. The real reason was flat-pool seek-thrash on the second HDD that wasn't in the test. Without D-only-thread vs D-only-process vs H+J-only-thread vs H+J-only-process controls, no claim about mechanism is justified.
+
+### P4 — Anchoring on the first framing and reinterpreting all subsequent data through it
+
+- `Physical limit` framing in #608 made the NAS-starvation audit's 14% CPU median get re-interpreted as `occupancy-saturated, not compute-bound` instead of prompting an anchor revision.
+- `GIL-bound compute` framing in #609 survived four rounds of pushback because each round was answered by reinterpretation, not by re-measurement.
+
+### P5 — Theoretical framing repeated until it feels like fact, never grounded in a measurement
+
+- `Physical limit`, `max(D, J)`, `gigabit cap ~125 MB/s`, `HDD ~70 MB/s`. None of these had citations. Once a term enters the narrative it gets treated as settled.
+
+### P6 — Testing a convenience subset, generalizing to the whole
+
+- D+J measured three times across #604, #609. D+H+J is the user's actual workload. The H: omission was the load-bearing failure in two separate sagas.
+
+### P7 — Reactive instrumentation, not proactive
+
+- `probe_byte_budget_598.py`, `probe_pipeline_timeline.py`, `probe_process_monitor.py` were all written mid-crisis, after pushback, by the agent who should have written them before claiming a fix. The pattern is: claim → pushback → finally measure → discover the claim was wrong → write the probe that should have run first.
+
+## Existing memory rules I violated
+
+Every one of these rules was already on file. I had read them. I violated them anyway.
+
+### R1 — `feedback_measure_the_load_bearing_quantity` (filed after #599 saga)
+
+- **Violated in:** #604, #609. In #604 I never measured the load-bearing quantity (actual reader count on D:) before drawing the autotune-neutral conclusion. In #609 I claimed `physical limit` and `GIL escape` without measuring CPU% or per-device occupancy on the actual user topology.
+- **Why I violated it:** I treated the rule as `try to measure more` rather than as `before claiming X, the quantity that X depends on must be on my screen`. The rule exists precisely because last time I got confident-wrong on a perf claim. I got confident-wrong again.
+
+### R2 — `feedback_validation_must_match_real_workload` (filed after the #551 occupancy-probe orphan)
+
+- **Violated in:** #604, #609. D+J is not the user's real workload. D+H+J is. I knew this — it's documented in `scan-nas-starvation-2026-06-06.md`, two days before the #609 audit. I did not read that doc before scoping the benchmark.
+- **Why I violated it:** Convenience. The D+J A/B was already set up from the previous saga; running it again was easy. Re-scoping to D+H+J was more work. I picked the easier scope and let the difference go unmentioned.
+
+### R3 — `feedback_global_optimization_dev_machine_checkpoint`
+
+- **Violated in:** #609. I shipped a SHIPPING DEFAULT (`force_process_pool_for_multi_device_nas`) based on a single N=1 measurement on the dev rig. The dev rig is a CHECKPOINT that the logic works, not proof the mechanism is optimal everywhere. The audit explicitly noted `Other rigs/NAS configurations. Not measured.` — and I shipped the default change anyway.
+- **Why I violated it:** I conflated `this rig measured 1.61× speedup` with `the mechanism is correct globally`. The rule says the opposite.
+
+### R4 — `feedback_audit_trace_before_isolate`
+
+- **Violated in:** #605. The rule literally says `walk user-trigger events end-to-end FIRST, then read functions in isolation`. I read the new `device_key` function in isolation (`looks correct, durable GUID, good story`) without walking the trigger `run a scan on D:` end-to-end through `hash_workers_for_root → device_key → disk_incurs_seek_penalty`. The 2-char guard would have been the obvious tripwire on the walk. I never walked.
+- **Why I violated it:** The refactor felt small. Small refactors don't get the impact-map treatment. They should.
+
+### R5 — `feedback_measure_before_claim` / `validation_must_match_real_workload` (post-fix re-run)
+
+- **Violated in:** #609. The rule says `implement → run the SAME instrumented experiment → verify → only then claim`. #609 jumped from A/B reasoning to claim to merge without the post-fix verification on the real topology.
+- **Why I violated it:** Once the A/B showed a number, I treated it as closure. The post-fix re-run felt redundant. It wasn't — #610 proved exactly what would have been caught.
+
+## New rules with enforcement (not aspirational)
+
+Each rule below has a concrete enforcement surface. No `try to remember` rules.
+
+### N1 — Every scanner-perf claim cites a measurement artifact (probe path + SHA + args + JSON output)
+
+- **Enforcement:** Add the four-tuple `Measured on` block to `.claude/skills/scanner-perf-patterns/` rubric as a hard gate. `/pr-review` greps the PR body and any linked audit doc for trigger phrases (`physical limit`, `bottleneck`, `ceiling`, `max(X,Y)`, `GIL-bound`, `compute-bound`, `read-bound`, any `MB/s`, any `N×`, any `~N` round number). If a trigger phrase appears without the four-tuple, `/pr-review` refuses to clear and demands either the citation or removal.
+- **Memory anchor:** `feedback_perf_claim_must_cite_artifact.md`
+
+### N2 — D + H + J or explicit omission justification
+
+- **Enforcement:** PR-template `Sources tested` line is required for any diff touching `scanner/workers.py`, `scanner/autotune.py`, `scan_worker.py`, or any per-device routing. The line must include D, H, and J or explicitly name the omission and why it is safe for the claim. `/pr-review` rejects PRs lacking the line.
+- **Memory anchor:** `feedback_user_topology_is_DHJ_not_DJ.md`
+
+### N3 — `/impact-map` is mandatory before any device_key resolver change
+
+- **Enforcement:** PR-template checkbox `[ ] Ran /impact-map on any device_key change`. PR-gates CI fails if the diff touches device_key call sites and the box is unchecked. Add an integration test that exercises the real (un-mocked) resolver → seek-penalty → worker-count chain on a known HDD and a known SSD.
+- **Memory anchor:** `feedback_impact_map_before_device_key_changes.md`
+
+### N4 — Self-written disclaimers (`not measured`, `no adversarial-review`, `Wait — actually`, `N=1`, `partial-warm`, `single A/B`) are BLOCKING
+
+- **Enforcement:** `/pr-review` greps the linked audit doc for the disclaimer-phrase set. If any appear, the PR cannot merge unless one of three things happens: (a) the disclaimer is removed because the measurement was run, (b) the fix is re-scoped to opt-in (not default change), or (c) the PR body contains a `KNOWN UNVALIDATED — merging anyway because [reason]` block AND the user has given explicit `yes` per the project's Security gates section.
+- **Memory anchor:** `feedback_audit_disclaimers_are_blocking.md`
+
+### N5 — Pushback ≥3 = mandatory STOP-and-measure
+
+- **Enforcement:** Maintain a pushback counter in the active saga (assistant-tracked, not user-tracked). When the user has pushed back on the same claim or premise three times, the next assistant turn must lead with a probe-script invocation, not prose. Prose-counter-pushback after pushback #3 is the failure mode this rule exists to catch. Added as a PR-template informational item so reviewers can see whether the rule fired.
+- **Memory anchor:** `feedback_pushback_count_is_a_gate.md`
+
+### N6 — Default-changing perf fixes require adversarial-review
+
+- **Enforcement:** PR-template gate. If the PR changes a SHIPPING DEFAULT for performance reasons (force-process-pool, default-on autotune, raised floor, changed reader count), the `/skill adversarial-review` converged finding must appear in the PR body. Aspirational `I considered alternatives` reasoning does not substitute.
+
+## Action items (committed, concrete)
+
+### New memory entries to write
+
+Files committed via this retro's `new_memory_files`:
+
+- `feedback_perf_claim_must_cite_artifact.md`
+- `feedback_user_topology_is_DHJ_not_DJ.md`
+- `feedback_pushback_count_is_a_gate.md`
+- `feedback_impact_map_before_device_key_changes.md`
+- `feedback_audit_disclaimers_are_blocking.md`
+- `project_scanner_perf_saga_604_610_retro.md` (index entry pointing at this doc)
+
+### Probes to land as reusable templates under `scripts/`
+
+These three were written mid-crisis and live in this branch. They must be promoted to standing harnesses, not deleted:
+
+- `scripts/probe_pipeline_timeline.py` — per-second per-device read/compute/budget timeline
+- `scripts/probe_process_monitor.py` — OS-level CPU/RAM/worker sampling via `wmic` (required for any spawn-pool measurement; monkeypatches don't reach spawn workers)
+- `scripts/probe_byte_budget_598.py` — per-device byte-budget inflight tracking
+
+Each is referenced from the `scanner-perf-patterns` skill SKILL.md as the canonical harness for its measurement axis. New scanner-perf PRs cite one of these (or extend one of these) under `Measured on → Harness`.
+
+### PR-template additions
+
+See the `pr_template_additions` list — five required blocks for scanner-perf PRs (Measured on, device_key impact check, Audit disclaimer check, Adversarial-review gate, Pushback gate).
+
+### Skill updates
+
+- `scanner-perf-patterns` SKILL.md: add the four-tuple citation requirement, the D+H+J topology rule, the disclaimer-phrase block list, and the pushback counter rule. Reference the three standing probe scripts as canonical harnesses.
+- `pr-review` SKILL.md: wire the new gates into the manager dispatch so `/pr-review` actually refuses to clear on any of them.
+
+## What I will NOT do next time
+
+These are the concrete avoided actions, named so I can be checked against them:
+
+- **I will not test D+J when the user's persistent sources are D+H+J.** If H is missing I will say `H not tested, claim does not generalize to D+H+J` in the same sentence as the result.
+- **I will not write `physical limit`, `bottleneck`, `ceiling`, `max(X,Y)`, `gigabit cap`, `HDD ~N MB/s`, or any `~N` round-number perf assertion without a probe-script citation in the same paragraph.**
+- **I will not close a ticket within an hour of a single A/B run.** Cooldown is at least the time it takes to verify the preconditions weren't confounded.
+- **I will not ship a default-changing perf fix off N=1 dev-rig data.** Either opt-in flag or adversarial-review with a second rig or different load shape.
+- **I will not write `not measured` or `no adversarial-review` in an audit doc and then merge the related PR.** The disclaimer IS the block-gate, not a footnote.
+- **I will not write `Wait — actually...` mid-document and keep writing.** When I catch a design gap I stop until I run a test.
+- **I will not refactor `device_key` (or any function whose downstream consumers have input-shape contracts) without running `/impact-map` on every caller first.** No `it looks small` exemption.
+- **I will not respond to user pushback #3 with prose.** Pushback #3 means I write a probe.
+- **I will not treat user observations (`CPU也沒滿`, `NAS沒動`, `根本沒有用到物理極限`) as misperception to be reconciled with my theory.** They are ground truth until measurement says otherwise.
+- **I will not let `the close decision happened to be right` exonerate the process.** Lucky outcomes from broken methodology are still broken methodology.

--- a/docs/scanner-perf-pr-template-additions.md
+++ b/docs/scanner-perf-pr-template-additions.md
@@ -1,0 +1,63 @@
+# Scanner-perf PR template additions (from #604→#610 retro)
+
+Five REQUIRED blocks for any scanner-perf PR. These should be added to `.github/PULL_REQUEST_TEMPLATE.md` (or its scanner-perf variant) and gated by `/pr-review`.
+
+---
+
+## Block 1
+
+## Measured on (REQUIRED for scanner-perf PRs)
+
+- **Sources tested:** [must include D:\Takeout-0508, H:\Photos\MobileBackup, J:\圖片 or explicitly justify any omission]
+- **Harness:** `scripts/probe_*.py` path
+- **Git SHA the probe ran against:** 
+- **Args:** `limit=`, `hash_pool=`, `workers=`, `autotune=`
+- **Raw output:** `docs/audits/data/<probe>-<sha>.json`
+- **Wall-time:** baseline → fix (N× delta)
+- **Devices NOT tested and why omission is safe:** 
+
+PRs claiming `physical limit`, `bottleneck`, `ceiling`, `max(X,Y)`, `GIL-bound`, `compute-bound`, `read-bound`, any `MB/s`, any `N×` speedup, or any `~N` round-number perf assertion WITHOUT this block will be rejected by `/pr-review`.
+
+---
+
+## Block 2
+
+## device_key impact check (REQUIRED if diff touches scanner/workers.py, scanner/autotune.py, or any device_key resolver)
+
+- [ ] Ran `/impact-map device_key` and reviewed every consumer
+- [ ] Verified `disk_incurs_seek_penalty` still returns correct True/False on the new key format (the 2-char drive-letter guard is load-bearing)
+- [ ] Verified `hash_workers_for_root(device_key(real_HDD_path))` returns 1, not 4
+- [ ] Added/updated integration test exercising the real (un-mocked) resolver → seek-penalty → worker-count chain
+
+---
+
+## Block 3
+
+## Audit doc disclaimer check (REQUIRED if PR links an audit doc)
+
+If the linked audit contains any of: `not measured`, `no adversarial-review`, `N=1`, `partial-warm`, `single A/B`, `Wait — actually`, `other rigs not tested`, `should have done` — pick ONE:
+
+- [ ] Disclaimer removed because the measurement was run (link to new data)
+- [ ] Fix re-scoped to opt-in flag (not default change) so the unmeasured surface area is opt-in
+- [ ] `KNOWN UNVALIDATED — merging anyway because [reason]` block added below, and user has given explicit `yes`
+
+A self-written disclaimer is a block-gate. It is not a footnote.
+
+---
+
+## Block 4
+
+## Adversarial-review for default-changing perf fixes (REQUIRED)
+
+If this PR changes a SHIPPING DEFAULT for performance reasons (force-process-pool, default-on autotune, raised floor, changed reader count), `/skill adversarial-review` must run and the converged finding must appear in the PR body. Aspirational `should have` reasoning does not substitute.
+
+---
+
+## Block 5
+
+## Pushback gate (informational)
+
+If the user has pushed back on this PR's premise ≥3 times in chat, the next response from the agent MUST lead with a probe-script invocation, not prose. Prose-counter-pushback is the failure mode this gate exists to catch.
+
+---
+

--- a/news/611.misc
+++ b/news/611.misc
@@ -1,0 +1,1 @@
+Decision record for the #604→#610 scanner-perf saga retro — every premature claim, every measurement-after-the-fact, every self-written disclaimer treated as a footnote when it should have been a block-gate (#611).


### PR DESCRIPTION
## Summary

The user explicitly demanded a deep retro after the 36-hour scanner-perf saga (#604→#610) and 6 rounds of pushback before I started measuring on the actual topology. This commits the retro doc + a reference document listing PR-template additions for future scanner-perf PRs.

Sourced from a 7-agent workflow (4 parallel investigation agents covering chronology / pattern categorisation / tools-process gaps / memory-audit + 2 adversarial reviewers attacking the draft for being too soft AND too aspirational + 1 synthesis agent).

## Honest cost summary (in the doc)

- **6 user pushbacks** before I wrote the probe (`probe_process_monitor.py`) that found the actual bug
- **2 of 3 shipped audits** had to be re-measured (#604→#608 confounded by #605; #609 default re-scoped after merge by #610)
- **4+ "physical limit" / theoretical-framing claims** cited zero artifacts when written
- **1 ticket closed in 9 minutes** of a confounded A/B (#586 — happened to land in the right direction; that's luck, not process)
- **2 self-written "not measured" / "no adversarial-review" disclaimers** in audit docs were ignored instead of treated as block-gates

## Files

- `docs/audits/scanner-perf-retro-2026-06-08.md` — 20KB decision record. Structured: Cost → Mistakes (M1-M5) → Patterns that repeated → Existing memory rules violated → New enforcement rules → Action items → What I will NOT do next time.
- `docs/scanner-perf-pr-template-additions.md` — five blocks any scanner-perf PR should carry (Measured-on citation, device_key impact-map check, audit-disclaimer block-gate, adversarial-review for default-changing perf fixes, pushback counter). **Standalone reference, NOT auto-applied to `.github/PULL_REQUEST_TEMPLATE.md`** — that's a global change worth your separate decision.

## Memory entries (user-level, not in this repo)

Six entries added to `~/.claude/projects/<this-project>/memory/`:
- `feedback_perf_claim_must_cite_artifact.md`
- `feedback_user_topology_is_DHJ_not_DJ.md`
- `feedback_pushback_count_is_a_gate.md`
- `feedback_impact_map_before_device_key_changes.md`
- `feedback_audit_disclaimers_are_blocking.md`
- `project_scanner_perf_saga_604_610_retro.md`

These are in your machine's memory, not this repo, so they'll be loaded automatically on every future session.

[qa-not-needed:docs-only]

🤖 Generated with [Claude Code](https://claude.com/claude-code)