### PR TITLE
fix(tree): refresh_model leaks prior proxy + model — root cause of #614 8-10 GB residency

### DIFF
--- a/app/views/components/tree_controller.py
+++ b/app/views/components/tree_controller.py
@@ -245,6 +245,11 @@ class TreeController:
         Args:
             groups: List of group objects to display in the tree
         """
+        # Capture prior refs before overwriting so we can schedule teardown
+        # after the new model is installed (#618).
+        old_proxy = getattr(self, '_proxy', None)
+        old_model = getattr(self, '_model', None)
+
         model, proxy = build_model(groups)
         if proxy is not None:
             proxy.setParent(self.tree)
@@ -257,6 +262,22 @@ class TreeController:
             self.tree.setModel(model)
             self._proxy = None
             self._model = model
+
+        # Tear down prior model+proxy AFTER setModel detached them from the view.
+        # Order: setSourceModel(None) first to sever the proxy→model reference,
+        # then setParent(None) to remove the proxy from self.tree's Qt children
+        # (without this the proxy stays in tree.children() until the tree is
+        # destroyed, keeping all ~163k QStandardItem alive — the #618 leak).
+        # deleteLater() defers the final C++ destruction to the next event-loop
+        # iteration, safely past any in-flight dataChanged / signal delivery.
+        # See feedback_qt_timer_teardown_uaf for the Qt UAF rationale.
+        # (#618 — root cause of #614's 8-10 GB residency).
+        if old_proxy is not None:
+            old_proxy.setSourceModel(None)
+            old_proxy.setParent(None)
+            old_proxy.deleteLater()
+        if old_model is not None and old_model is not model:
+            old_model.deleteLater()
 
         # Expand all first so content-based width accounts for children
         try:

--- a/news/619.bugfix
+++ b/news/619.bugfix
@@ -1,0 +1,1 @@
+TreeController.refresh_model now tears down the prior QStandardItemModel + QSortFilterProxyModel — fixes the ~250 MB/reload leak that caused 8-10 GB residency on close (#618, root cause of #614).

--- a/tests/test_tree_controller.py
+++ b/tests/test_tree_controller.py
@@ -556,3 +556,77 @@ class TestUpdateLockCells:
         controller, _vm = _build(qapp)
         # Group 0 has 2 members; index 99 is out of range.
         controller.update_lock_cells([(0, 99, True)])  # must not raise
+
+
+class TestRefreshModelTeardown:
+    """Each refresh_model call must release the previous proxy + model (#618).
+
+    Without explicit teardown, every reload leaks the entire prior tree state
+    to Qt's parent-child object tree — ~163k QStandardItem per typical 13k-row
+    reload, accumulating until app close (root cause of #614's 8-10 GB residency
+    report).
+
+    Assertion strategy: we use `tree.children()` membership as the primary
+    observable — if the old proxy remains in tree.children() after refresh, Qt's
+    parent-child relationship keeps it alive along with all its descendant items.
+    After the fix, setParent(None) removes the proxy from tree.children()
+    immediately (synchronous), then deleteLater() schedules the C++ destruction.
+    The PySide6 `destroyed` signal does not fire reliably for deleteLater() in
+    headless tests, so we do not use it here.
+    """
+
+    def test_old_proxy_removed_from_tree_children_after_refresh(self, qapp):
+        """The old proxy must NOT remain in tree.children() after refresh_model.
+
+        Without the #618 fix, old_proxy.setParent(self.tree) was never undone,
+        so every refresh added a new child but kept all prior proxies in
+        tree.children() forever — each proxy kept its full QStandardItemModel
+        alive.
+        """
+        controller, _ = _build(qapp)
+        first_proxy = controller._proxy
+        assert first_proxy is not None
+        assert first_proxy in controller.tree.children(), (
+            "pre-condition: newly built proxy must be a Qt child of the tree view"
+        )
+
+        new_groups = [
+            SimpleNamespace(group_number=99, items=[_rec("/photos/z.jpg")]),
+        ]
+        controller.refresh_model(new_groups)
+
+        assert first_proxy not in controller.tree.children(), (
+            "old proxy must be removed from tree.children() after refresh_model; "
+            "without the #618 fix the proxy lingers as a Qt child of the tree "
+            "view forever, keeping ~163k QStandardItems alive"
+        )
+        # The new proxy should now be in children.
+        assert controller._proxy in controller.tree.children()
+        assert controller._proxy is not first_proxy
+
+    def test_multiple_refreshes_only_current_proxy_in_tree_children(self, qapp):
+        """After N refreshes, exactly the current proxy (and no prior ones)
+        must be in tree.children() — guards against a partial fix where only
+        the first old proxy is removed."""
+        controller, _ = _build(qapp)
+
+        intermediate_proxies = []
+        for i in range(5):
+            intermediate_proxies.append(controller._proxy)
+            new_groups = [
+                SimpleNamespace(
+                    group_number=100 + i,
+                    items=[_rec(f"/photos/r{i}.jpg")],
+                ),
+            ]
+            controller.refresh_model(new_groups)
+
+        tree_children = controller.tree.children()
+        for idx, old_proxy in enumerate(intermediate_proxies):
+            assert old_proxy not in tree_children, (
+                f"intermediate proxy #{idx} from before refresh {idx+1} is "
+                f"still in tree.children() — that proxy keeps its entire "
+                f"QStandardItemModel subtree alive (the #618 leak)"
+            )
+        # Only the final current proxy should be a tree child.
+        assert controller._proxy in tree_children


### PR DESCRIPTION
## What

`TreeController.refresh_model` (`app/views/components/tree_controller.py:242-285`) leaked the entire prior `QStandardItemModel` + `QSortFilterProxyModel` on every call. Each call added the new proxy as a Qt child of `self.tree` via `proxy.setParent(self.tree)`, but never undid `setParent` on the prior proxy when installing the new one. Old proxies stayed in `self.tree.children()` forever, each keeping its `QStandardItemModel` alive via `setSourceModel()` — and the model held all ~163,680 `QStandardItem` objects per typical 13k-row manifest reload.

## Why

Root cause of #614's "8-10 GB on close" memory residency report.

Probe measurement on a 13k-row fixture × 3 in-process reloads:

| Metric | Slope per reload |
|---|---|
| `QStandardItem` count (gc + Qt destroyed signal) | **+163,680** (Qt counter confirms zero are released) |
| RSS | **+250 MB** |
| Private bytes | **+259 MB** |
| `tracemalloc` total | only **+20 MB** (Python heap is fine) |
| `PhotoRecord` count | **0** (Python GC works correctly) |

The Qt-heap allocation counter (tracemalloc is blind to Qt C++ heap) was the decisive measurement — it showed the leak is in Qt's parent-child object tree, not in Python.

`refresh_model` fires on: manifest open / reload, scan completion, `set_decision_by_regex` (per #613 scope boundary), `remove_from_list` family, type-filter combo change in Execute Action dialog, language-switch reload. A typical session = 5-10 invocations → 1.5-3 GB. Multi-manifest power-user sessions match the user's 8-10 GB observation.

## How

Capture `_proxy` + `_model` before overwriting, then **after** the new model is installed:

1. `old_proxy.setSourceModel(None)` — sever the proxy → model retainer.
2. `old_proxy.setParent(None)` — **synchronously** remove from `self.tree.children()`. This is the step that actually fixes the leak; the proxy must be detached from the Qt parent-child tree.
3. `old_proxy.deleteLater()` — defer final C++ destruction to next event-loop iteration, safely past any in-flight `dataChanged` / signal delivery (per `feedback_qt_timer_teardown_uaf`).
4. `old_model.deleteLater()` if `old_model is not model` (no-op for the proxy-less branch where the bare model is reused).

### Regression tests

`tests/test_tree_controller.py::TestRefreshModelTeardown` — 2 new tests:

- **`test_old_proxy_removed_from_tree_children_after_refresh`**: assert the prior `_proxy` is not in `tree.children()` after `refresh_model(new_groups)`.
- **`test_multiple_refreshes_only_current_proxy_in_tree_children`**: after 5 refreshes, none of the 5 intermediate proxies remain in `tree.children()` — guards against a partial fix.

**Assertion strategy** — `tree.children()` membership, not `QObject.destroyed` signal. Diagnostic round during dev found PySide6's `destroyed` slot does NOT fire reliably for `deleteLater()` in headless tests (known PySide6/SIP behaviour where the Python slot never fires when C++ deletion is deferred). `tree.children()` is synchronous and is the *actual* observable that proves the parent-child leak is severed. Both tests fail on the unpatched code and pass on the patched code (verified).

Per `feedback_no_test_padding` — these tests catch a real bug. They're not monkeypatching internals; `tree.children()` is the Qt contract.

## Related

- **#614** — original residency report. This is the root cause; #614 stays open as the diagnostic-probe tracking issue (the probe scaffolding lives on a separate worktree branch and can ship as a regression-guard PR if desired).
- **#616** — re-classified as OPT path (not BUG). `slots` / drop-`PATH_ROLE` / `LRU.clear()` / `worker.deleteLater` are per-instance size optimizations; they don't fix this retention chain. Re-prioritize after this lands.
- **#613 / PR #617** — orthogonal. The path index + incremental refresh stay untouched; `refresh_model` is still called on legitimate full-rebuild paths (manifest load, regex apply, etc.).

## Test plan

- [x] `pytest tests/test_tree_controller.py -v` — 36 passed (34 existing + 2 new)
- [x] `pytest tests/ --ignore=integration -x -q` — 2124 passed, 2 skipped, coverage 89.73%
- [ ] Manual smoke (post-merge): rerun the #614 probe on master with real ~20 MB user manifest, confirm `QStandardItem` count is FLAT across reloads.

[qa-not-needed: pure Qt object lifecycle fix; no user-visible behaviour change — leak severed, no new gating / no button / no dialog. Layer-3 scenarios already exercise refresh_model on every manifest load + every scan; any selection-handler / sort-state regression would surface there. The new unit tests are the canonical guard for the parent-child leak invariant.]

Closes #618
Refs #614
