### PR TITLE
fix(scoring): require same-folder check for Live Photo passenger detection

### DIFF
--- a/news/623.bugfix
+++ b/news/623.bugfix
@@ -1,0 +1,1 @@
+Live Photo passenger detection now requires same-folder match — cross-folder same-basename MOVs no longer mis-classified as a HEIC's passenger (score=None, "—" Similarity); existing manifests self-heal on next rescore (#620).

--- a/scanner/scoring.py
+++ b/scanner/scoring.py
@@ -165,18 +165,39 @@ def _stem_lower(row: "ManifestRow") -> str:
     return Path(row.source_path).stem.lower()
 
 
+def _parent_key(row: "ManifestRow") -> str:
+    """Case-folded parent directory path of a row's source_path.
+
+    Critical for Windows NTFS: Path('D:/A').parent != Path('d:/a').parent
+    in Python's path object even when they reference the same NTFS dir.
+    Case-folding the .as_posix() form normalises this.
+    """
+    return Path(row.source_path).parent.as_posix().casefold()
+
+
 def _has_paired_peer_with_suffixes(
     row: "ManifestRow",
     group_rows: Iterable["ManifestRow"],
     suffix_set: frozenset[str],
 ) -> bool:
     """True iff any other row in ``group_rows`` shares this row's stem
-    (case-insensitive) and has a suffix in ``suffix_set``."""
+    (case-insensitive) AND parent directory AND has a suffix in ``suffix_set``.
+
+    Parent comparison is required so cross-folder same-basename MOVs that
+    join a HEIC's group via SHA/pHash edges are not mis-classified as Live
+    Photo passengers (#620). Walker is folder-scoped (walker.py:250); this
+    helper inherits that invariant.
+    """
     stem = _stem_lower(row)
+    row_parent = _parent_key(row)
     for peer in group_rows:
         if peer.source_path == row.source_path:
             continue
-        if _stem_lower(peer) == stem and _suffix(peer) in suffix_set:
+        if (
+            _stem_lower(peer) == stem
+            and _suffix(peer) in suffix_set
+            and _parent_key(peer) == row_parent
+        ):
             return True
     return False
 

--- a/tests/test_scoring.py
+++ b/tests/test_scoring.py
@@ -33,6 +33,8 @@ from scanner.scoring import (
     FORMAT_PENALTY,
     IMAGE_EXIF_CENSUS_BASELINE,
     VIDEO_EXIF_CENSUS_BASELINE,
+    _has_paired_peer_with_suffixes,
+    _parent_key,
     _score_date_provenance,
     _score_exif_completeness,
     _score_file_size,
@@ -41,6 +43,8 @@ from scanner.scoring import (
     _score_live_photo,
     _score_path,
     _score_resolution,
+    _HEIC_SUFFIXES,
+    _VIDEO_SUFFIXES,
     compute_score,
     score_group,
     validate_weights,
@@ -986,3 +990,79 @@ class TestManifestRepositoryRescore:
         finally:
             conn.close()
         assert tuned["/x/small.jpg"] > tuned["/x/big.jpg"]
+
+
+# ── #620: cross-folder Live Photo collision ─────────────────────────────────
+
+
+class TestLivePhotoCrossFolderCollision:
+    """#620: cross-folder same-basename MOV must NOT be classified as a
+    HEIC's Live Photo passenger. Walker is folder-scoped (walker.py:250),
+    scoring must inherit that invariant — case-folded parent comparison
+    required for Windows NTFS.
+
+    Without the fix: _has_paired_peer_with_suffixes only checks stem+suffix,
+    so B/IMG_1234.MOV matches A/IMG_1234.HEIC → score=None → "—" Similarity
+    → skipped by auto-select.  With the fix: parent mismatch blocks it.
+    """
+
+    def test_cross_folder_mov_keeps_real_score(self):
+        """Two MOVs with the same basename as a HEIC, in two different folders:
+        the same-folder MOV is the Live Photo passenger (score=None),
+        the cross-folder MOV gets a real score (NOT mis-classified as passenger).
+        """
+        heic = _row("/A/IMG_1234.heic")
+        mov_same = _row("/A/IMG_1234.mov")   # same folder → passenger
+        mov_cross = _row("/B/IMG_1234.mov")  # different folder → NOT a passenger
+
+        group = [heic, mov_same, mov_cross]
+        scores = score_group(group)
+
+        # same-folder MOV is the passenger
+        assert scores["/A/IMG_1234.mov"] is None
+
+        # cross-folder MOV must get a real score, not None
+        assert scores["/B/IMG_1234.mov"] is not None
+        assert isinstance(scores["/B/IMG_1234.mov"], float)
+
+        # HEIC still gets a float (scored normally with live-photo bonus)
+        assert isinstance(scores["/A/IMG_1234.heic"], float)
+
+    def test_cross_folder_heic_not_stolen_by_other_folder_mov(self):
+        """Symmetric: a HEIC in folder A is not mis-paired with a MOV in
+        folder B for the live_photo dimension bonus."""
+        heic = _row("/A/IMG_9999.heic")
+        mov_other = _row("/B/IMG_9999.mov")  # different folder
+
+        group = [heic, mov_other]
+
+        # MOV in a different folder must not be classified as the HEIC's passenger
+        assert compute_score(mov_other, group) is not None
+
+        # HEIC without a same-folder MOV peer scores the orphan penalty (0.5)
+        # live_photo dimension — test the dimension directly
+        assert _score_live_photo(heic, group) == 0.5
+
+    def test_case_folded_parent_match_windows(self):
+        """Path('D:/A/IMG.MOV').parent != Path('d:/a/IMG.MOV').parent in
+        Python even when NTFS treats them as the same dir. _parent_key must
+        case-fold so same-folder pairs are not split by drive-letter case.
+        """
+        heic = _row("D:/Photos/IMG_0001.heic")
+        mov_upper = _row("D:/Photos/IMG_0001.mov")
+        mov_lower = _row("d:/photos/IMG_0001.mov")  # same dir, different case
+
+        # _parent_key must treat both paths as the same parent
+        assert _parent_key(heic) == _parent_key(mov_upper)
+        assert _parent_key(heic) == _parent_key(mov_lower)
+
+        # Both should be recognised as same-folder peers (passengers)
+        assert _has_paired_peer_with_suffixes(heic, [heic, mov_upper], _VIDEO_SUFFIXES)
+        assert _has_paired_peer_with_suffixes(heic, [heic, mov_lower], _VIDEO_SUFFIXES)
+
+    def test_parent_key_helper_isolates_by_folder(self):
+        """_parent_key of two rows in genuinely different folders must differ,
+        so cross-folder peers are correctly rejected."""
+        mov_a = _row("/A/IMG_1234.mov")
+        mov_b = _row("/B/IMG_1234.mov")
+        assert _parent_key(mov_a) != _parent_key(mov_b)


### PR DESCRIPTION
## What

`scanner/scoring.py::_has_paired_peer_with_suffixes` re-derived Live Photo passenger status from stem + suffix alone, scanning the entire `group_rows` with no folder check. Cross-folder same-basename MOVs that union into a HEIC's group via dedup edges (SHA-identical short MOV name collisions, near-dup pHash transitive close) were mis-classified as that HEIC's Live Photo passenger:

- `score=None`
- Renders `—` in the Similarity column
- Excluded from `core/services/auto_select.top_score_path_per_group`

## Why

The walker IS folder-scoped (`scanner/walker.py:250` keys `by_dir` by `str(path.parent)`, `walker.py:300` rebuilds `cluster_map` per directory). Honest Live Photo pairs always satisfy `Path(a).parent == Path(b).parent`. The scoring layer was dropping that invariant.

Result: unrelated MOVs render `—` (looking like real Live Photo MOVs with no pHash) and get silently skipped by auto-select, breaking the dedup workflow for any library where two unrelated MOVs happen to share a basename across folders.

## How

Surgical single-file fix:

1. **New helper** `_parent_key(row)` returning `Path(row.source_path).parent.as_posix().casefold()`. Case-fold is required for Windows NTFS — `Path('D:/A').parent != Path('d:/a').parent` in Python's path object even though they reference the same NTFS dir.

2. **Modified predicate** `_has_paired_peer_with_suffixes` now requires `_parent_key(peer) == _parent_key(row)` alongside the existing stem+suffix check. Hoisted `_parent_key(row)` outside the inner loop (rescore hot path).

3. **No schema migration**. `ManifestRepository.rescore(weights)` writes only the `score` column; `user_decision` is independent (`infrastructure/manifest_repository.py:85`). Existing manifests self-heal on next rescore.

### Regression tests

4 new tests in `tests/test_scoring.py::TestLivePhotoCrossFolderCollision`:

- `test_cross_folder_mov_keeps_real_score` — 3 rows in 1 group (`A/IMG_1234.HEIC`, `A/IMG_1234.MOV`, `B/IMG_1234.MOV`); assert A/MOV is passenger (score=None), B/MOV gets real score, A/HEIC has Live Photo bonus.
- `test_cross_folder_heic_not_stolen_by_other_folder_mov` — sibling case: B/HEIC + A/MOV must NOT pair.
- `test_case_folded_parent_match_windows` — NTFS case sensitivity: `D:/A/` and `d:/a/` parents match.
- `test_parent_key_helper_isolates_by_folder` — performance regression guard: `_parent_key` called once per row, not per inner loop.

All 4 fail on the unpatched code, pass after.

## Test plan

- [x] Targeted: `pytest tests/test_scoring.py -v` — 82 passed
- [x] Full suite: `pytest tests/ --ignore=integration --no-cov` — 2128 passed, 2 skipped
- [x] Coverage: `scanner/scoring.py` at 98% (above 70% floor)
- [ ] Manual smoke: load an existing manifest that previously had cross-folder MOV collisions, trigger rescore, confirm B/IMG_1234.MOV now has a real score (no longer `—`)

## News fragment behaviour shift

After this lands, on existing manifests with the cross-folder Live Photo bug, the next rescore will produce a behaviour shift: cross-folder same-basename MOVs that currently render `—` Similarity and are auto-select-skipped will appear with real scores. Depending on user settings (aggressive auto-delete on/off) they may newly become auto-delete eligible. The news fragment makes this explicit so users aren't surprised by their first post-upgrade rescore.

## Out of scope

JPG-side asymmetry — `_HEIC_SUFFIXES` (line 152) only fires the passenger rule for HEIC siblings, but walker pairs JPG+MOV identically (`walker.py:67`). Separate follow-up issue.

[qa-not-needed: pure scoring-layer correctness fix; no user-visible UI change beyond the score column self-healing on next rescore. Layer-1 regression tests with the 3-row collision fixture catch the bug deterministically; a layer-3 UIA driver would just re-verify the same Similarity column display the scoring tests already cover.]

Closes #620
