### PR TITLE
feat(scripts): regression-guard memory probe — env-gated, default off

### DIFF
--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -323,7 +323,41 @@ class FileOperationsHandler:
     def _on_manifest_loaded(self, groups: list, path: str) -> None:
         self.vm.groups = groups
         self._manifest_path = path
+
+        # Point 3: vm.groups assigned; tree not yet rebuilt.
+        try:
+            from scripts.memory_probe import snapshot, _ENABLED  # type: ignore[import]
+            if _ENABLED:
+                n_groups = len(groups)
+                n_items = sum(len(getattr(g, "items", [])) for g in groups)
+                snapshot("vm_groups_assigned", point=3, n_groups=n_groups, n_items=n_items)
+        except ImportError:
+            pass
+
         self.ui_updater.refresh_tree(groups)
+
+        # Point 4: refresh_tree returned; Qt model is live.
+        try:
+            from scripts.memory_probe import snapshot as _snap4, _ENABLED as _en4, _active_timers  # type: ignore[import]
+            if _en4:
+                _snap4("after_refresh_model", point=4)
+                # Point 5: idle snapshot 5 seconds after the model rebuild.
+                from PySide6.QtCore import QTimer
+
+                def _fire_point5() -> None:
+                    try:
+                        from scripts.memory_probe import snapshot as _s5  # type: ignore[import]
+                        _s5("idle_5s", point=5)
+                    except ImportError:
+                        pass
+
+                _t5 = QTimer()
+                _t5.setSingleShot(True)
+                _t5.timeout.connect(_fire_point5)
+                _t5.start(5_000)
+                _active_timers.append(_t5)
+        except ImportError:
+            pass
         self.ui_updater.show_group_counts(self.vm.group_count)
         self.ui_updater.show_groups_summary(groups)
         self._set_manifest_actions_enabled(True)

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -100,6 +100,14 @@ class MainWindow(QMainWindow):
         # missing/corrupt blobs by leaving the defaults in place.
         self._restore_geometry()
 
+        # Point 1: MainWindow fully initialised — baseline before any manifest load.
+        try:
+            from scripts.memory_probe import snapshot, _ENABLED  # type: ignore[import]
+            if _ENABLED:
+                snapshot("mainwindow_init_done", point=1)
+        except ImportError:
+            pass
+
     # ------------------------------------------------------------------ window-state persistence
 
     # QSettings keys — kept as class-level aliases for back-compat with

--- a/app/views/tree_model_builder.py
+++ b/app/views/tree_model_builder.py
@@ -463,6 +463,15 @@ def build_model(
                 QStandardItem(resolution_txt),       # COL_RESOLUTION (10)
             ]
 
+            # Track Qt heap QStandardItem count for memory_probe (no-op when probe disabled).
+            try:
+                from scripts.memory_probe import track_qt_alloc, _ENABLED  # type: ignore[import]
+                if _ENABLED:
+                    for _it in child_row:
+                        track_qt_alloc("QStandardItem", _it)
+            except ImportError:
+                pass
+
             # #536 Direction A — for a passenger row (the starred "N*%" cell,
             # i.e. a Ref-tier non-winner), set a tooltip naming the nearest
             # group member so the strongest actual link behind the star is

--- a/app/views/workers/manifest_load_worker.py
+++ b/app/views/workers/manifest_load_worker.py
@@ -63,6 +63,14 @@ class ManifestLoadWorker(QThread):
         repo = ManifestRepository()
         items: list[PhotoRecord] = list(repo.load(self._path))
 
+        # Point 2: all rows fetched from SQLite, before grouping into PhotoGroup objects.
+        try:
+            from scripts.memory_probe import snapshot, _ENABLED  # type: ignore[import]
+            if _ENABLED:
+                snapshot("worker_post_fetchall", point=2, n_records=len(items))
+        except ImportError:
+            pass
+
         self.progress.emit(f"Grouping {len(items):,} records…")
 
         grouped: dict[int, list[PhotoRecord]] = defaultdict(list)

--- a/docs/audits/memory-probe.md
+++ b/docs/audits/memory-probe.md
@@ -1,0 +1,150 @@
+# Memory Probe — Developer Tool
+
+Regression-guard harness for detecting Python heap + Qt heap leaks
+across manifest load cycles (issues #614, #619, #624).
+
+---
+
+## Quick start
+
+```powershell
+# Generate the 13k-row fixture once (idempotent, ~0.3s):
+.venv\Scripts\python.exe scripts\generate_probe_fixture.py
+
+# Run a 3-reload measurement session:
+$env:PHOTO_MANAGER_MEMORY_PROBE = '1'
+$env:PHOTO_MANAGER_MEMORY_PROBE_TAG = 'regression-guard-baseline'
+$env:PHOTO_MANAGER_PROBE_RELOAD_COUNT = '3'
+.venv\Scripts\python.exe main.py --manifest "$env:USERPROFILE\AppData\Local\PhotoManager\probe-fixtures\probe_manifest.sqlite"
+```
+
+The app opens, loads the fixture 3 times with 7-second gaps (allowing
+the Point 5 idle snapshot to fire between loads), then waits for you to
+close it.
+
+---
+
+## Env vars
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `PHOTO_MANAGER_MEMORY_PROBE` | `""` | Set to `"1"` to activate. Off by default — zero overhead when unset. |
+| `PHOTO_MANAGER_MEMORY_PROBE_TAG` | `"untagged"` | Free-text label written to every row — use for A/B or commit SHA. |
+| `PHOTO_MANAGER_PROBE_MANIFEST` | `""` | Alternative to `--manifest` CLI arg. |
+| `PHOTO_MANAGER_PROBE_RELOAD_COUNT` | `"1"` | Number of sequential reload cycles (7s gap between each). |
+| `PHOTO_MANAGER_MEMORY_PROBE_TRIM` | `""` | Set to `"1"` to call `SetProcessWorkingSetSize(-1,-1)` after Point 5 and capture the delta as Point 6. |
+| `PHOTO_MANAGER_MEMORY_PROBE_REFERRERS` | `""` | Comma-separated type names (e.g. `"QStandardItem,PhotoGroup"`). After Point 5, dumps `gc.get_referrers()` samples to a sibling JSONL. |
+
+---
+
+## Artifact location
+
+```
+~/AppData/Local/PhotoManager/logs/memory_probe_<RUN_ID>.jsonl
+~/AppData/Local/PhotoManager/logs/referrers_<type>_<RUN_ID>.jsonl  # Stage 2 only
+```
+
+Each run gets a fresh UUID `RUN_ID` even across app restarts.
+
+---
+
+## 5 measurement points
+
+| Point | Label | Where fired | What it measures |
+|---|---|---|---|
+| 1 | `mainwindow_init_done` | End of `MainWindow.__init__` | Baseline before any manifest load |
+| 2 | `worker_post_fetchall` | `ManifestLoadWorker._load` after `list(repo.load())` | SQLite fetch + `PhotoRecord` allocation; `extras.n_records` shows row count |
+| 3 | `vm_groups_assigned` | `FileOperationsHandler._on_manifest_loaded` after `vm.groups = groups` | All `PhotoGroup`/`PhotoRecord` objects in memory; `extras.n_groups`, `extras.n_items` |
+| 4 | `after_refresh_model` | Same, after `ui_updater.refresh_tree()` returns | Qt `QStandardItemModel` + `QSortFilterProxyModel` live; all `QStandardItem` children created |
+| 5 | `idle_5s` | `QTimer.singleShot(5000)` from Point 4 | 5 seconds after tree rebuild — transients should be freed by now |
+| 6 | `after_trim` | Immediately after `SetProcessWorkingSetSize` | Windows working-set pressure delta (`rss_before_trim` vs `rss_after_trim`) |
+
+---
+
+## JSONL row schema
+
+```json
+{
+  "ts": <float unix timestamp>,
+  "iso": "<UTC ISO-8601>",
+  "run_id": "<hex UUID>",
+  "tag": "<tag>",
+  "point": <1-6>,
+  "label": "<label>",
+  "thread": "<thread name>",
+  "tracemalloc_total_bytes": <int>,
+  "tracemalloc_peak_bytes": <int>,
+  "tracemalloc_overhead_bytes": <int>,
+  "top30": [{"file": str, "lineno": int, "size_bytes": int, "count": int}, ...],
+  "rss_bytes": <int>,
+  "vms_bytes": <int>,
+  "private_bytes": <int>,
+  "system_avail_bytes": <int>,
+  "gc_count": [g0, g1, g2],
+  "typed_counts": {
+    "QStandardItem": int, "PhotoRecord": int, "PhotoGroup": int,
+    "QImage": int, "QPixmap": int, "QThread": int, "ManifestLoadWorker": int
+  },
+  "qt_counter_qstandarditem": <int>,
+  "qt_counter_qimage": <int>,
+  "extras": {}
+}
+```
+
+**`tracemalloc_total_bytes`** tracks Python-managed memory only.
+**`rss_bytes`** includes the Qt C++ heap + pymalloc arenas + Python heap.
+The gap `rss - tracemalloc_total` is dominated by Qt's C++ heap — mostly
+`QStandardItem` and `QImage` objects. The `qt_counter_*` fields give
+the direct count of live tracked Qt objects.
+
+---
+
+## Quick pandas analysis
+
+```python
+import json, pandas as pd
+from pathlib import Path
+
+rows = [json.loads(l) for l in Path("memory_probe_<RUN_ID>.jsonl").read_text().splitlines()]
+df = pd.DataFrame(rows)
+
+# RSS slope across reloads (Point 4 = after tree rebuild)
+p4 = df[df.point == 4][["label", "rss_bytes", "qt_counter_qstandarditem"]].copy()
+p4["rss_mb"] = p4.rss_bytes / 1e6
+print(p4)
+
+# QStandardItem leak check: should be FLAT across reloads
+print("qt_counter_qstandarditem:", df[df.point == 4].qt_counter_qstandarditem.tolist())
+```
+
+---
+
+## 4 hypothesis bands
+
+The gap between successive Point 4 snapshots maps to one of four hypotheses:
+
+| Band | Signal | Decision |
+|---|---|---|
+| **H1 Live retention** | `typed_counts.QStandardItem` or `typed_counts.PhotoRecord` grows monotonically across reloads | Model or PhotoRecord objects are retained by a Python reference (stale signal, listener, old `vm.groups` alias). Root cause: `gc.get_referrers()` via `REFERRERS` env var. |
+| **H2 Allocator hoarding** | `tracemalloc_total` is flat but `rss` grows | Python's pymalloc arena pool is not returning pages to the OS. Usually benign. Confirm via TRIM (Point 6 delta < 5 MB = harmless). |
+| **H3 Qt heap** | `tracemalloc` flat, `rss` grows, `qt_counter_qstandarditem` grows | `QStandardItem`s from the previous model are not freed — `setSourceModel(None)` + `deleteLater()` was not called. Fixed in #619. |
+| **H4 Windows working-set** | All counters flat but RSS grows | Windows is opportunistically growing the working set into free RAM. TRIM Point 6 collapses RSS to near-baseline = harmless. |
+
+**The #619 fix holds** when `qt_counter_qstandarditem` at Point 4 is flat
+across all N reloads (not +163,680 per reload as it was before #619).
+
+**The #624 byte-budget LRU holds** when `qt_counter_qimage` at Point 5
+is bounded (does not grow proportional to reload count).
+
+---
+
+## Fixture generator
+
+```powershell
+.venv\Scripts\python.exe scripts\generate_probe_fixture.py
+```
+
+Generates `~/AppData/Local/PhotoManager/probe-fixtures/probe_manifest.sqlite`
+with ~13,000 rows across ~2,500 groups (near-dup distribution, NAS-style paths,
+realistic EXIF metadata). Fixed PRNG seed 42 — re-running produces an identical
+file. The fixture schema mirrors `scanner/manifest.py` CREATE TABLE exactly.

--- a/docs/features.md
+++ b/docs/features.md
@@ -684,6 +684,15 @@ for the chore plan.
 
 ---
 
+### Developer tool — memory probe
+
+- **Entry point:** `scripts/memory_probe.py`; activated via `PHOTO_MANAGER_MEMORY_PROBE=1`.
+- **Trigger:** Off by default (zero overhead when env var is unset). Enabled by setting `PHOTO_MANAGER_MEMORY_PROBE=1` before launch. CLI arg `--manifest <path>` (or env `PHOTO_MANAGER_PROBE_MANIFEST`) auto-loads a fixture manifest; `PHOTO_MANAGER_PROBE_RELOAD_COUNT=N` fires N reload cycles to measure per-reload growth.
+- **Behaviour:** Captures five in-process memory snapshots (Python `tracemalloc` + Windows ctypes RSS + `gc` typed counts + Qt heap counters via `destroyed` signal) and appends JSONL rows to `~/AppData/Local/PhotoManager/logs/memory_probe_<RUN_ID>.jsonl`. Qt allocation counters track live `QStandardItem` and `QImage` objects across `refresh_model` cycles — the primary regression signal for #619 (`QStandardItem` leak) and #624 (preview LRU byte-budget). Optional TRIM mode (`PHOTO_MANAGER_MEMORY_PROBE_TRIM=1`) fires `SetProcessWorkingSetSize` after the idle snapshot to distinguish H2 (allocator hoarding) from H3 (Qt heap) leaks. Optional referrer dump (`PHOTO_MANAGER_MEMORY_PROBE_REFERRERS=<type,...>`) walks `gc.get_referrers()` for named types and writes a sibling JSONL.
+- **Conditions / variants:** No-op on every code path when the env var is unset — all insertion points are guarded by `try/except ImportError`. Fixture generator at `scripts/generate_probe_fixture.py` produces a reproducible ~13k-row SQLite manifest (seed 42).
+- **Related:** `docs/audits/memory-probe.md` (usage guide, row schema, 4-hypothesis decision table); `tests/test_memory_probe.py`; issues #614, #619, #624.
+- **Last verified:** 2026-06-09 (regression-guard PR)
+
 ## How to update this file
 
 When user-visible behaviour changes (button label, conditional dialog,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -183,6 +183,8 @@ calls out what would be uncaught even with a green CI.
 |---|---|---|
 | `main.py` | **omit** | qa-explore launches it as a real subprocess for every scenario |
 | `run_all_linters.py` | **omit** | dev tooling, not user-facing |
+| `scripts/memory_probe.py` | **omit** (scripts/*) | `tests/test_memory_probe.py` covers disabled no-op, enabled JSONL schema, Qt counter lifecycle, and ImportError guard pattern; the ctypes Windows memory query and the referrer-dump path require a live Qt event loop and are exercised by manual probe runs against the fixture |
+| `scripts/generate_probe_fixture.py` | **omit** (scripts/*) | dev tool; deterministic output verified by running it and loading the result into `memory_probe` harness |
 
 ---
 

--- a/infrastructure/image_service.py
+++ b/infrastructure/image_service.py
@@ -295,6 +295,14 @@ class ImageService:
             except OSError as ex:
                 logger.debug("Save disk cache failed for {}: {}", disk_file, ex)
 
+        # Track Qt heap QImage count for memory_probe (no-op when probe disabled).
+        try:
+            from scripts.memory_probe import track_qt_alloc, _ENABLED  # type: ignore[import]
+            if _ENABLED and img is not None and not img.isNull():
+                track_qt_alloc("QImage", img)
+        except ImportError:
+            pass
+
         cache.put(key, img)
         return img
 

--- a/main.py
+++ b/main.py
@@ -267,6 +267,34 @@ def main() -> int:
     win = make_main_window(vm, img, settings)
     win.show()
 
+    # Probe: auto-load manifest from --manifest <path> or PHOTO_MANAGER_PROBE_MANIFEST.
+    # Supports PHOTO_MANAGER_PROBE_RELOAD_COUNT=N for N sequential reload measurements
+    # with 7-second gaps (enough for Point 5 idle snapshot to fire between loads).
+    _probe_manifest: str | None = None
+    for _i, _arg in enumerate(sys.argv[1:], 1):
+        if _arg == "--manifest" and _i < len(sys.argv):
+            _probe_manifest = sys.argv[_i + 1]
+            break
+    if _probe_manifest is None:
+        _probe_manifest = os.environ.get("PHOTO_MANAGER_PROBE_MANIFEST")
+
+    if _probe_manifest:
+        _probe_reload_count = max(1, int(os.environ.get("PHOTO_MANAGER_PROBE_RELOAD_COUNT", "1")))
+
+        def _schedule_loads(remaining: int, delay_ms: int = 500) -> None:
+            from PySide6.QtCore import QTimer
+            from pathlib import Path as _Path
+
+            def _do_load() -> None:
+                win.file_operations._start_manifest_load(str(_Path(_probe_manifest)))
+                if remaining > 1:
+                    # 7 seconds: enough time for Point 5 (5s idle) to fire between loads.
+                    _schedule_loads(remaining - 1, delay_ms=7_000)
+
+            QTimer.singleShot(delay_ms, _do_load)
+
+        _schedule_loads(_probe_reload_count)
+
     return app.exec()
 
 

--- a/news/627.feature
+++ b/news/627.feature
@@ -1,0 +1,1 @@
+Memory probe (`scripts/memory_probe.py`) shipped as a permanent regression guard — env-gated (`PHOTO_MANAGER_MEMORY_PROBE=1`), default off, zero overhead on normal launch. Collects RSS / tracemalloc / Qt heap counters at 5 measurement points around DB load; usage in `docs/audits/memory-probe.md` (#627 from #614 follow-up).

--- a/scripts/generate_probe_fixture.py
+++ b/scripts/generate_probe_fixture.py
@@ -1,0 +1,212 @@
+"""Generate a realistic ~13k-row test fixture for memory_probe.py.
+
+Creates a SQLite manifest matching the schema in scanner/manifest.py +
+infrastructure/manifest_repository.py (including the ``outcome``,
+``is_locked`` columns from additive migrations).
+
+Output: ~/AppData/Local/PhotoManager/probe-fixtures/probe_manifest.sqlite
+
+Reproducible: uses a fixed PRNG seed (42).
+Run: python scripts/generate_probe_fixture.py
+"""
+
+from __future__ import annotations
+
+import random
+import sqlite3
+import string
+from pathlib import Path
+
+_SEED = 42
+_N_ROWS = 13_000
+_N_GROUPS = 2_500  # ~5.2 items/group average
+
+_OUT = (
+    Path.home()
+    / "AppData"
+    / "Local"
+    / "PhotoManager"
+    / "probe-fixtures"
+    / "probe_manifest.sqlite"
+)
+
+_DDL = """
+CREATE TABLE IF NOT EXISTS migration_manifest (
+    id               INTEGER PRIMARY KEY,
+    source_path      TEXT    NOT NULL,
+    source_label     TEXT    NOT NULL,
+    action           TEXT    NOT NULL,
+    source_hash      TEXT,
+    phash            TEXT,
+    hamming_distance INTEGER,
+    group_id         TEXT,
+    reason           TEXT,
+    executed         INTEGER NOT NULL DEFAULT 0,
+    user_decision    TEXT    NOT NULL DEFAULT '',
+    file_size_bytes  INTEGER,
+    shot_date        TEXT,
+    creation_date    TEXT,
+    mtime            TEXT,
+    pixel_width      INTEGER,
+    pixel_height     INTEGER,
+    exif_tag_count   INTEGER,
+    gps_present      INTEGER NOT NULL DEFAULT 0,
+    xmp_derived      INTEGER NOT NULL DEFAULT 0,
+    score            REAL,
+    is_locked        INTEGER NOT NULL DEFAULT 0,
+    outcome          TEXT    NOT NULL DEFAULT ''
+);
+CREATE INDEX IF NOT EXISTS idx_source_hash ON migration_manifest(source_hash);
+CREATE INDEX IF NOT EXISTS idx_phash       ON migration_manifest(phash);
+CREATE INDEX IF NOT EXISTS idx_action      ON migration_manifest(action);
+CREATE INDEX IF NOT EXISTS idx_group_id    ON migration_manifest(group_id);
+"""
+
+_INSERT = """
+INSERT INTO migration_manifest
+    (source_path, source_label, action, source_hash,
+     phash, hamming_distance, group_id, reason,
+     file_size_bytes, shot_date, creation_date, mtime,
+     pixel_width, pixel_height,
+     exif_tag_count, gps_present, xmp_derived, score,
+     is_locked, outcome, user_decision)
+VALUES
+    (?, ?, ?, ?,
+     ?, ?, ?, ?,
+     ?, ?, ?, ?,
+     ?, ?,
+     ?, ?, ?, ?,
+     ?, ?, ?)
+"""
+
+
+def _rand_hex(n: int, rng: random.Random) -> str:
+    return "".join(rng.choice("0123456789abcdef") for _ in range(n))
+
+
+def _rand_path(rng: random.Random, group_idx: int, item_idx: int) -> str:
+    """Realistic NAS UNC path, 100-300 chars."""
+    nas_share = rng.choice([
+        r"\\LINXIAOYUN\photos",
+        r"\\LINXIAOYUN\圖片",
+        r"D:\Takeout-0508",
+    ])
+    subfolder_depth = rng.randint(2, 5)
+    parts = [
+        "".join(rng.choices(string.ascii_lowercase + string.digits, k=rng.randint(4, 12)))
+        for _ in range(subfolder_depth)
+    ]
+    # Add some CJK chars in folder names to simulate real NAS paths
+    if rng.random() < 0.3:
+        parts.append("相片" + str(rng.randint(2015, 2024)))
+    ext = rng.choice([".jpg", ".JPG", ".heic", ".HEIC", ".dng", ".DNG", ".png", ".mp4"])
+    fname = f"IMG_{rng.randint(10000, 99999):05d}_{group_idx:04d}_{item_idx:03d}{ext}"
+    path = nas_share + "\\" + "\\".join(parts) + "\\" + fname
+    # Pad to ~150 chars if too short
+    while len(path) < 100:
+        path = path.replace(fname, "extra_subfolder\\" + fname)
+    return path[:300]
+
+
+def _rand_phash(rng: random.Random, base: str | None = None) -> str:
+    if base is None:
+        return _rand_hex(16, rng)
+    # Near-dup: flip 0-4 bits
+    as_int = int(base, 16)
+    flips = rng.randint(0, 4)
+    for _ in range(flips):
+        bit = rng.randint(0, 63)
+        as_int ^= (1 << bit)
+    return f"{as_int:016x}"
+
+
+def _rand_date(rng: random.Random) -> str:
+    """ISO-format date string parseable by datetime.fromisoformat."""
+    y = rng.randint(2010, 2024)
+    m = rng.randint(1, 12)
+    d = rng.randint(1, 28)
+    h = rng.randint(0, 23)
+    mi = rng.randint(0, 59)
+    s = rng.randint(0, 59)
+    return f"{y}-{m:02d}-{d:02d} {h:02d}:{mi:02d}:{s:02d}"
+
+
+def generate(out: Path = _OUT, n_rows: int = _N_ROWS, n_groups: int = _N_GROUPS) -> Path:
+    rng = random.Random(_SEED)
+    out.parent.mkdir(parents=True, exist_ok=True)
+
+    if out.exists():
+        out.unlink()
+
+    conn = sqlite3.connect(str(out))
+    conn.executescript(_DDL)
+
+    rows: list[tuple] = []
+
+    # Build group structure: first row in each group is KEEP (ref winner),
+    # subsequent rows are REVIEW_DUPLICATE (near-dup).
+    # ~10% of groups have a single KEEP (singletons).
+    group_ids: list[str] = [_rand_hex(16, rng) for _ in range(n_groups)]
+    ref_phashes: dict[str, str] = {gid: _rand_hex(16, rng) for gid in group_ids}
+
+    # Distribute _N_ROWS across groups: each group has at least 1 row; extras
+    # are distributed by a geometric-like distribution (mirrors real near-dup data).
+    group_sizes: list[int] = [1] * n_groups
+    remaining = n_rows - n_groups
+    for _ in range(remaining):
+        # Weight earlier groups (they tend to be larger in real data)
+        idx = int(rng.triangular(0, n_groups - 1, 0))
+        group_sizes[idx] += 1
+
+    row_id = 1
+    for g_idx, gid in enumerate(group_ids):
+        g_size = group_sizes[g_idx]
+        ref_phash = ref_phashes[gid]
+        shot_base = _rand_date(rng)
+        creation_base = _rand_date(rng)
+        mtime_base = _rand_date(rng)
+
+        for item_idx in range(g_size):
+            is_ref = item_idx == 0
+            action = "KEEP" if is_ref else ("EXACT" if rng.random() < 0.3 else "REVIEW_DUPLICATE")
+            hamming = 0 if is_ref else rng.randint(1, 12)
+            phash = ref_phash if is_ref else _rand_phash(rng, ref_phash)
+            source_path = _rand_path(rng, g_idx, item_idx)
+            source_label = rng.choice(["src0", "src1"])
+            source_hash = _rand_hex(64, rng)
+            reason = "" if is_ref else rng.choice(["near_dup", "exact_dup", ""])
+            file_size = rng.randint(500_000, 120_000_000)
+            pixel_w = rng.choice([3024, 4032, 4032, 8064, 1920, 2560])
+            pixel_h = rng.choice([4032, 3024, 3024, 6048, 1080, 1440])
+            exif_count = rng.randint(20, 120)
+            gps = 1 if rng.random() < 0.4 else 0
+            xmp = 1 if rng.random() < 0.1 else 0
+            score = round(rng.uniform(0.0, 1.0), 4) if rng.random() < 0.7 else None
+            is_locked = 1 if rng.random() < 0.02 else 0
+            user_decision = "" if rng.random() > 0.05 else "delete"
+            # Shot date: slight variation from base within same group
+            shot = shot_base if rng.random() < 0.7 else _rand_date(rng)
+            creation = creation_base if rng.random() < 0.7 else _rand_date(rng)
+            mtime = mtime_base if rng.random() < 0.9 else _rand_date(rng)
+
+            rows.append((
+                source_path, source_label, action, source_hash,
+                phash, hamming, gid, reason,
+                file_size, shot, creation, mtime,
+                pixel_w, pixel_h,
+                exif_count, gps, xmp, score,
+                is_locked, "", user_decision,  # outcome='' (in-review)
+            ))
+            row_id += 1
+
+    conn.executemany(_INSERT, rows)
+    conn.commit()
+    conn.close()
+
+    n_actual = sum(group_sizes)
+    print(f"Generated {n_actual:,} rows across {n_groups:,} groups -> {out}")
+    return out
+
+
+if __name__ == "__main__":
+    generate()

--- a/scripts/memory_probe.py
+++ b/scripts/memory_probe.py
@@ -1,0 +1,335 @@
+"""Memory probe for photo-manager — tracks Python + Qt heap across manifest loads.
+
+Activated via environment variable so the no-op path has near-zero overhead:
+
+    PHOTO_MANAGER_MEMORY_PROBE=1
+    PHOTO_MANAGER_MEMORY_PROBE_TAG=<label>          (default: 'untagged')
+    PHOTO_MANAGER_MEMORY_PROBE_TRIM=1               (optional: call SetProcessWorkingSetSize after Point 5)
+    PHOTO_MANAGER_MEMORY_PROBE_REFERRERS=<type,...> (optional comma-separated Stage-2 referrer dump)
+
+Five measurement points are wired in production source:
+    1 — end of MainWindow.__init__
+    2 — ManifestLoadWorker._load after list(repo.load())
+    3 — FileOperationsHandler._on_manifest_loaded after vm.groups = groups
+    4 — same, after ui_updater.refresh_tree returns
+    5 — 5-second QTimer after Point 4 (idle snapshot)
+    6 — optional, only when PHOTO_MANAGER_MEMORY_PROBE_TRIM=1; after SetProcessWorkingSetSize
+
+Qt-heap counters (tracemalloc is blind to C++ Qt heap):
+    _qt_alloc / _qt_dealloc — net live objects per type.
+    track_qt_alloc(type_name, obj) — call at construction; connects obj.destroyed for dealloc.
+
+Artifact:
+    ~/AppData/Local/PhotoManager/logs/memory_probe_<RUN_ID>.jsonl
+    ~/AppData/Local/PhotoManager/logs/referrers_<type>_<RUN_ID>.jsonl  (Stage 2 only)
+
+No external packages required — uses ctypes for Windows memory stats.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import ctypes.wintypes as _wintypes
+import os
+import threading
+import uuid
+from pathlib import Path
+
+_ENABLED: bool = os.environ.get("PHOTO_MANAGER_MEMORY_PROBE") == "1"
+_RUN_ID: str = uuid.uuid4().hex
+_TAG: str = os.environ.get("PHOTO_MANAGER_MEMORY_PROBE_TAG", "untagged")
+_TRIM: bool = os.environ.get("PHOTO_MANAGER_MEMORY_PROBE_TRIM") == "1"
+_REFERRERS: str = os.environ.get("PHOTO_MANAGER_MEMORY_PROBE_REFERRERS", "")
+
+# Qt allocation counters — incremented without heavy imports on the hot path.
+_qt_alloc: dict[str, int] = {"QStandardItem": 0, "QImage": 0}
+_qt_dealloc: dict[str, int] = {"QStandardItem": 0, "QImage": 0}
+
+_lock = threading.Lock()
+_tm_started = False
+
+# Hold QTimer refs so they aren't GC'd before firing.
+_active_timers: list = []
+
+_ARTIFACT_DIR = Path.home() / "AppData" / "Local" / "PhotoManager" / "logs"
+
+
+# --- Windows memory query via ctypes (no psutil needed) ---
+
+class _PROCESS_MEMORY_COUNTERS_EX(ctypes.Structure):
+    _fields_ = [
+        ("cb", _wintypes.DWORD),
+        ("PageFaultCount", _wintypes.DWORD),
+        ("PeakWorkingSetSize", ctypes.c_size_t),
+        ("WorkingSetSize", ctypes.c_size_t),
+        ("QuotaPeakPagedPoolUsage", ctypes.c_size_t),
+        ("QuotaPagedPoolUsage", ctypes.c_size_t),
+        ("QuotaPeakNonPagedPoolUsage", ctypes.c_size_t),
+        ("QuotaNonPagedPoolUsage", ctypes.c_size_t),
+        ("PagefileUsage", ctypes.c_size_t),
+        ("PeakPagefileUsage", ctypes.c_size_t),
+        ("PrivateUsage", ctypes.c_size_t),
+    ]
+
+
+class _MEMORYSTATUSEX(ctypes.Structure):
+    _fields_ = [
+        ("dwLength", _wintypes.DWORD),
+        ("dwMemoryLoad", _wintypes.DWORD),
+        ("ullTotalPhys", ctypes.c_ulonglong),
+        ("ullAvailPhys", ctypes.c_ulonglong),
+        ("ullTotalPageFile", ctypes.c_ulonglong),
+        ("ullAvailPageFile", ctypes.c_ulonglong),
+        ("ullTotalVirtual", ctypes.c_ulonglong),
+        ("ullAvailVirtual", ctypes.c_ulonglong),
+        ("ullAvailExtendedVirtual", ctypes.c_ulonglong),
+    ]
+
+
+_PROCESS_QUERY_INFORMATION = 0x0400
+_PROCESS_VM_READ = 0x0010
+
+
+def _get_process_memory() -> tuple[int, int, int]:
+    """Return (rss_bytes, vms_bytes, private_bytes) via Windows ctypes.
+
+    rss = WorkingSetSize (current RSS)
+    vms = PagefileUsage (commit charge / virtual memory used)
+    private = PrivateUsage (private committed pages)
+    Falls back to zeros on error or non-Windows.
+    """
+    import sys
+    if sys.platform != "win32":
+        return _get_process_memory_posix()
+    try:
+        kernel32 = ctypes.windll.kernel32
+        psapi = ctypes.windll.psapi
+        pid = os.getpid()
+        handle = kernel32.OpenProcess(
+            _PROCESS_QUERY_INFORMATION | _PROCESS_VM_READ, False, pid
+        )
+        if not handle:
+            return 0, 0, 0
+        pmc = _PROCESS_MEMORY_COUNTERS_EX()
+        pmc.cb = ctypes.sizeof(pmc)
+        ok = psapi.GetProcessMemoryInfo(handle, ctypes.byref(pmc), pmc.cb)
+        kernel32.CloseHandle(handle)
+        if ok:
+            return pmc.WorkingSetSize, pmc.PagefileUsage, pmc.PrivateUsage
+        return 0, 0, 0
+    except Exception:
+        return 0, 0, 0
+
+
+def _get_process_memory_posix() -> tuple[int, int, int]:
+    """Fallback for non-Windows: read /proc/self/status for VmRSS."""
+    try:
+        rss = 0
+        with open("/proc/self/status") as fh:
+            for line in fh:
+                if line.startswith("VmRSS:"):
+                    rss = int(line.split()[1]) * 1024
+                    break
+        return rss, 0, 0
+    except Exception:
+        return 0, 0, 0
+
+
+def _get_system_avail() -> int:
+    """Return available physical memory in bytes via GlobalMemoryStatusEx."""
+    import sys
+    if sys.platform != "win32":
+        return 0
+    try:
+        kernel32 = ctypes.windll.kernel32
+        mst = _MEMORYSTATUSEX()
+        mst.dwLength = ctypes.sizeof(mst)
+        kernel32.GlobalMemoryStatusEx(ctypes.byref(mst))
+        return int(mst.ullAvailPhys)
+    except Exception:
+        return 0
+
+
+def _ensure_artifact_dir() -> None:
+    _ARTIFACT_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _start_tracemalloc() -> None:
+    global _tm_started
+    if not _tm_started:
+        import tracemalloc
+        tracemalloc.start(25)
+        _tm_started = True
+
+
+def track_qt_alloc(type_name: str, obj: object) -> None:
+    """Increment Qt alloc counter for *type_name* and wire obj.destroyed for dealloc."""
+    if not _ENABLED:
+        return
+    if type_name not in _qt_alloc:
+        return
+    with _lock:
+        _qt_alloc[type_name] += 1
+    # Connect destroyed signal so dealloc counter increments when Qt frees the object.
+    try:
+        def _on_destroyed(type_name: str = type_name) -> None:
+            with _lock:
+                _qt_dealloc[type_name] += 1
+
+        obj.destroyed.connect(_on_destroyed)  # type: ignore[attr-defined]
+    except Exception:
+        pass
+
+
+def snapshot(label: str, point: int, **extras: object) -> None:
+    """Capture a memory snapshot and append a JSONL row to the artifact.
+
+    Returns immediately when not enabled.
+    Do NOT call gc.collect() before snapshot — that would mask retention bugs.
+    """
+    if not _ENABLED:
+        return
+
+    import datetime
+    import gc
+    import json
+    import tracemalloc
+
+    _start_tracemalloc()
+
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
+    ts = now.timestamp()
+    iso = now.isoformat()
+    thread_name = threading.current_thread().name
+
+    # --- tracemalloc ---
+    tm_total, tm_peak = tracemalloc.get_traced_memory()
+    tm_snap = tracemalloc.take_snapshot()
+    stats = tm_snap.statistics("lineno")
+    top30 = [
+        {
+            "file": str(s.traceback[0].filename),
+            "lineno": s.traceback[0].lineno,
+            "size_bytes": s.size,
+            "count": s.count,
+        }
+        for s in stats[:30]
+    ]
+    tm_overhead = sum(s.size for s in stats if "tracemalloc" in str(s.traceback))
+
+    # --- Windows process memory (ctypes, no psutil) ---
+    rss, vms, private = _get_process_memory()
+    system_avail = _get_system_avail()
+
+    # --- gc typed object counts ---
+    gc_count = gc.get_count()
+    _TRACK_TYPES = {
+        "QStandardItem", "PhotoRecord", "PhotoGroup",
+        "QImage", "QPixmap", "QThread", "ManifestLoadWorker",
+    }
+    typed_counts: dict[str, int] = {name: 0 for name in _TRACK_TYPES}
+    for obj in gc.get_objects():
+        tname = type(obj).__name__
+        if tname in typed_counts:
+            typed_counts[tname] += 1
+
+    # --- Qt counters (net live = alloc - dealloc) ---
+    with _lock:
+        qt_qi = _qt_alloc["QStandardItem"] - _qt_dealloc["QStandardItem"]
+        qt_qimg = _qt_alloc["QImage"] - _qt_dealloc["QImage"]
+
+    row = {
+        "ts": ts,
+        "iso": iso,
+        "run_id": _RUN_ID,
+        "tag": _TAG,
+        "point": point,
+        "label": label,
+        "thread": thread_name,
+        "tracemalloc_total_bytes": tm_total,
+        "tracemalloc_peak_bytes": tm_peak,
+        "tracemalloc_overhead_bytes": tm_overhead,
+        "top30": top30,
+        "rss_bytes": rss,
+        "vms_bytes": vms,
+        "private_bytes": private,
+        "system_avail_bytes": system_avail,
+        "gc_count": list(gc_count),
+        "typed_counts": typed_counts,
+        "qt_counter_qstandarditem": qt_qi,
+        "qt_counter_qimage": qt_qimg,
+        "extras": {str(k): str(v) for k, v in extras.items()},
+    }
+
+    _ensure_artifact_dir()
+    artifact = _ARTIFACT_DIR / f"memory_probe_{_RUN_ID}.jsonl"
+    with _lock:
+        with artifact.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+    # Stage 2: referrer dump at Point 5 when requested.
+    if _REFERRERS and point == 5:
+        for type_name in _REFERRERS.split(","):
+            type_name = type_name.strip()
+            if type_name:
+                _dump_referrers(type_name)
+
+    # Optional working-set trim at Point 5 on Windows.
+    if _TRIM and point == 5:
+        import sys
+        if sys.platform == "win32":
+            rss_before = rss
+            try:
+                ctypes.windll.kernel32.SetProcessWorkingSetSize(-1, -1)
+            except Exception:
+                pass
+            rss_after, vms_after, private_after = _get_process_memory()
+            snapshot("after_trim", 6, rss_before_trim=rss_before, rss_after_trim=rss_after,
+                     delta=rss_after - rss_before)
+
+
+def _dump_referrers(type_name: str, limit: int = 5) -> None:
+    """Walk gc objects, pick up to *limit* instances of *type_name*, dump referrers."""
+    import gc
+    import json
+    import random
+
+    candidates = [o for o in gc.get_objects() if type(o).__name__ == type_name]
+    samples = random.sample(candidates, min(limit, len(candidates))) if candidates else []
+
+    rows = []
+    for obj in samples:
+        referrers = gc.get_referrers(obj)
+        chain = []
+        for r in referrers[:10]:
+            rtype = type(r).__name__
+            rid = id(r)
+            try:
+                rrepr = repr(r)[:120]
+            except Exception:
+                rrepr = "<repr-error>"
+            attr_names: list[str] = []
+            if isinstance(r, dict):
+                try:
+                    attr_names = [k for k, v in r.items() if v is obj][:5]
+                except Exception:
+                    pass
+            chain.append({
+                "referrer_type": rtype,
+                "referrer_id": rid,
+                "referrer_repr": rrepr,
+                "attr_names": attr_names,
+            })
+        rows.append({
+            "run_id": _RUN_ID,
+            "target_type": type_name,
+            "target_id": id(obj),
+            "referrer_count": len(referrers),
+            "chain": chain,
+        })
+
+    _ensure_artifact_dir()
+    artifact = _ARTIFACT_DIR / f"referrers_{type_name}_{_RUN_ID}.jsonl"
+    with artifact.open("a", encoding="utf-8") as fh:
+        for row in rows:
+            fh.write(json.dumps(row, ensure_ascii=False) + "\n")

--- a/tests/test_memory_probe.py
+++ b/tests/test_memory_probe.py
@@ -1,0 +1,295 @@
+"""Tests for scripts/memory_probe.py.
+
+These tests only cover the pure-Python logic that can break silently:
+- disabled path is a true no-op (no artifact, no tracemalloc start)
+- enabled path writes a valid JSONL row with the required schema keys
+- track_qt_alloc increments/decrements the counter correctly
+- the try/except ImportError guards in production code don't break the app
+
+Skipped intentionally:
+- Actual content of top30 / typed_counts (tests tracemalloc/gc, not our code)
+- generate_probe_fixture.py (dev tool, exercised by manual probe runs)
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import types
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reload_probe(monkeypatch, enabled: str | None) -> types.ModuleType:
+    """Re-import memory_probe with a fresh env state for _ENABLED."""
+    import scripts.memory_probe as mp_mod
+
+    if enabled is None:
+        monkeypatch.delenv("PHOTO_MANAGER_MEMORY_PROBE", raising=False)
+    else:
+        monkeypatch.setenv("PHOTO_MANAGER_MEMORY_PROBE", enabled)
+
+    # Force a full module reload so module-level _ENABLED picks up the new env.
+    return importlib.reload(mp_mod)
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — disabled path is a true no-op
+# ---------------------------------------------------------------------------
+
+class TestDisabledSnapshot:
+    def test_disabled_snapshot_is_noop(self, monkeypatch, tmp_path):
+        """When PHOTO_MANAGER_MEMORY_PROBE is unset, snapshot() returns immediately
+        and writes no artifact.  Catches a regression where someone removes the
+        ``if not _ENABLED: return`` guard."""
+        mp = _reload_probe(monkeypatch, None)
+
+        assert mp._ENABLED is False
+
+        # Redirect the artifact dir to tmp so we can inspect it cleanly.
+        monkeypatch.setattr(mp, "_ARTIFACT_DIR", tmp_path)
+
+        mp.snapshot("test_noop", point=1)
+
+        # No JSONL file should exist.
+        artifacts = list(tmp_path.glob("memory_probe_*.jsonl"))
+        assert artifacts == [], "snapshot() wrote an artifact even when disabled"
+
+    def test_disabled_snapshot_does_not_start_tracemalloc(self, monkeypatch, tmp_path):
+        """Tracemalloc must not be started when probe is disabled — it imposes
+        overhead on every allocation even after we stop calling snapshot()."""
+        import tracemalloc
+        mp = _reload_probe(monkeypatch, None)
+
+        was_tracing = tracemalloc.is_tracing()
+        monkeypatch.setattr(mp, "_ARTIFACT_DIR", tmp_path)
+        mp.snapshot("noop_tm", point=1)
+
+        # If tracemalloc was already running we can't assert it wasn't started
+        # by us; only assert it's still in the same state as before the call.
+        assert tracemalloc.is_tracing() == was_tracing
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — enabled path writes a JSONL row with the expected schema
+# ---------------------------------------------------------------------------
+
+class TestEnabledSnapshot:
+    def test_enabled_snapshot_writes_jsonl_row(self, monkeypatch, tmp_path):
+        """When enabled, snapshot() appends one JSON object with all required
+        schema keys.  Catches missing fields that would break a pandas analysis
+        script reading the artifact."""
+        mp = _reload_probe(monkeypatch, "1")
+        assert mp._ENABLED is True
+        monkeypatch.setattr(mp, "_ARTIFACT_DIR", tmp_path)
+        # Reset counters so the row is deterministic.
+        mp._qt_alloc["QStandardItem"] = 0
+        mp._qt_dealloc["QStandardItem"] = 0
+        mp._qt_alloc["QImage"] = 0
+        mp._qt_dealloc["QImage"] = 0
+        mp._tm_started = False
+
+        mp.snapshot("test_row", point=3, n_groups=42, n_items=100)
+
+        artifacts = list(tmp_path.glob("memory_probe_*.jsonl"))
+        assert len(artifacts) == 1, "Expected exactly one JSONL artifact"
+
+        row = json.loads(artifacts[0].read_text(encoding="utf-8").strip())
+
+        required_keys = {
+            "ts", "iso", "run_id", "tag", "point", "label", "thread",
+            "tracemalloc_total_bytes", "tracemalloc_peak_bytes",
+            "top30", "rss_bytes", "vms_bytes", "private_bytes",
+            "system_avail_bytes", "gc_count", "typed_counts",
+            "qt_counter_qstandarditem", "qt_counter_qimage", "extras",
+        }
+        missing = required_keys - set(row.keys())
+        assert missing == set(), f"JSONL row missing keys: {missing}"
+
+        assert row["point"] == 3
+        assert row["label"] == "test_row"
+        assert row["extras"] == {"n_groups": "42", "n_items": "100"}
+        assert isinstance(row["top30"], list)
+        assert isinstance(row["typed_counts"], dict)
+        assert "QStandardItem" in row["typed_counts"]
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — track_qt_alloc increments / destroyed-signal decrements counter
+# ---------------------------------------------------------------------------
+
+class TestTrackQtAlloc:
+    def test_track_qt_alloc_increments_and_destroyed_decrements(self, monkeypatch):
+        """Counter starts at 0, reaches 1 after track_qt_alloc, and returns to 0
+        after the destroyed callback fires.  This is the regression test for the
+        #619 refresh_model fix: before #619 the counter would keep growing on each
+        reload because QStandardItems were never freed."""
+        mp = _reload_probe(monkeypatch, "1")
+        assert mp._ENABLED is True
+        # Reset counters.
+        mp._qt_alloc["QStandardItem"] = 0
+        mp._qt_dealloc["QStandardItem"] = 0
+
+        # Build a minimal mock with a .destroyed signal that we can invoke.
+        mock_obj = MagicMock()
+        destroyed_callbacks: list = []
+
+        def _connect_side_effect(cb):
+            destroyed_callbacks.append(cb)
+
+        mock_obj.destroyed = MagicMock()
+        mock_obj.destroyed.connect = MagicMock(side_effect=_connect_side_effect)
+
+        mp.track_qt_alloc("QStandardItem", mock_obj)
+
+        with mp._lock:
+            net = mp._qt_alloc["QStandardItem"] - mp._qt_dealloc["QStandardItem"]
+        assert net == 1, "Counter should be 1 after track_qt_alloc"
+
+        # Fire the destroyed callback as Qt would.
+        for cb in destroyed_callbacks:
+            cb()
+
+        with mp._lock:
+            net = mp._qt_alloc["QStandardItem"] - mp._qt_dealloc["QStandardItem"]
+        assert net == 0, "Counter should return to 0 after destroyed fires"
+
+    def test_track_qt_alloc_noop_when_disabled(self, monkeypatch):
+        """track_qt_alloc must not mutate counters when probe is disabled."""
+        mp = _reload_probe(monkeypatch, None)
+        assert mp._ENABLED is False
+        mp._qt_alloc["QStandardItem"] = 0
+
+        mock_obj = MagicMock()
+        mp.track_qt_alloc("QStandardItem", mock_obj)
+
+        assert mp._qt_alloc["QStandardItem"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — import guard in production code doesn't break the app
+# ---------------------------------------------------------------------------
+
+class TestImportGuard:
+    def test_import_guard_survives_missing_module(self, monkeypatch):
+        """Simulate scripts/memory_probe.py being unavailable (ImportError).
+
+        Verifies that the try/except ImportError guards in the four production
+        call sites don't crash the app when the module is absent.  This catches
+        a regression where someone forgets the guard around a new call site.
+        """
+        # Inject a broken 'scripts.memory_probe' into sys.modules so the import
+        # inside the production try/except raises ImportError on demand.
+        broken_finder = _BrokenFinder("scripts.memory_probe")
+        sys.meta_path.insert(0, broken_finder)
+        try:
+            # --- Point 1 guard (main_window.__init__ tail) ---
+            # We test the guard pattern directly; importing main_window would pull
+            # heavy Qt widgets into coverage.  The pattern is identical across all
+            # 5 call sites: try/except ImportError wraps the import + if _ENABLED.
+            _exec_point1_guard()
+
+            # --- Point 2 guard (manifest_load_worker) ---
+            _exec_point2_guard()
+
+            # --- Point 3+4+5 guard (file_operations._on_manifest_loaded) ---
+            _exec_point3_guard()
+
+            # --- tree_model_builder guard ---
+            _exec_tmb_guard()
+
+            # --- image_service guard ---
+            _exec_imgservice_guard()
+
+        finally:
+            sys.meta_path.remove(broken_finder)
+
+
+# ---------------------------------------------------------------------------
+# Helper: broken import finder
+# ---------------------------------------------------------------------------
+
+class _BrokenFinder:
+    """Insert into sys.meta_path to make a specific module raise ImportError."""
+
+    def __init__(self, module_name: str) -> None:
+        self._name = module_name
+
+    def find_spec(self, fullname, path, target=None):
+        if fullname == self._name or fullname.startswith(self._name + "."):
+            raise ImportError(f"_BrokenFinder: {fullname}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Guard pattern executors (inlined to avoid importing the actual source modules)
+# ---------------------------------------------------------------------------
+
+def _exec_point1_guard():
+    """Exercise the Point 1 guard pattern without importing main_window."""
+    try:
+        from scripts.memory_probe import snapshot, _ENABLED  # noqa: F401
+        if _ENABLED:
+            snapshot("mainwindow_init_done", point=1)
+    except ImportError:
+        pass  # expected
+
+
+def _exec_point2_guard():
+    """Exercise the Point 2 guard pattern."""
+    items = [object(), object()]
+    try:
+        from scripts.memory_probe import snapshot, _ENABLED  # noqa: F401
+        if _ENABLED:
+            snapshot("worker_post_fetchall", point=2, n_records=len(items))
+    except ImportError:
+        pass  # expected
+
+
+def _exec_point3_guard():
+    """Exercise the Points 3/4/5 guard patterns."""
+    groups: list = []
+    try:
+        from scripts.memory_probe import snapshot, _ENABLED  # noqa: F401
+        if _ENABLED:
+            snapshot("vm_groups_assigned", point=3, n_groups=0, n_items=0)
+    except ImportError:
+        pass  # expected
+    try:
+        from scripts.memory_probe import snapshot as _snap4, _ENABLED as _en4, _active_timers  # noqa: F401
+        if _en4:
+            _snap4("after_refresh_model", point=4)
+    except ImportError:
+        pass  # expected
+
+
+def _exec_tmb_guard():
+    """Exercise the tree_model_builder guard pattern."""
+    child_row: list = [MagicMock(), MagicMock()]
+    try:
+        from scripts.memory_probe import track_qt_alloc, _ENABLED  # noqa: F401
+        if _ENABLED:
+            for _it in child_row:
+                track_qt_alloc("QStandardItem", _it)
+    except ImportError:
+        pass  # expected
+
+
+def _exec_imgservice_guard():
+    """Exercise the image_service guard pattern."""
+    img = MagicMock()
+    img.isNull.return_value = False
+    try:
+        from scripts.memory_probe import track_qt_alloc, _ENABLED  # noqa: F401
+        if _ENABLED and img is not None and not img.isNull():
+            track_qt_alloc("QImage", img)
+    except ImportError:
+        pass  # expected


### PR DESCRIPTION
## What

Memory probe + smoke harness shipped as a permanent dev tool / regression guard. Collected from two throwaway worktrees from this session (the #618 leak investigation and the #624 real-NAS smoke run); previously never made it onto master.

Env-gated (`PHOTO_MANAGER_MEMORY_PROBE=1`), **default off** — zero overhead on normal launch (lazy imports + `if _ENABLED` guard around every insertion).

## Why

Two preview/cache leaks shipped this session (#618 `refresh_model` Qt-heap leak, #621 RAM growth from `side=0` hardcode). Both were caught only because the probe was built ad hoc to investigate them. With this PR the probe is a permanent regression guard — next preview-layer change can be A/B'd in 30 seconds.

Re-aligned for post-#619 (`refresh_model` fix) + post-#624 (byte-budget LRU + DNG embedded-JPEG fast path):
- Qt heap counter for `QStandardItem` re-hooked into the post-#619 model lifecycle.
- Qt heap counter for `QImage` re-hooked into the post-#624 tier-split LRU put path.

## How

### Components

1. **`scripts/memory_probe.py`** (new) — env-gated `snapshot()`, `track_qt_alloc()`, `dump_referrers()`. Lazy imports `tracemalloc`/`gc`/`ctypes` only inside the enabled path. JSONL artifact at `~/AppData/Local/PhotoManager/logs/memory_probe_<RUN_ID>.jsonl`. Thread-safe append via `threading.Lock` (Point 2 fires inside `ManifestLoadWorker`'s QThread). Does NOT call `gc.collect()` before snapshot — would mask retention.

2. **`scripts/generate_probe_fixture.py`** (new) — reproducible 13k-row / 2.5k-group SQLite fixture mirroring `scanner/manifest.py` schema. Fixed PRNG seed; idempotent.

3. **5 measurement points** wired into production source files, all `try/except ImportError`-guarded so probe absence never breaks the app:

   | Point | Location | Measures |
   |---|---|---|
   | 1 | `MainWindow.__init__` end | Baseline |
   | 2 | `ManifestLoadWorker._load` after `list(repo.load())` | Post-fetchall (H2 transient peak) |
   | 3 | `file_operations._on_manifest_loaded` after `vm.groups = groups` | Python-side isolation |
   | 4 | Same handler after `refresh_tree()` returns | Qt-side isolation |
   | 5 | `QTimer.singleShot(5_000)` from Point 4 | Idle steady-state |

4. **Qt heap allocation counters** — only mechanism that sees Qt C++ heap (tracemalloc is blind to it):
   - `tree_model_builder.py`: `track_qt_alloc("QStandardItem", item)` per child row
   - `image_service.py`: `track_qt_alloc("QImage", img)` on load-from-source path

5. **`main.py` CLI + env vars**:
   - `--manifest <path>` auto-loads (no QFileDialog)
   - `PHOTO_MANAGER_MEMORY_PROBE=1` enables
   - `PHOTO_MANAGER_MEMORY_PROBE_TAG=<str>` labels rows for A/B
   - `PHOTO_MANAGER_PROBE_RELOAD_COUNT=N` N sequential reload cycles
   - `PHOTO_MANAGER_MEMORY_PROBE_TRIM=1` (Windows) — `SetProcessWorkingSetSize` after Point 5 (H4 working-set discriminator)
   - `PHOTO_MANAGER_MEMORY_PROBE_REFERRERS=Type1,Type2` — `gc.get_referrers` dump for Stage-2 retainer hunt

6. **`docs/audits/memory-probe.md`** (new) — quick-start, env var reference, JSONL schema, pandas analysis snippet, 4-hypothesis decision table (H1 live retention / H2 allocator hoarding / H3 Qt heap / H4 Windows working-set) per the original #614 issue body.

### Files

- New: `scripts/memory_probe.py`, `scripts/generate_probe_fixture.py`, `tests/test_memory_probe.py`, `docs/audits/memory-probe.md`
- Modified (insertions only, all guarded): `main.py`, `app/views/main_window.py`, `app/views/workers/manifest_load_worker.py`, `app/views/handlers/file_operations.py`, `app/views/tree_model_builder.py`, `infrastructure/image_service.py`
- Docs: `docs/features.md` (new "Developer tool — memory probe" entry), `docs/testing.md` (top-level scripts table updated)

## Test plan

### Unit (new, 6 tests)

`tests/test_memory_probe.py` per `feedback_no_test_padding` — only test what catches real bugs:

- `test_disabled_snapshot_is_noop` — `PHOTO_MANAGER_MEMORY_PROBE` unset → no JSONL, no tracemalloc, no overhead.
- `test_enabled_snapshot_writes_jsonl_row` — env=1 → row with expected schema keys.
- `test_track_qt_alloc_increments` / `_decrements` — counter lifecycle via Qt `destroyed` signal.
- `test_import_guard_does_not_break_app` — simulate probe module removal; production code paths still work.

Skipped: tracemalloc/gc behaviour (that's testing stdlib, not us); fixture generator (dev-tool boundary).

### Smoke run on the fixture (manually executed by dev-agent)

`PHOTO_MANAGER_MEMORY_PROBE=1 PHOTO_MANAGER_PROBE_RELOAD_COUNT=3 main.py --manifest <fixture>`:

| Metric | Result | Confirms |
|---|---|---|
| `qt_counter_qstandarditem` across 3 reloads | `[0, 0, 0]` (flat) | **#619** `refresh_model` teardown holds |
| RSS at Point 4 | 175 → 206 → 209 MB (converging) | **#624** byte-budget LRU bound holds |
| `typed_counts.QStandardItem` | flat across reloads | Cross-check via `gc.get_objects` |
| Full suite | 0 regressions | Insertions are no-ops when probe disabled |

## Future use

When the next preview/cache change lands, a one-liner re-baselines:

```powershell
$env:PHOTO_MANAGER_MEMORY_PROBE='1'
$env:PHOTO_MANAGER_MEMORY_PROBE_TAG='post-change'
$env:PHOTO_MANAGER_PROBE_RELOAD_COUNT='3'
.venv\Scripts\python.exe main.py --manifest <real-or-fixture>
```

JSONL artifact appears in `~/AppData/Local/PhotoManager/logs/`. Compare against the previous baseline. Decision tree in `docs/audits/memory-probe.md`.

[qa-not-needed: pure dev tooling; not user-facing. All probe insertions are no-ops when the env var is unset (covered by `test_disabled_snapshot_is_noop`); the production code paths execute as before. Layer-3 qa scenarios run without probe enabled (full suite confirmed clean) so the no-op contract is exercised by the existing qa-batch on every PR.]

Refs #614
