### PR TITLE
fix(preview): apply EXIF orientation to DNG embedded-JPEG fast path

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -657,9 +657,9 @@ for the chore plan.
 - **Entry point:** `infrastructure/image_service.py` — `ImageService.__init__` and `_ByteBudgetLRUCache`.
 - **Trigger:** Populated automatically as the user navigates the result tree (each row selection or grid display triggers background image loads).
 - **Behaviour:** The in-memory image cache uses a byte-budget eviction policy instead of a fixed item count. Two independent tiers: a thumbnail tier (≈64 MB) for grid thumbnails (longest side ≤ 256 px) and a preview tier (≈192 MB) for single-view previews. Total budget = `min(256 MB, RAM // 32)`. When a tier exceeds its budget the least-recently-used entry is evicted. The on-disk cache writes versioned files under `~/AppData/Local/PhotoManager/thumbs/v1/<sha1>.jpg`; a recipe-version bump invalidates the old namespace. On first launch after upgrade, any unversioned `.jpg` files under `thumbs/` root are automatically deleted and a one-time status-bar notice is shown.
-- **Conditions / variants:** DNG files use the embedded JPEG fast path (rawpy `extract_thumb`) if the embedded thumbnail's longest side ≥ viewport cap (2048 px default); falls through to full `postprocess` decode only when the embedded thumb is too small or absent.
+- **Conditions / variants:** DNG files use the embedded JPEG fast path (rawpy `extract_thumb`) if the embedded thumbnail's longest side ≥ viewport cap (2048 px default); falls through to full `postprocess` decode only when the embedded thumb is too small or absent. **EXIF Orientation is applied** to the embedded JPEG via Pillow's `ImageOps.exif_transpose` before conversion to QImage — without this, portrait-grip iPhone ProRAW DNGs (which store landscape pixels + Orientation=6/8 in the embedded JPEG's EXIF) would render 90° rotated relative to Lightroom / File Explorer (`QImage.loadFromData` does not honour the Orientation tag; only `QImageReader.setAutoTransform` does, and the fast path uses neither). The bitmap (non-JPEG) thumb branch is unaffected — rawpy delivers the array in correct orientation natively.
 - **Related:** [#622](https://github.com/jackal998/photo-manager/issues/622) Phase 1; `infrastructure/image_service.py`; `tests/test_image_service.py`.
-- **Last verified:** 2026-06-09 (#622 Phase 1)
+- **Last verified:** 2026-06-10 (DNG embedded-JPEG orientation fix)
 
 ---
 

--- a/infrastructure/image_service.py
+++ b/infrastructure/image_service.py
@@ -503,11 +503,41 @@ class ImageService:
             # or thumb.format == rawpy.ThumbFormat.JPEG
             import rawpy as _rawpy  # type: ignore[attr-defined]
             if thumb.format == _rawpy.ThumbFormat.JPEG:  # type: ignore[attr-defined]
-                # JPEG bytes → decode via QImage
-                qimg = QImage()
-                ok = qimg.loadFromData(bytes(thumb.data))
-                if not ok or qimg.isNull():
-                    return None
+                # JPEG bytes → decode via Pillow so EXIF Orientation is honoured,
+                # then convert to QImage. PR #624's original `QImage.loadFromData`
+                # call ignored the embedded JPEG's Orientation tag (Qt only
+                # auto-rotates via `QImageReader.setAutoTransform`, never via
+                # `loadFromData`), so iPhone ProRAW DNGs shot in portrait grip
+                # rendered 90° rotated relative to Lightroom / File Explorer.
+                # Pillow is already a hard dependency (HEIC support); the
+                # bare-QImage fallback below is purely defensive.
+                qimg: QImage | None = None
+                if self._pillow_available:
+                    import io as _io
+                    assert Image is not None and ImageOps is not None
+                    try:
+                        with Image.open(_io.BytesIO(bytes(thumb.data))) as pil_im:
+                            try:
+                                pil_im = ImageOps.exif_transpose(pil_im)
+                            except (OSError, ValueError, AttributeError):
+                                # exif_transpose only raises on malformed EXIF —
+                                # fall through to the un-rotated image rather
+                                # than failing the whole load.
+                                pass
+                            qimg = self._pil_to_qimage(pil_im)
+                    except Exception as ex:
+                        logger.debug(
+                            "PIL thumb decode failed, falling back to QImage: {}",
+                            ex,
+                        )
+                        qimg = None
+                if qimg is None or qimg.isNull():
+                    # Fallback path: bare QImage.loadFromData (no rotation).
+                    # Reaches here only if Pillow is absent OR PIL decode raised.
+                    qimg = QImage()
+                    ok = qimg.loadFromData(bytes(thumb.data))
+                    if not ok or qimg.isNull():
+                        return None
             else:
                 # Bitmap array (H, W, 3)
                 arr = thumb.data

--- a/news/632.bugfix
+++ b/news/632.bugfix
@@ -1,0 +1,1 @@
+Preview pane — DNG embedded-JPEG fast path now honours the embedded EXIF Orientation tag. Portrait-grip iPhone ProRAW DNGs no longer render 90° rotated relative to Lightroom / File Explorer (#632 fixes a #624 regression).

--- a/tests/test_image_service.py
+++ b/tests/test_image_service.py
@@ -195,6 +195,7 @@ class TestDngEmbeddedJpegFastPath:
         """
         svc = ImageService.__new__(ImageService)
         svc._rawpy_available = True
+        svc._pillow_available = True
 
         raw = self._make_raw_mock_jpeg(4000, 3000)
         result = svc._try_rawpy_embedded_thumb(raw, viewport_cap=2048)
@@ -214,6 +215,7 @@ class TestDngEmbeddedJpegFastPath:
         """
         svc = ImageService.__new__(ImageService)
         svc._rawpy_available = True
+        svc._pillow_available = True
 
         raw = self._make_raw_mock_jpeg(800, 600)
         result = svc._try_rawpy_embedded_thumb(raw, viewport_cap=2048)
@@ -232,6 +234,7 @@ class TestDngEmbeddedJpegFastPath:
         """
         svc = ImageService.__new__(ImageService)
         svc._rawpy_available = True
+        svc._pillow_available = True
 
         raw = self._make_raw_mock_no_thumb()
         result = svc._try_rawpy_embedded_thumb(raw, viewport_cap=2048)
@@ -249,12 +252,74 @@ class TestDngEmbeddedJpegFastPath:
         """
         svc = ImageService.__new__(ImageService)
         svc._rawpy_available = True
+        svc._pillow_available = True
 
         raw = self._make_raw_mock_jpeg(400, 300)  # small thumb
         result = svc._try_rawpy_embedded_thumb(raw, viewport_cap=0)
 
         assert result is not None, (
             "With viewport_cap=0 (full-res), even a small embedded JPEG should be used"
+        )
+
+    def _make_raw_mock_jpeg_with_orientation(
+        self, pixel_width: int, pixel_height: int, orientation: int
+    ) -> MagicMock:
+        """Build a rawpy mock whose embedded JPEG carries a real EXIF
+        Orientation tag. Distinct from ``_make_raw_mock_jpeg`` (which
+        uses ``QImage.save`` and writes NO EXIF) — this one uses PIL
+        so ``ImageOps.exif_transpose`` has something to act on.
+        """
+        import io
+        import rawpy as _rawpy
+        from PIL import Image as PILImage
+
+        pil_im = PILImage.new(
+            "RGB", (pixel_width, pixel_height), color=(200, 100, 50)
+        )
+        buf = io.BytesIO()
+        exif = pil_im.getexif()
+        exif[0x0112] = orientation  # TIFF tag 0x0112 = Orientation
+        pil_im.save(buf, format="JPEG", exif=exif.tobytes())
+
+        thumb = SimpleNamespace(
+            format=_rawpy.ThumbFormat.JPEG,
+            data=buf.getvalue(),
+        )
+        raw = MagicMock()
+        raw.extract_thumb.return_value = thumb
+        return raw
+
+    def test_exif_orientation_corrected_for_dng_thumb(self, qapp_m):
+        """Embedded JPEG with Orientation=6 (rotate 90 CW, the iPhone
+        portrait-grip case) must be transposed so the returned QImage
+        comes out landscape (width > height).
+
+        Real failure mode (the bug reported on 2026-06-10): PR #624's
+        fast path called ``QImage.loadFromData`` which never reads the
+        Orientation tag, so portrait-grip ProRAW DNGs displayed 90°
+        rotated relative to Lightroom / File Explorer.
+
+        Pre-fix: ``QImage.loadFromData`` returns a 3000×4000 QImage
+        regardless of orientation → assertion ``width > height`` fails.
+
+        Post-fix: PIL decode + ``ImageOps.exif_transpose`` swaps the
+        dimensions according to the Orientation tag → 4000×3000 → passes.
+        """
+        svc = ImageService.__new__(ImageService)
+        svc._rawpy_available = True
+        svc._pillow_available = True
+
+        # Pixels written as 3000×4000 with Orientation=6.
+        # After exif_transpose, the image should be 4000×3000 (landscape).
+        raw = self._make_raw_mock_jpeg_with_orientation(
+            pixel_width=3000, pixel_height=4000, orientation=6
+        )
+        result = svc._try_rawpy_embedded_thumb(raw, viewport_cap=0)
+
+        assert result is not None and not result.isNull()
+        assert result.width() > result.height(), (
+            f"DNG embedded JPEG with Orientation=6 must come out landscape "
+            f"after exif_transpose; got {result.width()}×{result.height()}"
         )
 
 


### PR DESCRIPTION
## What

DNG previews (specifically iPhone ProRAW shot in portrait grip) were rendering **90° rotated** in the preview pane and full-res viewer. PR #624's embedded-JPEG fast path decodes the thumbnail via `QImage.loadFromData(bytes)` — but Qt's `loadFromData` never honours the EXIF Orientation tag (TIFF tag 0x0112). Only `QImageReader.setAutoTransform(True)` does.

This decodes the embedded JPEG through Pillow + `ImageOps.exif_transpose` first, then converts to QImage via the existing `_pil_to_qimage` helper.

## Why

Before #624 the DNG path went through `raw.postprocess()`, which reads `raw.sizes.flip` and rotates the sensor bitmap automatically — orientation was correct "for free". #624 shipped the fast path without porting that correction. iPhone ProRAW DNGs in portrait grip (landscape pixel buffer + Orientation=6) became upside-down/sideways compared to Lightroom or Windows File Explorer.

## How

### Source change (`infrastructure/image_service.py:505-510`)

Replaced the bare `QImage.loadFromData` JPEG branch with a PIL-primary path:

```python
if thumb.format == _rawpy.ThumbFormat.JPEG:
    qimg: QImage | None = None
    if self._pillow_available:
        import io as _io
        try:
            with Image.open(_io.BytesIO(bytes(thumb.data))) as pil_im:
                try:
                    pil_im = ImageOps.exif_transpose(pil_im)
                except (OSError, ValueError, AttributeError):
                    pass
                qimg = self._pil_to_qimage(pil_im)
        except Exception as ex:
            logger.debug("PIL thumb decode failed, falling back to QImage: {}", ex)
            qimg = None
    if qimg is None or qimg.isNull():
        # Defensive fallback: bare QImage.loadFromData (no rotation)
        qimg = QImage()
        if not qimg.loadFromData(bytes(thumb.data)) or qimg.isNull():
            return None
```

The bitmap (non-JPEG) thumb branch is unchanged — rawpy already delivers that array in correct orientation.

Pillow is a hard dependency (HEIC support), so the `_pillow_available=False` fallback realistically never triggers in production.

### Why CI didn't catch this

The existing `_make_raw_mock_jpeg` helper builds JPEG bytes via `QImage.save()`, which **does not write an EXIF Orientation tag**. So all four prior `TestDngEmbeddedJpegFastPath` tests decoded orientation-neutral JPEGs and would have passed regardless of whether the source path applies `exif_transpose`. This PR adds a new test, `test_exif_orientation_corrected_for_dng_thumb`, that uses **PIL** to write a real EXIF Orientation=6 tag into the mock JPEG. It fails on the pre-fix `loadFromData` code and passes after the fix — guarding future regressions of this exact shape.

### `docs/features.md`

The Preview-pane byte-budget LRU entry now documents the EXIF orientation step in the Conditions / variants section, with the rationale captured for future readers.

## Test plan

- [x] **Unit suite**: 12/12 tests in `tests/test_image_service.py` pass; full suite green; coverage gate satisfied
- [x] **Regression test**: new `test_exif_orientation_corrected_for_dng_thumb` covers the failure mode
- [ ] **Manual smoke** (on your end): open a portrait-grip iPhone ProRAW DNG in the app — preview should now match Lightroom / File Explorer orientation
- [ ] **CI**: qa shards will exercise the happy path

[qa-not-needed: the bug only surfaces on real DNGs with a non-identity EXIF Orientation tag in the embedded JPEG; qa-batch fixtures don't include such files. The new layer-1 test catches the exact regression with a synthetic JPEG carrying Orientation=6 — same coverage the layer-3 path would offer, without needing a binary DNG fixture in the repo. Manual smoke on a real iPhone DNG is the layer-3 equivalent.]

Refs #622 (PR #624 introduced the fast path that caused this regression)
