### PR TITLE
perf(file-ops): skip wasted incremental pass before regex full rebuild

### DIFF
--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -906,7 +906,12 @@ class FileOperationsHandler:
         self._mark_dirty()
         self._refresh_after_remove(paths)
 
-    def set_decision(self, items: list[dict], new_decision: str) -> None:
+    def set_decision(
+        self,
+        items: list[dict],
+        new_decision: str,
+        incremental: bool = True,
+    ) -> None:
         """Set user_decision for the given file items in memory and in SQLite.
 
         Note: this is the SHARED dispatcher. Single-row right-click calls
@@ -916,11 +921,12 @@ class FileOperationsHandler:
         that call into here. See photo-manager#164.
 
         Uses incremental cell update instead of a full model rebuild for
-        performance (#613). set_decision_by_regex stays on the full-rebuild
-        path because it may change the group-level SORT_ROLE aggregates
-        (min-decision across all members) — that requires re-reading all
-        members, which is cheaper via a complete rebuild than per-group
-        aggregate patching.
+        performance (#613). Pass ``incremental=False`` from callers that
+        will follow up with a full ``refresh_tree`` rebuild
+        (``set_decision_by_regex`` — the regex path mutates group-level
+        SORT_ROLE aggregates that can only be patched via complete
+        rebuild) so the inner ``update_decision_cells`` pass is skipped
+        rather than wasted (#629).
         """
         manifest_path = getattr(self, "_manifest_path", None)
         if not manifest_path:
@@ -945,11 +951,12 @@ class FileOperationsHandler:
             self._mark_dirty()
         # Incremental update: push only changed cells onto the existing model.
         # Falls back gracefully when tree_controller is not wired (unit tests).
-        tree_controller = getattr(self.parent, "tree_controller", None)
-        if tree_controller is not None and changes:
-            tree_controller.update_decision_cells(changes)
-        elif not changes:
-            pass  # nothing to update
+        # Skipped when ``incremental=False`` — caller will do a full rebuild
+        # (#629).
+        if incremental:
+            tree_controller = getattr(self.parent, "tree_controller", None)
+            if tree_controller is not None and changes:
+                tree_controller.update_decision_cells(changes)
         # #425 — pass the localised label, not the raw internal value:
         # the {decision} placeholder was previously interpolated with
         # "delete" / "" / "keep" verbatim, so zh_TW status reads showed
@@ -958,7 +965,12 @@ class FileOperationsHandler:
             t("file_op.decision_set_status", decision=_decision_display_label(new_decision))
         )
 
-    def set_locked_state(self, items: list[dict], locked: bool) -> None:
+    def set_locked_state(
+        self,
+        items: list[dict],
+        locked: bool,
+        incremental: bool = True,
+    ) -> None:
         """Flip ``is_locked`` for the given file items, in memory and SQLite.
 
         Lock state is orthogonal to ``user_decision`` and lives on its own
@@ -967,7 +979,9 @@ class FileOperationsHandler:
         photo-manager#164.
 
         Uses incremental cell update instead of a full model rebuild for
-        performance (#613).
+        performance (#613). Pass ``incremental=False`` from callers that
+        will follow up with a full ``refresh_tree`` rebuild (regex path —
+        same rationale as :meth:`set_decision`, #629).
         """
         manifest_path = getattr(self, "_manifest_path", None)
         if not manifest_path:
@@ -992,9 +1006,12 @@ class FileOperationsHandler:
             self._mark_dirty()
         # Incremental update: push only changed cells onto the existing model.
         # Falls back gracefully when tree_controller is not wired (unit tests).
-        tree_controller = getattr(self.parent, "tree_controller", None)
-        if tree_controller is not None and lock_changes:
-            tree_controller.update_lock_cells(lock_changes)
+        # Skipped when ``incremental=False`` — caller will do a full rebuild
+        # (#629).
+        if incremental:
+            tree_controller = getattr(self.parent, "tree_controller", None)
+            if tree_controller is not None and lock_changes:
+                tree_controller.update_lock_cells(lock_changes)
         report_count(
             self.status_reporter,
             t("file_op.locked_verb") if locked else t("file_op.unlocked_verb"),
@@ -1084,7 +1101,10 @@ class FileOperationsHandler:
         return [p for p in item_paths_in_order if p in locked_paths]
 
     def set_decision_with_lock_check(
-        self, items: list[dict], new_decision: str
+        self,
+        items: list[dict],
+        new_decision: str,
+        incremental: bool = True,
     ) -> None:
         """Apply ``new_decision`` to ``items``, surfacing the unified
         :class:`LockedRowsConfirmDialog` when any item is locked.
@@ -1096,6 +1116,12 @@ class FileOperationsHandler:
         freeze, unlocking IS the explicit escape, neither needs an
         extra confirm. See photo-manager#175 for the prior hybrid
         behavior and #182 for the redesign rationale.
+
+        ``incremental=False`` is threaded down to the inner
+        :meth:`set_decision` / :meth:`set_locked_state` calls (and the
+        inline ``APPLY_ALL_UNLOCKED`` branch) so callers that follow up
+        with a full rebuild — ``set_decision_by_regex`` — don't pay for
+        a discarded incremental pass first (#629).
         """
         file_items = [it for it in items if it.get("type") == "file"]
         if not file_items:
@@ -1103,10 +1129,10 @@ class FileOperationsHandler:
 
         # Lock / unlock — idempotent, applied to all file_items.
         if new_decision == LOCK_SENTINEL:
-            self.set_locked_state(file_items, locked=True)
+            self.set_locked_state(file_items, locked=True, incremental=incremental)
             return
         if new_decision == UNLOCK_SENTINEL:
-            self.set_locked_state(file_items, locked=False)
+            self.set_locked_state(file_items, locked=False, incremental=incremental)
             return
 
         locked_paths = self._locked_paths_in(file_items)
@@ -1122,7 +1148,7 @@ class FileOperationsHandler:
 
         if not locked_paths:
             # Fast path — no locked rows touched, no dialog needed.
-            self.set_decision(file_items, resolved_decision)
+            self.set_decision(file_items, resolved_decision, incremental=incremental)
             return
 
         from app.views.dialogs.locked_rows_confirm_dialog import (
@@ -1171,12 +1197,15 @@ class FileOperationsHandler:
             if batch_decisions or batch_locks:
                 self._mark_dirty()
             # Single incremental tree-update pass for both COL_ACTION + COL_LOCK.
-            tree_controller = getattr(self.parent, "tree_controller", None)
-            if tree_controller is not None:
-                if decision_changes:
-                    tree_controller.update_decision_cells(decision_changes)
-                if lock_changes:
-                    tree_controller.update_lock_cells(lock_changes)
+            # Skipped when ``incremental=False`` — caller will do a full rebuild
+            # (#629).
+            if incremental:
+                tree_controller = getattr(self.parent, "tree_controller", None)
+                if tree_controller is not None:
+                    if decision_changes:
+                        tree_controller.update_decision_cells(decision_changes)
+                    if lock_changes:
+                        tree_controller.update_lock_cells(lock_changes)
             self.status_reporter.show_status(
                 t("file_op.decision_set_status", decision=_decision_display_label(resolved_decision))
             )
@@ -1186,7 +1215,7 @@ class FileOperationsHandler:
         locked_set = set(locked_paths)
         unlocked_items = [it for it in file_items if it["path"] not in locked_set]
         if unlocked_items:
-            self.set_decision(unlocked_items, resolved_decision)
+            self.set_decision(unlocked_items, resolved_decision, incremental=incremental)
         if locked_set:
             self.status_reporter.show_status(
                 t(
@@ -1285,12 +1314,16 @@ class FileOperationsHandler:
         # All destructive + lock/unlock routing now goes through the
         # shared entry point so the dialog flow is identical to
         # single-row right-click and bulk multi-select.
-        self.set_decision_with_lock_check(matching, new_decision)
+        # ``incremental=False`` skips the inner ``update_decision_cells`` /
+        # ``update_lock_cells`` pass — the rebuild below would discard it
+        # anyway (#629).
+        self.set_decision_with_lock_check(matching, new_decision, incremental=False)
         # Full rebuild here — the regex path may affect many rows across
         # many groups, and the group-level SORT_ROLE aggregates (min-decision
         # per group) can only be updated correctly via a complete rebuild.
         # The incremental path inside set_decision is intentionally bypassed
-        # for this reason.  See #613 scope boundary comment in set_decision.
+        # for this reason. See #613 scope boundary comment in set_decision
+        # and #629 for the incremental-pass-skip.
         self.ui_updater.refresh_tree(self.vm.groups)
 
     def _matched_paths_for_pattern(

--- a/news/636.feature
+++ b/news/636.feature
@@ -1,0 +1,1 @@
+Set Action regex no longer pays for a discarded incremental cell update before the unavoidable full tree rebuild — N wasted `setData` calls per Apply on a large manifest are now skipped (#636, closes #629).

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -288,15 +288,89 @@ class TestSetDecision:
         """set_decision_by_regex must still call ui_updater.refresh_tree — it
         modifies group-level SORT_ROLE aggregates that require a full rebuild.
         Regression guard: the incremental path must NOT be taken here (#613).
+        And the inner incremental pass must be SKIPPED (not just discarded) so
+        N wasted setData calls don't precede the rebuild (#629).
         """
         rec = _rec("/a.jpg", group=1)
         vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=[rec])])
         db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
         handler, ui_updater, _ = _make_handler(vm, str(db))
+        # Wire a real-shape tree_controller mock so we can assert the
+        # inner incremental pass is actually skipped (#629), not silently
+        # absent because parent.tree_controller happens to be unwired.
+        tree_controller = MagicMock()
+        handler.parent.tree_controller = tree_controller
 
         handler.set_decision_by_regex("File Name", r"a\.jpg", "delete")
 
         ui_updater.refresh_tree.assert_called_once()
+        tree_controller.update_decision_cells.assert_not_called()
+
+    def test_set_decision_incremental_false_skips_cell_update(self, tmp_path):
+        """set_decision(incremental=False) must mutate state + write SQLite but
+        SKIP the tree_controller.update_decision_cells pass (#629). The kwarg
+        is the lever set_decision_by_regex pulls to avoid the wasted setData
+        round-trip before its unavoidable refresh_tree rebuild.
+        """
+        rec = _rec("/a.jpg")
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=[rec])])
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
+        handler, ui_updater, _ = _make_handler(vm, str(db))
+        tree_controller = MagicMock()
+        handler.parent.tree_controller = tree_controller
+
+        handler.set_decision(
+            [{"type": "file", "path": "/a.jpg"}], "delete", incremental=False
+        )
+
+        # State + persistence still happen.
+        assert rec.user_decision == "delete"
+        assert _read_decision(db, "/a.jpg") == "delete"
+        # Incremental pass skipped; full rebuild not triggered either (that's
+        # the caller's job in the regex path).
+        tree_controller.update_decision_cells.assert_not_called()
+        ui_updater.refresh_tree.assert_not_called()
+
+    def test_set_locked_state_incremental_false_skips_cell_update(self, tmp_path):
+        """set_locked_state(incremental=False) must mutate state + write SQLite
+        but SKIP the tree_controller.update_lock_cells pass (#629). Mirror of
+        the user_decision regex path for LOCK_SENTINEL / UNLOCK_SENTINEL regex
+        applies.
+        """
+        rec = _rec("/a.jpg")
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=[rec])])
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
+        handler, ui_updater, _ = _make_handler(vm, str(db))
+        tree_controller = MagicMock()
+        handler.parent.tree_controller = tree_controller
+
+        handler.set_locked_state(
+            [{"type": "file", "path": "/a.jpg"}], locked=True, incremental=False
+        )
+
+        assert rec.is_locked is True
+        tree_controller.update_lock_cells.assert_not_called()
+        ui_updater.refresh_tree.assert_not_called()
+
+    def test_lock_regex_skips_inner_incremental_pass(self, tmp_path):
+        """Regex with LOCK_SENTINEL routes through set_decision_with_lock_check
+        → set_locked_state — and must also skip the inner incremental pass
+        before the regex-path refresh_tree rebuild (#629).
+        """
+        from app.views.constants import LOCK_SENTINEL
+
+        rec = _rec("/a.jpg", group=1)
+        vm = SimpleNamespace(groups=[PhotoGroup(group_number=1, items=[rec])])
+        db = _make_db(tmp_path, [{"source_path": "/a.jpg"}])
+        handler, ui_updater, _ = _make_handler(vm, str(db))
+        tree_controller = MagicMock()
+        handler.parent.tree_controller = tree_controller
+
+        handler.set_decision_by_regex("File Name", r"a\.jpg", LOCK_SENTINEL)
+
+        assert rec.is_locked is True
+        ui_updater.refresh_tree.assert_called_once()
+        tree_controller.update_lock_cells.assert_not_called()
 
 
 # ── remove_from_list (DB sync) ─────────────────────────────────────────────


### PR DESCRIPTION
## What

Closes #629 — `set_decision_by_regex` used to do N incremental `setData`
calls + N proxy `dataChanged` emissions via
`tree_controller.update_decision_cells(...)` and then **immediately**
discard all of that work by firing a full `ui_updater.refresh_tree(...)`
rebuild on the very next line. The incremental pass was pure waste.

After this PR an `incremental: bool = True` kwarg threads through
`set_decision_with_lock_check` → `set_decision` / `set_locked_state`.
The regex path passes `incremental=False`, so the inner per-cell pass
is **skipped** rather than discarded. Every other caller keeps the
default `True` and is byte-identical to before.

## Why

PR #617 (the original `update_decision_cells` introduction) explicitly
called out that `set_decision_by_regex` stays on full-rebuild — the
regex change can shift group-level SORT_ROLE aggregates (min-decision
across all members) which can't be patched incrementally without
re-reading every sibling row. That part is still true; the full
rebuild stays. What was wrong was doing the per-cell pass **first**
and then throwing it away.

User-visible impact: medium. The regex-set-action gesture is less
frequent than single-row set-decision, but on a large manifest (13k
rows) the wasted pass added visible latency on top of the unavoidable
rebuild. The four-item audit workflow that drove #629–#635 ranked
this as the highest-impact perf finding remaining after #634's
incremental `remove_rows`.

## How

### Thread `incremental` kwarg through the three dispatchers

`app/views/handlers/file_operations.py`:

- `set_decision(items, new_decision, incremental: bool = True)` — when
  `False`, skips the `tree_controller.update_decision_cells(changes)`
  block entirely. State mutation + SQLite write are unconditional.
- `set_locked_state(items, locked, incremental: bool = True)` —
  symmetric for `update_lock_cells`. Covers the regex
  `LOCK_SENTINEL` / `UNLOCK_SENTINEL` path which also pays the
  rebuild cost downstream.
- `set_decision_with_lock_check(items, new_decision, incremental: bool = True)`
  — threads the kwarg to both inner `set_decision` /
  `set_locked_state` calls (lock-sentinel short-circuits, fast path,
  `APPLY_UNLOCKED_ONLY`) **and** to the inline `APPLY_ALL_UNLOCKED`
  branch which used to do `update_decision_cells` + `update_lock_cells`
  directly.

### Regex callsite

`set_decision_by_regex` (line ~1320) passes `incremental=False`. The
subsequent `refresh_tree(self.vm.groups)` is unchanged — the regex
path still needs the full rebuild to recompute group SORT_ROLE
aggregates; that's correct and #613's scope-boundary comment was
right about it. The fix is just not paying for an incremental pass
that the rebuild would clobber a microsecond later.

### Other callers are byte-identical

Every other callsite of `set_decision` / `set_locked_state` /
`set_decision_with_lock_check` (single-row right-click, multi-select
context menu, `set_decision_to_highlighted`, the d/k decision
shortcut from #625) passes only positional args, gets the default
`True`, and behaves exactly as before. Grepped to confirm:
`context_menu.py`, `action_handlers.py`, and the internal recursive
call in `set_decision_with_lock_check` all qualify.

## Tests

`tests/test_file_operations.py`:

1. **Tightened** `test_set_decision_by_regex_still_uses_full_rebuild` —
   used to only assert `refresh_tree.assert_called_once()`, which
   passed even when no `tree_controller` was wired (so an unconditional
   inner pass would have gone undetected). Now wires a mock
   `tree_controller` and **additionally** asserts
   `update_decision_cells.assert_not_called()` to pin the
   skip-the-inner-pass contract.
2. **New** `test_set_decision_incremental_false_skips_cell_update` —
   direct call with `incremental=False`: state mutation +
   `_read_decision` still happen, `update_decision_cells` does NOT.
3. **New** `test_set_locked_state_incremental_false_skips_cell_update` —
   mirror for the lock path.
4. **New** `test_lock_regex_skips_inner_incremental_pass` — end-to-end
   regex with `LOCK_SENTINEL` proves the threading actually reaches
   `set_locked_state` and the inner pass is skipped before the
   refresh_tree fires.

## Test plan

- [x] **Unit suite**: `tests/test_file_operations.py` 130 tests pass
- [x] **Full suite**: pytest passes with coverage gate
- [ ] **Manual smoke**: open Set Action dialog on a large manifest →
      regex → Apply → grouping/sorting still correct (full rebuild
      preserved) + perceived latency drops (no wasted inner pass)
- [ ] **CI**: full suite + qa-batch

[qa-not-needed: `qa/scenarios/s31_simple_mode_regex.py` already
exercises the regex Apply path end-to-end at layer 3 (correctness:
matched rows get the right action). The new unit tests pin the
skip-the-inner-pass contract at layer 1. A qa scenario for perf
specifically would need wall-clock timing assertions which qa-batch
doesn't reliably support on Windows CI.]

[docs-not-needed: pure internal perf optimization with no
user-visible behaviour change — same Set Action dialog, same regex
input, same Apply button, same row-matching semantics. Only the
internal cell-update pass before the rebuild is skipped. The
existing features.md entry for the Set Action dialog (dual-section
Simple + Regex view) already documents the user-facing behaviour
and remains accurate.]

Closes #629
