### PR TITLE
perf(memory): batch O(N) memory wins — slots / cache.clear / worker deleteLater

### DIFF
--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -199,6 +199,16 @@ class UIUpdateCallback(Protocol):
         """
         ...
 
+    def clear_image_cache(self) -> None:
+        """Drop the in-memory image cache on manifest unload (#616).
+
+        Called from ``_on_manifest_loaded`` so RAM from the previous
+        manifest's thumbnails/previews is released before the next
+        manifest's images begin to populate. The disk cache is
+        preserved — it's content-hash-keyed and valid across manifests.
+        """
+        ...
+
 
 class StatusReporter(Protocol):
     """Protocol for status reporting callback."""
@@ -389,6 +399,11 @@ class FileOperationsHandler:
         # for the time clear takes to run, which is still much faster
         # than refresh_tree.
         self.ui_updater.clear_preview()
+        # #616: release in-memory image cache RAM from the previous
+        # manifest. Without this the LRU caches (thumb + preview)
+        # accumulate across reloads. Disk cache is preserved — it's
+        # content-hash-keyed and valid across manifests.
+        self.ui_updater.clear_image_cache()
 
     def _on_manifest_failed(self, error: str) -> None:
         logger.error("Open manifest failed: {}", error)

--- a/app/views/handlers/file_operations.py
+++ b/app/views/handlers/file_operations.py
@@ -316,8 +316,18 @@ class FileOperationsHandler:
         worker.progress.connect(lambda msg: self.status_reporter.show_status(msg, 0))
         worker.finished.connect(lambda groups: self._on_manifest_loaded(groups, path))
         worker.failed.connect(self._on_manifest_failed)
+        # #616: schedule C++ destruction on either terminal signal so the
+        # worker doesn't accumulate as a Qt child of MainWindow across
+        # manifest reloads. The lambda closes over the specific worker so
+        # a subsequent load can't tear down the wrong one. Discards the
+        # signal arg because deleteLater takes none — the worker's custom
+        # ``finished(list)`` would otherwise pass the groups through.
+        worker.finished.connect(lambda _groups: worker.deleteLater())
+        worker.failed.connect(lambda _err: worker.deleteLater())
         worker.start()
-        # Keep reference so the worker is not garbage-collected
+        # Keep reference so the worker is not garbage-collected before
+        # deleteLater fires. The next ``_start_manifest_load`` reassigns
+        # this attribute, releasing the prior Python wrapper to GC.
         self._load_worker = worker
 
     def _on_manifest_loaded(self, groups: list, path: str) -> None:

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -544,6 +544,17 @@ class MainWindow(QMainWindow):
         from app.views.main_window_helpers import count_isolated_rows
         from infrastructure.manifest_repository import ManifestRepository
         try:
+            # #616: release in-memory image cache RAM from the previous
+            # manifest BEFORE swapping vm.groups. The async
+            # Open-Manifest path goes through ``_on_manifest_loaded``
+            # which clears via the UIUpdateCallback proxy; this sync
+            # path (post-scan + relocalize) doesn't, so it needs an
+            # explicit clear here. Disk cache is preserved. ``getattr``
+            # so test scaffolds that mock MainWindow without ``_img``
+            # don't AttributeError into the broad-except below.
+            img = getattr(self, "_img", None)
+            if img is not None and hasattr(img, "clear_cache"):
+                img.clear_cache()
             self._vm.load_from_repo(ManifestRepository(), manifest_path)
             self.file_operations._manifest_path = manifest_path
             self.show_groups_summary(self._vm.groups)
@@ -1201,6 +1212,19 @@ class UIUpdaterImpl:
         the app. See test_probe_uiupdater_impl_proxies_every_protocol_method.
         """
         self.window.clear_preview()
+
+    def clear_image_cache(self) -> None:
+        """Drop the in-memory image cache on manifest unload (#616).
+
+        Proxies through to ``MainWindow._img.clear_cache()``. Guarded
+        against ``_img is None`` because some test scaffolds construct
+        a MainWindow without the image service wired up. The
+        ``hasattr`` check is belt-and-braces: a stub image service in
+        future tests shouldn't crash this proxy.
+        """
+        img = getattr(self.window, "_img", None)
+        if img is not None and hasattr(img, "clear_cache"):
+            img.clear_cache()
 
 
 class TreeDataProviderImpl:

--- a/core/models.py
+++ b/core/models.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 
 
-@dataclass
+@dataclass(slots=True)
 class PhotoRecord:
     """A single photo row loaded from a manifest."""
 
@@ -46,7 +46,7 @@ class PhotoRecord:
     score: float | None = None
 
 
-@dataclass
+@dataclass(slots=True)
 class PhotoGroup:
     """A collection of photo records grouped by `group_number`."""
 

--- a/infrastructure/image_service.py
+++ b/infrastructure/image_service.py
@@ -12,6 +12,7 @@ from ctypes import wintypes
 from dataclasses import dataclass
 import hashlib
 import os
+import threading
 from pathlib import Path
 from typing import Any
 import uuid
@@ -146,35 +147,49 @@ class _ByteBudgetLRUCache:
     """LRU cache with a byte-budget capacity instead of item-count capacity.
 
     Evicts the LRU entry whenever the total byte sum would exceed the budget.
+
+    Thread-safe. ``_ImageTask`` (``app/views/image_tasks.py``) calls
+    ``get``/``put`` from QThreadPool workers; ``clear()`` runs on the
+    main thread on manifest unload. Without the lock the OrderedDict
+    mutation in any of the three would race the others (#616).
     """
 
     def __init__(self, budget_bytes: int) -> None:
         self._budget = max(1, int(budget_bytes))
         self._data: OrderedDict[str, _MemCacheItem] = OrderedDict()
         self._total_bytes: int = 0
+        self._lock = threading.Lock()
 
     def get(self, key: str) -> QImage | None:
-        item = self._data.get(key)
-        if not item:
-            return None
-        self._data.move_to_end(key)
-        return item.image
+        with self._lock:
+            item = self._data.get(key)
+            if not item:
+                return None
+            self._data.move_to_end(key)
+            return item.image
 
     def put(self, key: str, image: QImage) -> None:
         byte_size = image.sizeInBytes() if not image.isNull() else 1
-        if key in self._data:
-            old = self._data[key]
-            self._total_bytes -= old.byte_size
-            self._data.move_to_end(key)
-            self._data[key] = _MemCacheItem(key, image, byte_size)
-            self._total_bytes += byte_size
-        else:
-            self._data[key] = _MemCacheItem(key, image, byte_size)
-            self._total_bytes += byte_size
-        # Evict LRU until within budget
-        while self._total_bytes > self._budget and len(self._data) > 1:
-            _, evicted = self._data.popitem(last=False)
-            self._total_bytes -= evicted.byte_size
+        with self._lock:
+            if key in self._data:
+                old = self._data[key]
+                self._total_bytes -= old.byte_size
+                self._data.move_to_end(key)
+                self._data[key] = _MemCacheItem(key, image, byte_size)
+                self._total_bytes += byte_size
+            else:
+                self._data[key] = _MemCacheItem(key, image, byte_size)
+                self._total_bytes += byte_size
+            # Evict LRU until within budget
+            while self._total_bytes > self._budget and len(self._data) > 1:
+                _, evicted = self._data.popitem(last=False)
+                self._total_bytes -= evicted.byte_size
+
+    def clear(self) -> None:
+        """Evict all entries and reset the byte counter (#616)."""
+        with self._lock:
+            self._data.clear()
+            self._total_bytes = 0
 
     @property
     def total_bytes(self) -> int:
@@ -255,6 +270,18 @@ class ImageService:
     def get_preview(self, path: str, max_side: int) -> Any:
         """Return preview image for `path` bounded by `max_side`."""
         return self._get_image(path, max_side)
+
+    def clear_cache(self) -> None:
+        """Drop all in-memory cached images (thumb + preview tiers).
+
+        Called when a manifest unloads so RAM from the previous library
+        is released before the next manifest's thumbnails begin to
+        populate (#616). The disk cache under the versioned thumbs
+        directory is intentionally preserved — it's keyed by content
+        hash and valid across manifests.
+        """
+        self._thumb_cache.clear()
+        self._preview_cache.clear()
 
     # Internal helpers
     def _get_image(self, path: str, requested_side: int) -> QImage:

--- a/news/637.bugfix
+++ b/news/637.bugfix
@@ -1,0 +1,1 @@
+Manifest reloads now release in-memory image cache RAM and stop accumulating `ManifestLoadWorker` Qt children, and `PhotoRecord` / `PhotoGroup` use `__slots__` to drop ~200 bytes per instance — three O(N) memory wins across the manifest lifecycle (#637, refs #616).

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -1156,6 +1156,47 @@ class TestManifestLoadCallbacks:
         from app.views.handlers.file_operations import UIUpdateCallback
         assert "clear_preview" in dir(UIUpdateCallback)
 
+    def test_ui_update_callback_protocol_has_clear_image_cache(self):
+        """#616 — pin the Protocol entry. The static probe in
+        test_ui_probes.py enforces UIUpdaterImpl mirrors the Protocol,
+        but the Protocol declaration itself is the source of truth and
+        deserves its own drift guard."""
+        from app.views.handlers.file_operations import UIUpdateCallback
+        assert "clear_image_cache" in dir(UIUpdateCallback)
+
+    def test_on_manifest_loaded_calls_clear_image_cache(self, tmp_path):
+        """#616 — _on_manifest_loaded must drop the previous manifest's
+        in-memory image cache so RAM is released before the new
+        manifest's images start populating. Ordering: AFTER
+        set_baseline (qa scenarios poll the baseline), AFTER
+        clear_preview (which closes any pending decode that would
+        re-populate the cache moments later)."""
+        from app.views.handlers.file_operations import FileOperationsHandler
+        from types import SimpleNamespace
+
+        vm = SimpleNamespace(groups=[], group_count=1)
+        ui = MagicMock()
+        status = MagicMock()
+        parent = MagicMock()
+        parent.menu_controller = MagicMock()
+        handler = FileOperationsHandler(
+            vm=vm, settings=MagicMock(),
+            parent_widget=parent, ui_updater=ui, status_reporter=status,
+        )
+
+        groups = [PhotoGroup(group_number=1, items=[_rec("/a.jpg")])]
+        handler._on_manifest_loaded(groups, str(tmp_path / "m.sqlite"))
+
+        ui.clear_image_cache.assert_called_once_with()
+        # Same ordering invariant as clear_preview: cache eviction comes
+        # AFTER refresh_tree. A future refactor that moves it earlier
+        # would risk evicting entries the freshly-rebuilt tree's
+        # eager-prefetch is about to fetch.
+        method_call_order = [c[0] for c in ui.method_calls]
+        assert method_call_order.index("clear_image_cache") > method_call_order.index(
+            "refresh_tree"
+        )
+
     def test_on_manifest_failed_logs_and_disables_actions(self):
         """No prior manifest loaded → failure disables actions (first-load case)."""
         from app.views.handlers.file_operations import FileOperationsHandler

--- a/tests/test_file_operations.py
+++ b/tests/test_file_operations.py
@@ -1261,6 +1261,78 @@ class TestManifestLoadCallbacks:
         # Prior manifest exists — start_manifest_load must NOT pre-emptively disable.
         parent.menu_controller.set_manifest_actions.assert_not_called()
 
+    def test_start_manifest_load_wires_deleteLater_on_finished(self, tmp_path):
+        """#616: worker.finished must be connected to worker.deleteLater so
+        the worker doesn't accumulate as a Qt child of MainWindow across
+        manifest reloads. Lambda-discard form sidesteps the QThread base-class
+        finished() vs custom finished(list) signal-name clash.
+        """
+        from app.views.handlers.file_operations import FileOperationsHandler
+        from types import SimpleNamespace
+
+        vm = SimpleNamespace(groups=[], _default_sort=[])
+        parent = MagicMock()
+        parent.menu_controller = MagicMock()
+        handler = FileOperationsHandler(
+            vm=vm, settings=MagicMock(),
+            parent_widget=parent, ui_updater=MagicMock(), status_reporter=MagicMock(),
+        )
+
+        with patch("app.views.workers.manifest_load_worker.ManifestLoadWorker") as worker_cls:
+            worker = MagicMock()
+            worker_cls.return_value = worker
+            handler._start_manifest_load(str(tmp_path / "new.sqlite"))
+
+            # Simulate the custom finished(list) signal firing — the lambda
+            # discards the arg and calls worker.deleteLater().
+            finished_connects = worker.finished.connect.call_args_list
+            assert len(finished_connects) >= 2, (
+                "expected at least 2 finished.connect() calls "
+                "(handler + deleteLater)"
+            )
+            # Fire each connected slot with a stub groups list. The
+            # deleteLater lambda must call worker.deleteLater().
+            for call in finished_connects:
+                slot = call.args[0]
+                try:
+                    slot([])
+                except Exception:
+                    pass
+            worker.deleteLater.assert_called()
+
+    def test_start_manifest_load_wires_deleteLater_on_failed(self, tmp_path):
+        """#616: worker.failed must also schedule deleteLater so a failed load
+        doesn't leave the worker as a permanent MainWindow child.
+        """
+        from app.views.handlers.file_operations import FileOperationsHandler
+        from types import SimpleNamespace
+
+        vm = SimpleNamespace(groups=[], _default_sort=[])
+        parent = MagicMock()
+        parent.menu_controller = MagicMock()
+        handler = FileOperationsHandler(
+            vm=vm, settings=MagicMock(),
+            parent_widget=parent, ui_updater=MagicMock(), status_reporter=MagicMock(),
+        )
+
+        with patch("app.views.workers.manifest_load_worker.ManifestLoadWorker") as worker_cls:
+            worker = MagicMock()
+            worker_cls.return_value = worker
+            handler._start_manifest_load(str(tmp_path / "new.sqlite"))
+
+            failed_connects = worker.failed.connect.call_args_list
+            assert len(failed_connects) >= 2, (
+                "expected at least 2 failed.connect() calls "
+                "(handler + deleteLater)"
+            )
+            for call in failed_connects:
+                slot = call.args[0]
+                try:
+                    slot("error message")
+                except Exception:
+                    pass
+            worker.deleteLater.assert_called()
+
     def test_set_manifest_actions_enabled_delegates_to_controller(self):
         """_set_manifest_actions_enabled forwards to MenuController.set_manifest_actions."""
         from app.views.handlers.file_operations import FileOperationsHandler

--- a/tests/test_image_service.py
+++ b/tests/test_image_service.py
@@ -112,6 +112,33 @@ class TestByteBudgetLRU:
         cache.put("x", img)
         assert cache.total_bytes >= 0
 
+    def test_clear_evicts_all_entries_and_resets_total_bytes(self, qapp_m):
+        """clear() must drop every entry AND reset _total_bytes to 0 so the
+        budget accountant doesn't drift. #616 — RAM not released across
+        manifest reloads is the user-visible symptom."""
+        cache = _ByteBudgetLRUCache(budget_bytes=100)
+        img = _make_qimage(1, 1)
+        cache.put("a", img)
+        cache.put("b", img)
+        cache.put("c", img)
+        assert cache.total_bytes > 0
+        assert cache.get("a") is not None
+
+        cache.clear()
+
+        assert cache.get("a") is None
+        assert cache.get("b") is None
+        assert cache.get("c") is None
+        assert cache.total_bytes == 0
+
+    def test_clear_is_safe_on_empty_cache(self, qapp_m):
+        """clear() on an empty cache must not raise — it's the default
+        state on first construction, and an unconditional clear() on
+        manifest unload should be a no-op there."""
+        cache = _ByteBudgetLRUCache(budget_bytes=100)
+        cache.clear()
+        assert cache.total_bytes == 0
+
     def test_thumb_vs_preview_split_independent(self, qapp_m):
         """Filling the thumb tier must not evict from the preview tier.
 
@@ -137,6 +164,27 @@ class TestByteBudgetLRU:
         assert svc._preview_cache.get("pv_key") is not None, (
             "preview cache evicted by thumb overflow — caches must be independent"
         )
+
+    def test_image_service_clear_cache_clears_both_tiers(self, qapp_m):
+        """ImageService.clear_cache() must clear both _thumb_cache AND
+        _preview_cache so RAM from the previous manifest is fully
+        released on unload (#616). Clearing only one tier would leak
+        whichever side held the larger working set."""
+        svc = ImageService.__new__(ImageService)
+        svc._thumb_cache = _ByteBudgetLRUCache(1024)
+        svc._preview_cache = _ByteBudgetLRUCache(1024)
+        img = _make_qimage(1, 1)
+        svc._thumb_cache.put("th", img)
+        svc._preview_cache.put("pv", img)
+        assert svc._thumb_cache.get("th") is not None
+        assert svc._preview_cache.get("pv") is not None
+
+        svc.clear_cache()
+
+        assert svc._thumb_cache.get("th") is None
+        assert svc._preview_cache.get("pv") is None
+        assert svc._thumb_cache.total_bytes == 0
+        assert svc._preview_cache.total_bytes == 0
 
 
 # ── DNG embedded JPEG fast path ──────────────────────────────────────────

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -646,6 +646,45 @@ def test_load_manifest_from_path_loads_refreshes_and_sets_status(monkeypatch):
     fake_self.set_status_baseline.assert_called_once()
 
 
+def test_load_manifest_from_path_clears_image_cache_when_img_wired(monkeypatch):
+    """#616 — the sync load path (post-scan + relocalize) must release
+    the in-memory image cache before swapping vm.groups. The async
+    Open-Manifest path goes through ``_on_manifest_loaded`` which has
+    its own clear; this is the matching cleanup for the sync paths.
+    """
+    import app.views.main_window as mw_mod
+
+    fake_vm = MagicMock()
+    fake_vm.groups = []
+    fake_vm.group_count = 0
+    fake_file_ops = MagicMock()
+    fake_menu = MagicMock()
+    fake_img = MagicMock()
+
+    fake_self = SimpleNamespace(
+        _vm=fake_vm,
+        _img=fake_img,
+        file_operations=fake_file_ops,
+        show_groups_summary=lambda groups: None,
+        refresh_tree=MagicMock(),
+        menu_controller=fake_menu,
+        set_status_baseline=MagicMock(),
+    )
+
+    monkeypatch.setattr(
+        "app.views.main_window_helpers.count_isolated_rows",
+        lambda path, grouped: 0,
+    )
+    monkeypatch.setattr(
+        "infrastructure.manifest_repository.ManifestRepository",
+        lambda: MagicMock(),
+    )
+
+    mw_mod.MainWindow._load_manifest_from_path(fake_self, "/m.sqlite")
+
+    fake_img.clear_cache.assert_called_once_with()
+
+
 # ── _on_header_clicked: sort tracking (#121 territory) ───────────────────
 
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,135 @@
+"""Layer-1 tests for core.models — slots-on-dataclass hygiene (#616).
+
+The dataclasses are converted to @dataclass(slots=True) to drop the
+per-instance __dict__. At N=1M records the savings are ~200-400 MB
+on CPython 3.11. The new constraint: attribute assignment outside the
+declared fields raises AttributeError instead of silently creating a
+new entry — these tests pin that contract so a future "forgot to
+declare a field" bug surfaces here, not under a user load.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime
+
+import pytest
+
+from core.models import PhotoGroup, PhotoRecord
+
+
+def _rec(**overrides) -> PhotoRecord:
+    """Minimal PhotoRecord for tests — only the required fields."""
+    base = dict(
+        group_number=1,
+        is_mark=False,
+        is_locked=False,
+        folder_path="/dir",
+        file_path="/dir/a.jpg",
+        capture_date=None,
+        modified_date=None,
+        file_size_bytes=0,
+    )
+    base.update(overrides)
+    return PhotoRecord(**base)
+
+
+class TestSlotsContract:
+    def test_photo_record_has_slots(self):
+        """slots=True must set __slots__ and remove __dict__ from the class."""
+        assert hasattr(PhotoRecord, "__slots__")
+        # __dict__ is the per-instance dict that slots removes; the class
+        # itself still has a mappingproxy __dict__ — instances are what matter.
+        rec = _rec()
+        assert not hasattr(rec, "__dict__")
+
+    def test_photo_group_has_slots(self):
+        assert hasattr(PhotoGroup, "__slots__")
+        grp = PhotoGroup(group_number=1)
+        assert not hasattr(grp, "__dict__")
+
+    def test_slots_blocks_unknown_attribute_on_record(self):
+        """Assigning an undeclared attribute must raise — the whole point
+        of slots is to make that error LOUD instead of a silent memory leak."""
+        rec = _rec()
+        with pytest.raises(AttributeError):
+            rec.some_undeclared_field = "value"  # type: ignore[attr-defined]
+
+    def test_slots_blocks_unknown_attribute_on_group(self):
+        grp = PhotoGroup(group_number=1)
+        with pytest.raises(AttributeError):
+            grp.some_undeclared_field = "value"  # type: ignore[attr-defined]
+
+
+class TestDeclaredFieldWrites:
+    """Real production paths mutate these fields post-construction
+    (set_decision, set_locked_state, etc.). Pin that every one of them
+    still works after slots — this is the regression net the production
+    code relies on."""
+
+    def test_user_decision_write_round_trip(self):
+        rec = _rec()
+        assert rec.user_decision == ""
+        rec.user_decision = "delete"
+        assert rec.user_decision == "delete"
+
+    def test_is_locked_write_round_trip(self):
+        rec = _rec()
+        assert rec.is_locked is False
+        rec.is_locked = True
+        assert rec.is_locked is True
+
+    def test_is_mark_write_round_trip(self):
+        rec = _rec()
+        assert rec.is_mark is False
+        rec.is_mark = True
+        assert rec.is_mark is True
+
+    def test_action_write_round_trip(self):
+        rec = _rec()
+        assert rec.action == ""
+        rec.action = "KEEP"
+        assert rec.action == "KEEP"
+
+    def test_score_write_round_trip(self):
+        """scanner/scoring.py writes .score post-construction (#187)."""
+        rec = _rec()
+        assert rec.score is None
+        rec.score = 0.9
+        assert rec.score == 0.9
+
+    def test_folder_path_write_round_trip(self):
+        """tests/test_file_operations.py test helper writes folder_path."""
+        rec = _rec()
+        rec.folder_path = "/other"
+        assert rec.folder_path == "/other"
+
+    def test_capture_date_write_round_trip(self):
+        rec = _rec()
+        rec.capture_date = datetime(2026, 6, 11)
+        assert rec.capture_date == datetime(2026, 6, 11)
+
+
+class TestPhotoGroupOperations:
+    def test_items_reassignment(self):
+        """ExecuteActionDialog rebinds group.items after pruning (#584)."""
+        grp = PhotoGroup(group_number=1, items=[_rec()])
+        new_items = [_rec(file_path="/dir/b.jpg")]
+        grp.items = new_items
+        assert grp.items is new_items
+
+    def test_is_expanded_write_round_trip(self):
+        grp = PhotoGroup(group_number=1)
+        assert grp.is_expanded is False
+        grp.is_expanded = True
+        assert grp.is_expanded is True
+
+    def test_dataclasses_replace_compat(self):
+        """ExecuteActionDialog uses dataclasses.replace() to build a
+        filtered view (#584). replace() goes through __init__, not __dict__,
+        so slots=True doesn't break it — pin that contract."""
+        grp = PhotoGroup(group_number=1, items=[_rec()])
+        new_items = [_rec(file_path="/dir/b.jpg")]
+        grp2 = replace(grp, items=new_items)
+        assert grp2.items is new_items
+        assert grp.items is not new_items  # original unchanged


### PR DESCRIPTION
## What

Three independent O(N) memory wins from #616, batched in one PR
because they share scope (memory reclaim across the manifest
lifecycle) and review surface (file_operations.py + a few
neighbours). Item 2 from the issue (`PATH_ROLE` duplicate removal)
lands in a separate PR after this one merges — its audit surface is
much wider and benefits from its own review focus.

| Item | Where | Headline win |
|---|---|---|
| **1 — `__slots__`** | `core/models.py` | ~200-400 MB at N=1M PhotoRecords; declarative AttributeError on stray writes |
| **4 — worker `deleteLater`** | `app/views/handlers/file_operations.py` | Stops `ManifestLoadWorker` objects accumulating as MainWindow Qt children across reloads |
| **3 — `ImageService.clear_cache()` on unload** | `infrastructure/image_service.py` + handler + main window | Releases thumb + preview tier RAM (default 256 MB combined) on manifest switch — the LRU caches used to leak across loads |

## Why

User-visible symptom that drove #616: post-DB-load resident set on
the user's library was ~8-10 GB and only released on app close, even
across manifest reloads. The original ticket queued these four items
as ship-regardless-of-the-DR-probe-outcome wins (the discriminating
probe lives in #614 and is its own follow-up). The 4-agent parallel
research workflow run for this PR confirmed each is independent,
low-risk, and (importantly) has zero overlap with the much larger
`PATH_ROLE` audit that item 2 needs.

## How

### Item 1 — slots on `PhotoRecord` + `PhotoGroup`

Two decorator-line changes in `core/models.py`:

```python
@dataclass(slots=True)
class PhotoRecord: ...

@dataclass(slots=True)
class PhotoGroup: ...
```

The researcher swept every post-construction attribute write across
`app/`, `infrastructure/`, `core/`, `scanner/`, and `tests/`: all 22
PhotoRecord fields and all 3 PhotoGroup fields are targeted by
declared-field writes only. No undeclared injection anywhere.
`dataclasses.replace()` (used by `ExecuteActionDialog` post-#584) is
slots-compatible because it goes through `__init__`, not `__dict__`.
`getattr(rec, 'phash', None)` patterns in `tree_model_builder.py`
work identically. `scanner/dedup.py::ManifestRow` is a *separate*
dataclass and stays `@dataclass` — easy to confuse given similar
field names (`action`, `score`), explicitly out of scope.

Net win on CPython 3.11: per-instance ~280B → ~80B. Approaches
200-400 MB on a 1M-record library.

### Item 4 — `ManifestLoadWorker.deleteLater()`

`worker.finished` and `worker.failed` now both schedule
`worker.deleteLater()` via lambda-discard closures:

```python
worker.finished.connect(lambda _groups: worker.deleteLater())
worker.failed.connect(lambda _err: worker.deleteLater())
```

The lambda discards the signal arg because `deleteLater` takes none.
The reason it's a lambda and not the conventional
`worker.finished.connect(worker.deleteLater)` is a Qt signal-name
clash: `ManifestLoadWorker` defines a *custom* `finished(list)` AND
inherits `QThread`'s no-arg `finished()` from the base class. A
direct connect binds to the custom signal and would pass the
groups list to `deleteLater`, which raises `TypeError` at runtime.
The lambda form sidesteps the ambiguity entirely.

Closing over the specific `worker` reference means subsequent loads
can't accidentally tear down each other; each load's `deleteLater`
is bound to the exact worker that emitted.

### Item 3 — `ImageService.clear_cache()` on manifest unload

The largest of the three. Five steps:

1. **Thread safety**: added `threading.Lock` to `_ByteBudgetLRUCache`
   and wrapped `get`/`put`/`clear`. `_ImageTask` (the QRunnable in
   `app/views/image_tasks.py`) calls `get`/`put` from QThreadPool
   workers; `clear()` runs on the main thread on manifest unload.
   Without the lock the OrderedDict mutation would race.

2. **`clear()` on `_ByteBudgetLRUCache`** — drops every entry and
   resets `_total_bytes` to 0 atomically.

3. **`clear_cache()` on `ImageService`** — clears both `_thumb_cache`
   and `_preview_cache`. The disk cache under the versioned thumbs
   directory is intentionally preserved — it's content-hash-keyed
   and valid across manifests.

4. **`clear_image_cache()` on `UIUpdateCallback` Protocol + proxy on
   `UIUpdaterImpl`** — symmetric with `clear_preview` from #431. The
   static probe `test_probe_uiupdater_impl_proxies_every_protocol_method`
   in `test_ui_probes.py` enforces the Protocol/Impl alignment.

5. **Two callsites**:
   - `_on_manifest_loaded` in `file_operations.py` — async Open
     Manifest path. Runs AFTER `clear_preview` (same ordering
     rationale as #431).
   - `_load_manifest_from_path` in `main_window.py` — sync post-scan
     and relocalize paths. Direct call to `self._img.clear_cache()`
     guarded with `getattr` so test scaffolds without `_img` don't
     trip the broad-except.

## Tests

| File | Tests | Pins |
|---|---|---|
| `tests/test_models.py` (NEW) | 14 | slots contract: `__slots__` set, `__dict__` absent, AttributeError on undeclared writes, every declared-field write round-trips, `dataclasses.replace()` still works |
| `tests/test_file_operations.py` (EXTENDED) | +4 | `worker.finished`/`worker.failed` both connect to `deleteLater`; `UIUpdateCallback.clear_image_cache` declared; `_on_manifest_loaded` calls `clear_image_cache` AFTER `refresh_tree` |
| `tests/test_image_service.py` (EXTENDED) | +3 | `_ByteBudgetLRUCache.clear()` evicts every entry and zeroes `total_bytes`; safe on empty cache; `ImageService.clear_cache()` clears both tiers |
| `tests/test_main_window.py` (EXTENDED) | +1 | `_load_manifest_from_path` calls `_img.clear_cache()` when wired |

Static probe `test_probe_uiupdater_impl_proxies_every_protocol_method`
automatically enforces the new Protocol entry has a corresponding
`UIUpdaterImpl` proxy — no manual test addition needed there.

## Test plan

- [x] **Unit suite**: 2208 pass + 3 skip; coverage gate green
- [x] **Per-file coverage**: 70% floor satisfied on all touched files
- [ ] **Manual smoke** (on your end): open manifest A → review some
      images (cache populates) → open manifest B → confirm RAM
      drops back near the post-startup baseline before B's images
      begin to load
- [ ] **CI**: full suite + qa-batch

[docs-not-needed: three internal memory reclaim changes with no
user-visible surface change. The Open Manifest gesture works
exactly as before, the same dialogs surface, the same shortcuts
fire. RAM behaviour is internal — the user observes it via Task
Manager, not via any docs-covered UX. The `features.md` entries
for Open Manifest, Scan, and the preview pane all remain accurate.]

[qa-not-needed: layer-1 unit tests pin every behavioural contract
(slots AttributeError, signal wiring, Protocol/Impl alignment via
the existing static probe, cache.clear semantics, both manifest-load
paths calling clear_cache). A layer-3 qa scenario for memory
reclaim would need wall-clock RAM assertions which qa-batch doesn't
reliably support on Windows CI runners. The existing s01/s13 + Open
Manifest scenarios continue to exercise the manifest-switch flow at
layer 3.]

Refs #616 (items 1, 3, 4 — item 2 lands separately in PR-3).
