### PR TITLE
perf(preview): finish #622 Phase 1 wiring — async res + status notice

### DIFF
--- a/app/views/dialogs/full_res_viewer.py
+++ b/app/views/dialogs/full_res_viewer.py
@@ -68,9 +68,22 @@ class FullResViewerDialog(QDialog):
     brief pause; async loading via ImageTaskRunner is a Phase 2 concern.
     """
 
-    def __init__(self, path: str, parent: QWidget | None = None) -> None:
+    def __init__(
+        self,
+        path: str,
+        parent: QWidget | None = None,
+        *,
+        service: Any | None = None,
+    ) -> None:
         super().__init__(parent)
         self._path = path
+        # Optional dependency-injected ImageService. Production wires the
+        # app-level instance via ``main_window.on_open_full_res_viewer`` so
+        # the dialog reuses the same disk cache, byte-budget LRU, and
+        # status-reporter wiring. Falls back to constructing a bare instance
+        # when None — the test path patches the class symbol and exercises
+        # both branches (see ``tests/test_dialogs/test_full_res_viewer.py``).
+        self._service: Any | None = service
         self._full_qimage: Any = None  # QImage | None
         self._current_scale: float = 1.0
 
@@ -102,9 +115,14 @@ class FullResViewerDialog(QDialog):
     def _load_image(self) -> None:
         """Load the full-resolution image synchronously."""
         try:
-            from infrastructure.image_service import ImageService
-
-            svc = ImageService()
+            if self._service is not None:
+                svc = self._service
+            else:
+                # Fallback: standalone construction (no DI). Triggers an
+                # extra ``_migrate_legacy_disk_cache`` pass on first open,
+                # which is idempotent once the v1/ sub-dir is populated.
+                from infrastructure.image_service import ImageService
+                svc = ImageService()
             # side=0 → full resolution (bypass viewport cap)
             img = svc.get_preview(self._path, 0)
             if img is None or img.isNull():

--- a/app/views/image_tasks.py
+++ b/app/views/image_tasks.py
@@ -69,6 +69,43 @@ class _ImageTask(QRunnable):
             pass
 
 
+class _ResolutionTask(QRunnable):
+    """QRunnable for off-thread image resolution reads (#622 Phase 1).
+
+    Emits ``receiver.resolutionLoaded(path, resolution_str)`` upon completion.
+    The receiver is expected to own a Qt ``Signal(str, str)`` named
+    ``resolutionLoaded``. Failed reads emit an empty string rather than
+    raising — matches the pre-async ``_read_resolution`` returning None,
+    so the info-label silently stays without a resolution row rather than
+    surfacing a parser failure to the user.
+
+    The ``_read_resolution`` import is lazy because ``preview_pane`` already
+    imports ``image_tasks`` at module load; a top-level import here would
+    cycle. Inside ``run()`` the cycle is harmless — both modules are fully
+    loaded by the time any QRunnable executes.
+    """
+
+    def __init__(self, *, path: str, receiver: QObject) -> None:
+        super().__init__()
+        self._path = path
+        self._receiver = receiver
+
+    def run(self) -> None:  # type: ignore[override]
+        try:
+            from app.views.media_utils import normalize_windows_path
+            from app.views.preview_pane import _read_resolution
+            res = _read_resolution(normalize_windows_path(self._path))
+        except Exception as ex:
+            logger.error("Resolution task failed: {}", ex)
+            res = None
+        try:
+            self._receiver.resolutionLoaded.emit(  # type: ignore[attr-defined]
+                self._path, res or ""
+            )
+        except Exception:  # pragma: no cover - best effort
+            pass
+
+
 class ImageTaskRunner:
     """Dispatches image load tasks to the global thread pool.
 
@@ -80,7 +117,35 @@ class ImageTaskRunner:
     def __init__(self, *, service: Any, receiver: QObject) -> None:
         self._service = service
         self._receiver = receiver
+        # Receiver for ``_ResolutionTask`` results. Set later via
+        # ``set_resolution_receiver`` — PreviewPane is constructed AFTER
+        # the runner, so it self-registers in its ``__init__``.
+        self._resolution_receiver: QObject | None = None
         self._pool = QThreadPool.globalInstance()
+
+    def set_resolution_receiver(self, receiver: QObject) -> None:
+        """Register the receiver for off-thread resolution reads.
+
+        PreviewPane owns the ``resolutionLoaded(str, str)`` signal that
+        ``_ResolutionTask`` emits on; the runner has no reason to relay
+        through ``self._receiver`` (MainWindow) since resolution updates
+        are pane-local. Idempotent — last registration wins.
+        """
+        self._resolution_receiver = receiver
+
+    def request_resolution(self, path: str) -> None:
+        """Submit an off-thread resolution read.
+
+        Delivery happens via the registered receiver's ``resolutionLoaded``
+        signal. Silent no-op when no resolution receiver is wired —
+        constructor-time test paths exercise the runner standalone, and
+        the pre-PreviewPane init window has no receiver yet.
+        """
+        recv = self._resolution_receiver
+        if recv is None:
+            return
+        task = _ResolutionTask(path=path, receiver=recv)
+        self._pool.start(task)
 
     def request_single_preview(self, path: str) -> str:
         """Request a single-image preview. Returns the token string."""

--- a/app/views/main_window.py
+++ b/app/views/main_window.py
@@ -235,6 +235,21 @@ class MainWindow(QMainWindow):
         self.status_reporter = StatusReporterImpl(self)
         self.ui_updater = UIUpdaterImpl(self)
 
+        # #622 Phase 1 — flush ImageService's startup-queued status messages.
+        # main.py constructs ImageService BEFORE MainWindow, so the
+        # legacy-thumbs-wipe notice produced during _migrate_legacy_disk_cache
+        # has no reporter to talk to at that point. The setter below attaches
+        # one now and synchronously flushes the queued message. 8 s timeout
+        # gives the user a beat to read it before the status bar reverts.
+        if self._img is not None and hasattr(self._img, "set_status_reporter"):
+            try:
+                reporter = self.status_reporter
+                self._img.set_status_reporter(
+                    lambda msg, _r=reporter: _r.show_status(msg, timeout=8000)
+                )
+            except Exception:
+                pass
+
         # #165 — runner needs to exist before the file operations
         # handler so the handler can forward it to ExecuteActionDialog's
         # embedded PreviewPane. The PreviewPane in the main window
@@ -692,10 +707,14 @@ class MainWindow(QMainWindow):
 
         Connected to ``preview_pane.requestFullRes`` — fires when the user
         double-clicks a preview tile or the single-view image label.
+
+        Passes the app-level ImageService via DI so the dialog reuses the
+        existing disk cache and skips constructing a second bare instance
+        (which would re-run ``_migrate_legacy_disk_cache`` on every open).
         """
         from app.views.dialogs.full_res_viewer import FullResViewerDialog
 
-        dlg = FullResViewerDialog(path, parent=self)
+        dlg = FullResViewerDialog(path, parent=self, service=self._img)
         dlg.show()
 
     # PRESERVED: Tree selection change handler

--- a/app/views/preview_pane.py
+++ b/app/views/preview_pane.py
@@ -137,6 +137,12 @@ class PreviewPane(QWidget):
         # suffix and drive the double-click → modal full-res viewer flow.
         # Production code never reads the name; it exists for UIA only.
         self._single_label.setObjectName("preview_single_label")
+        # QLabel defaults to Qt.NoFocus; ClickFocus makes the widget a real
+        # mouse-event target so synthetic SendInput presses (qa scenarios on
+        # non-interactive CI runners) are not filtered out by Qt's input
+        # router. s40's QTreeView path works because trees default to
+        # StrongFocus — QLabel needs this explicit opt-in.
+        self._single_label.setFocusPolicy(Qt.ClickFocus)
         self._preview_layout.addWidget(self._single_label)
         # Wire double-click → requestFullRes signal; path captured per show_single call.
         self._single_label_path: str | None = None

--- a/app/views/preview_pane.py
+++ b/app/views/preview_pane.py
@@ -95,6 +95,13 @@ class PreviewPane(QWidget):
     # image; MainWindow connects this to on_open_full_res_viewer(path).
     requestFullRes = Signal(str)
 
+    # Emitted by ``_ResolutionTask`` (app/views/image_tasks.py) when an
+    # off-thread resolution read completes. Carries (path, "W×H") or
+    # (path, "") on read failure. Self-connected to ``_on_resolution_loaded``
+    # in __init__ — the slot's stale-path guard discards results that
+    # arrived after the user already navigated to a different file.
+    resolutionLoaded = Signal(str, str)
+
     def __init__(
         self, parent: QWidget | None, task_runner: ImageTaskRunner, thumb_size: int | None = None
     ) -> None:
@@ -126,10 +133,33 @@ class PreviewPane(QWidget):
         self._single_label = QLabel(t("preview.placeholder"))
         self._single_label.setAlignment(Qt.AlignLeft | Qt.AlignTop)
         self._single_label.setMinimumHeight(200)
+        # Object name so qa scenario s68 can locate this label by aid
+        # suffix and drive the double-click → modal full-res viewer flow.
+        # Production code never reads the name; it exists for UIA only.
+        self._single_label.setObjectName("preview_single_label")
         self._preview_layout.addWidget(self._single_label)
         # Wire double-click → requestFullRes signal; path captured per show_single call.
         self._single_label_path: str | None = None
         self._single_label.mouseDoubleClickEvent = self._on_single_label_double_click
+
+        # Async resolution wiring (#622 Phase 1).
+        # The info dict and path most recently passed to show_single are
+        # cached here so ``_on_resolution_loaded`` can rebuild the info
+        # label with the resolution row once the off-thread read returns.
+        # ``None`` means single-view is currently empty (cleared or showing
+        # a video).
+        self._single_info_payload: tuple[str, dict] | None = None
+        self.resolutionLoaded.connect(self._on_resolution_loaded)
+        # Register with the runner so ``_ResolutionTask`` knows where to
+        # deliver. Runner is constructed before PreviewPane (MainWindow
+        # builds it first), so post-construction setter is the only path.
+        try:
+            task_runner.set_resolution_receiver(self)
+        except AttributeError:
+            # Older runners without resolution support (test stubs) silently
+            # skip — the sync ``_read_resolution`` fallback is gone, but the
+            # info label simply renders without a resolution row in that case.
+            pass
 
         self.preview_area.setWidget(self._preview_container)
         root.addWidget(self.preview_area)
@@ -212,20 +242,27 @@ class PreviewPane(QWidget):
             self.preview_area.setVerticalScrollBarPolicy(Qt.ScrollBarAlwaysOn)
             self._single_label.setVisible(True)
             if info and isinstance(info, dict):
-                res = _read_resolution(normalize_windows_path(path))
+                # Initial render with no resolution row — the off-thread
+                # ``_ResolutionTask`` fills it in via ``_on_resolution_loaded``
+                # once the (potentially expensive) rawpy/QImageReader/PIL
+                # probe completes. Sync ``_read_resolution`` on the UI thread
+                # used to block 3-5 s on NAS DNGs before the placeholder
+                # painted — see #622 ticket item 6.
                 info_rows = build_info_rows(
                     name=info.get("name") or "",
                     folder=info.get("folder") or "",
                     size_txt=info.get("size") or "",
                     creation_txt=info.get("creation") or "",
                     shot_txt=info.get("shot") or "",
-                    resolution=res or "",
+                    resolution="",
                 )
                 html = format_info_html(info_rows)
                 if html:
                     self._single_info_label.setTextFormat(Qt.RichText)
                     self._single_info_label.setText(html)
                     self._single_info_label.setVisible(True)
+                self._single_info_payload = (path, info)
+                self._runner.request_resolution(path)
             self._single_label.setText(t("preview.loading"))
             self._current_single_token = self._runner.request_single_preview(path)
 
@@ -428,6 +465,7 @@ class PreviewPane(QWidget):
         self._single_label.setVisible(False)
         self._single_pm = None
         self._single_label_path = None
+        self._single_info_payload = None
 
     def toggle_play_pause(self) -> None:
         """Toggle playback on the single-view video player, if any.
@@ -646,6 +684,41 @@ class PreviewPane(QWidget):
         """Double-click on the single-view label → emit requestFullRes."""
         if self._single_label_path:
             self.requestFullRes.emit(self._single_label_path)
+
+    def _on_resolution_loaded(self, path: str, res: str) -> None:
+        """Slot for off-thread resolution arrival (#622 Phase 1).
+
+        Rebuilds the info label with the resolution row once the
+        ``_ResolutionTask`` returns. Two guards:
+        1. ``self._single_label_path != path``: the user navigated to a
+           different file (or cleared the view) while the read was in
+           flight. Discard — splashing a stale "W×H" onto the now-current
+           file is a visible bug.
+        2. payload missing or path-mismatched: ``clear()`` ran between
+           ``show_single`` and arrival. Discard for the same reason.
+
+        Mirrors the token-mismatch guard in ``on_image_loaded`` for the
+        async image path — same staleness class, same defence.
+        """
+        if self._single_label_path != path:
+            return
+        payload = self._single_info_payload
+        if payload is None or payload[0] != path:
+            return
+        _, info = payload
+        info_rows = build_info_rows(
+            name=info.get("name") or "",
+            folder=info.get("folder") or "",
+            size_txt=info.get("size") or "",
+            creation_txt=info.get("creation") or "",
+            shot_txt=info.get("shot") or "",
+            resolution=res or "",
+        )
+        html = format_info_html(info_rows)
+        if html:
+            self._single_info_label.setTextFormat(Qt.RichText)
+            self._single_info_label.setText(html)
+            self._single_info_label.setVisible(True)
 
     # Qt events
     def resizeEvent(self, event) -> None:  # type: ignore[override]

--- a/docs/features.md
+++ b/docs/features.md
@@ -660,7 +660,7 @@ for the chore plan.
 - **Behaviour:** The in-memory image cache uses a byte-budget eviction policy instead of a fixed item count. Two independent tiers: a thumbnail tier (≈64 MB) for grid thumbnails (longest side ≤ 256 px) and a preview tier (≈192 MB) for single-view previews. Total budget = `min(256 MB, RAM // 32)`. When a tier exceeds its budget the least-recently-used entry is evicted. The on-disk cache writes versioned files under `~/AppData/Local/PhotoManager/thumbs/v1/<sha1>.jpg`; a recipe-version bump invalidates the old namespace. On first launch after upgrade, any unversioned `.jpg` files under `thumbs/` root are automatically deleted and a one-time status-bar notice is shown.
 - **Conditions / variants:** DNG files use the embedded JPEG fast path (rawpy `extract_thumb`) if the embedded thumbnail's longest side ≥ viewport cap (2048 px default); falls through to full `postprocess` decode only when the embedded thumb is too small or absent. **EXIF Orientation is applied** to the embedded JPEG via Pillow's `ImageOps.exif_transpose` before conversion to QImage — without this, portrait-grip iPhone ProRAW DNGs (which store landscape pixels + Orientation=6/8 in the embedded JPEG's EXIF) would render 90° rotated relative to Lightroom / File Explorer (`QImage.loadFromData` does not honour the Orientation tag; only `QImageReader.setAutoTransform` does, and the fast path uses neither). The bitmap (non-JPEG) thumb branch is unaffected — rawpy delivers the array in correct orientation natively.
 - **Related:** [#622](https://github.com/jackal998/photo-manager/issues/622) Phase 1; `infrastructure/image_service.py`; `tests/test_image_service.py`.
-- **Last verified:** 2026-06-10 (DNG embedded-JPEG orientation fix)
+- **Last verified:** 2026-06-13 (#622 Phase 1 status-reporter wiring — the legacy-thumbs-wipe notice now actually reaches the status bar; previously the notice was logger-only because ImageService was constructed before MainWindow's StatusReporterImpl existed, so the queue + `set_status_reporter()` flush was added to bridge the construction-order gap)
 
 ---
 
@@ -670,8 +670,8 @@ for the chore plan.
 - **Trigger:** User double-clicks any image tile in the grid view or the single-image label in single-view mode.
 - **Behaviour:** Opens `FullResViewerDialog` — a non-modal window showing the full raw-decoded image (side=0 → bypass viewport cap). Pan: drag with left mouse button. Zoom: Ctrl+scroll-wheel (scale clamped 5%–800%). Esc or window close dismisses it. The dialog's QImage is released on close; it is NOT stored in the byte-budget LRU (the dialog owns its own reference). Window title shows filename + pixel dimensions.
 - **Conditions / variants:** Each double-click opens a new viewer window (non-modal — multiple files can be viewed simultaneously). Video tiles do not trigger the full-res viewer (videos have their own click-to-play behaviour). Double-click before any preview is loaded is a no-op (path is None, signal is not emitted).
-- **Related:** [#622](https://github.com/jackal998/photo-manager/issues/622) Phase 1; `app/views/dialogs/full_res_viewer.py`; `app/views/preview_pane.py`; `tests/test_dialogs/test_full_res_viewer.py`.
-- **Last verified:** 2026-06-09 (#622 Phase 1)
+- **Related:** [#622](https://github.com/jackal998/photo-manager/issues/622) Phase 1; `app/views/dialogs/full_res_viewer.py`; `app/views/preview_pane.py`; `tests/test_dialogs/test_full_res_viewer.py`; QA scenario [`qa/scenarios/s68_full_res_viewer_double_click.py`](../qa/scenarios/s68_full_res_viewer_double_click.py).
+- **Last verified:** 2026-06-13 (#622 Phase 1 — DI-injected ImageService via `main_window.on_open_full_res_viewer(service=self._img)` so the dialog reuses the app-level LRU instead of constructing a bare instance each open; s68 pins the live double-click → modal-viewer flow)
 
 ---
 

--- a/infrastructure/image_service.py
+++ b/infrastructure/image_service.py
@@ -202,6 +202,12 @@ class ImageService:
     def __init__(self, settings: object | None = None, status_reporter: Any | None = None) -> None:
         """Initialize caches and optional decoder capabilities from settings."""
         self._status_reporter = status_reporter
+        # Queue for migration-time messages produced before a reporter is
+        # attached. Production constructs ImageService in main.py BEFORE
+        # MainWindow's StatusReporterImpl exists, so the legacy-cache wipe
+        # has no one to talk to at __init__ time. ``set_status_reporter``
+        # flushes this queue when called.
+        self._pending_status_msg: str | None = None
         self._disk_dir = str(
             Path.home() / "AppData" / "Local" / "PhotoManager" / "thumbs"
         )
@@ -249,18 +255,62 @@ class ImageService:
                     f.unlink()
                 except OSError:
                     pass
-            msg = (
-                "Rebuilding thumbnail cache "
-                f"(version {PREVIEW_RECIPE_VERSION}) — this is a one-time operation."
-            )
+            msg = self._build_rebuilding_cache_message()
             logger.info(msg)
             if self._status_reporter is not None:
                 try:
                     self._status_reporter(msg)
                 except Exception:
                     pass
+            else:
+                # Production case: reporter not wired yet (main.py builds
+                # ImageService before MainWindow). Queue for ``set_status_reporter``.
+                self._pending_status_msg = msg
         except Exception as ex:
             logger.debug("Legacy disk cache migration failed: {}", ex)
+
+    def _build_rebuilding_cache_message(self) -> str:
+        """Return the legacy-cache-wipe status string, i18n if available.
+
+        Lazy-imports the translator so the disk-cache migration also runs
+        cleanly in unit tests that construct ImageService before
+        ``init_translator``. Falls back to the original English string when
+        the translator returns the bare key (catalog miss) or when the i18n
+        module itself can't be imported.
+        """
+        fallback = (
+            "Rebuilding thumbnail cache "
+            f"(version {PREVIEW_RECIPE_VERSION}) — this is a one-time operation."
+        )
+        try:
+            from infrastructure.i18n import t  # lazy import — see docstring
+            translated = t("preview.rebuilding_cache", version=PREVIEW_RECIPE_VERSION)
+            if not translated or translated == "preview.rebuilding_cache":
+                return fallback
+            return translated
+        except Exception:
+            return fallback
+
+    def set_status_reporter(self, reporter: Any) -> None:
+        """Attach a status reporter post-construction.
+
+        Required because ``main.py`` builds the ImageService BEFORE the
+        MainWindow's ``StatusReporterImpl`` exists, so any "rebuilding cache"
+        message produced during ``_migrate_legacy_disk_cache`` would otherwise
+        be silently swallowed (logger-only). The queued message is flushed
+        synchronously here — the reporter's ``showMessage`` is allowed to be
+        called before ``QMainWindow.show()`` (Qt queues the text until the
+        status bar is realised).
+        """
+        self._status_reporter = reporter
+        pending = self._pending_status_msg
+        if pending is not None and reporter is not None:
+            try:
+                reporter(pending)
+            except Exception:
+                pass
+            finally:
+                self._pending_status_msg = None
 
     # Public API
     def get_thumbnail(self, path: str, size: int) -> Any:

--- a/news/638.bugfix
+++ b/news/638.bugfix
@@ -1,0 +1,1 @@
+Single-view preview's resolution row reads off the UI thread (no more 3-5 s NAS-DNG stutter), and the first-launch thumbnail-cache rebuild notice now actually reaches the status bar (#638).

--- a/qa/scenarios/_batch.py
+++ b/qa/scenarios/_batch.py
@@ -283,6 +283,11 @@ ALL_SCENARIOS = [
     # the always-path swept them silently). Disposable 2-JPEG cluster;
     # CANCEL → outcome='' (lock holds); Unlock & Apply → outcome='ignored'.
     "s67_locked_singleton_prune_always",
+    # s68 (#622 Phase 1) — double-click on the single-view preview tile
+    # opens FullResViewerDialog as a top-level window with the filename in
+    # title. Uses qa/sandbox/huge (1 file). Pins the live double-click →
+    # requestFullRes → on_open_full_res_viewer(service=…) wiring.
+    "s68_full_res_viewer_double_click",
 ]
 
 

--- a/qa/scenarios/_config.py
+++ b/qa/scenarios/_config.py
@@ -284,6 +284,14 @@ SCENARIO_SOURCES: dict[str, list[str] | None] = {
     # locked rows silently). Two variants: CANCEL → outcome=''; Unlock &
     # Apply → outcome='ignored'. No file deletes — DB-only outcome writes.
     "s67_locked_singleton_prune_always": ["qa/sandbox/_disposable/s67_source"],
+    # s68 (#622 Phase 1) — double-click on the single-view preview tile
+    # opens the FullResViewerDialog. Pins the live wiring that L1 tests
+    # can't reach: real mouseDoubleClickEvent → requestFullRes.emit →
+    # on_open_full_res_viewer(service=self._img) → dialog appears as a
+    # top-level window. Uses near-duplicates (5 JPEGs clustered into one
+    # group) — huge sandbox is one isolated file which never appears as
+    # a TreeItem (singletons are status-bar-only).
+    "s68_full_res_viewer_double_click": ["qa/sandbox/near-duplicates"],
 }
 
 # Per-scenario overrides for ui.prune_singletons. build_settings maps a

--- a/qa/scenarios/s68_full_res_viewer_double_click.py
+++ b/qa/scenarios/s68_full_res_viewer_double_click.py
@@ -170,6 +170,20 @@ def main() -> int:
     cx = (rect.left + rect.right) // 2
     cy = (rect.top + rect.bottom) // 2
     print(f"  label_screen_center=({cx},{cy}) rect={rect}")
+    # Diagnostic dumps so a CI failure carries enough state to pick the
+    # next hypothesis without another blind iteration. Cheap and stays in
+    # for the long haul — they help local-vs-CI bisects too.
+    SM_CXSCREEN, SM_CYSCREEN = 0, 1
+    screen_w = _user32.GetSystemMetrics(SM_CXSCREEN)
+    screen_h = _user32.GetSystemMetrics(SM_CYSCREEN)
+    win_rect = win.rectangle()
+    print(f"  screen_dims=({screen_w}x{screen_h}) main_window_rect={win_rect}")
+    in_screen = 0 <= cx < screen_w and 0 <= cy < screen_h
+    in_window = (
+        win_rect.left <= cx < win_rect.right
+        and win_rect.top <= cy < win_rect.bottom
+    )
+    print(f"  click_in_screen={in_screen} click_in_main_window={in_window}")
     # Bring the main window to the foreground so the seed click is
     # delivered to it rather than dispatched to whichever window happens
     # to be active. Windows refuses ``SetForegroundWindow`` from
@@ -179,6 +193,11 @@ def main() -> int:
     # this the CI runner's "no active window" state silently routes the
     # SendInput click into the void.
     _uia._focus(win)
+    fg_hwnd = _user32.GetForegroundWindow()
+    print(
+        f"  after_focus: foreground_hwnd={fg_hwnd} main_hwnd={main_hwnd} "
+        f"focus_succeeded={fg_hwnd == main_hwnd}"
+    )
     time.sleep(0.2)
     # Seed click — registers Qt's input-tracking state on the target widget
     # so the subsequent WM_LBUTTONDBLCLK is unambiguously a "second click".

--- a/qa/scenarios/s68_full_res_viewer_double_click.py
+++ b/qa/scenarios/s68_full_res_viewer_double_click.py
@@ -113,6 +113,42 @@ def main() -> int:
     pid = win.process_id()
     print(f"connected: pid={pid} title={win.window_text()!r}")
 
+    # Enlarge main window only if it's too small to contain the QLabel's
+    # natural rect. The CI runner provisions a 1024x768 display; the
+    # restored main-window state from previous scenarios leaves the
+    # window narrower than the QLabel's natural width (~225 px plus
+    # framing), so the label's screen-center ends up CLIPPED past the
+    # window's right edge — the seed click then lands in the void
+    # outside the client area and Qt never registers a press. Dev rigs
+    # already have a wide enough window so the resize is a no-op there
+    # (and we DON'T want to resize huge — going from ~1600 to ~3800
+    # confuses Qt's focus and the next menu_path hangs).
+    SM_CXSCREEN, SM_CYSCREEN = 0, 1
+    sw = _user32.GetSystemMetrics(SM_CXSCREEN)
+    sh = _user32.GetSystemMetrics(SM_CYSCREEN)
+    cur = win.rectangle()
+    cur_w, cur_h = cur.right - cur.left, cur.bottom - cur.top
+    MIN_W, MIN_H = 900, 700
+    if cur_w < MIN_W or cur_h < MIN_H:
+        margin = 16
+        target_w = min(sw - 2 * margin, max(MIN_W, cur_w))
+        target_h = min(sh - 2 * margin, max(MIN_H, cur_h))
+        target_w = max(target_w, MIN_W)
+        target_h = max(target_h, MIN_H)
+        _user32.MoveWindow(main_hwnd, margin, margin, target_w, target_h, True)
+        time.sleep(0.3)
+        _uia._focus(win)
+        time.sleep(0.2)
+        print(
+            f"step: enlarge_main_window screen=({sw}x{sh}) "
+            f"was=({cur_w}x{cur_h}) new_rect={win.rectangle()}"
+        )
+    else:
+        print(
+            f"step: main_window_size_ok screen=({sw}x{sh}) "
+            f"rect=({cur_w}x{cur_h})"
+        )
+
     print("step: open_scan_dialog")
     dlg, _ = _uia.open_scan_dialog(win)
     print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")

--- a/qa/scenarios/s68_full_res_viewer_double_click.py
+++ b/qa/scenarios/s68_full_res_viewer_double_click.py
@@ -312,9 +312,15 @@ def main() -> int:
 
     print("step: verify_main_window_responsive")
     _, win = _uia.connect_main()
-    rows = _uia.read_result_rows(win)
-    print(f"  total_rows_after_close={len(rows)}")
-    if len(rows) == 0:
+    # Use read_tree_row_order (no y-filter) rather than read_result_rows
+    # (defaults to y_min=600). On the 1024x768 CI runner the main window
+    # tops out at y=708, so every TreeItem has top<600 and read_result_rows
+    # silently returns []; this used to look like "unresponsive" but the
+    # window was actually fine — _uia.py's own read_tree_row_order docstring
+    # flags this exact CI-vs-dev-rig pitfall.
+    basenames = _uia.read_tree_row_order(win)
+    print(f"  total_rows_after_close={len(basenames)}")
+    if len(basenames) == 0:
         print(
             "FAIL: main window appears unresponsive after closing the "
             "full-res viewer — no rows readable via UIA"

--- a/qa/scenarios/s68_full_res_viewer_double_click.py
+++ b/qa/scenarios/s68_full_res_viewer_double_click.py
@@ -205,21 +205,46 @@ def main() -> int:
     rect = label.rectangle()
     cx = (rect.left + rect.right) // 2
     cy = (rect.top + rect.bottom) // 2
-    print(f"  label_screen_center=({cx},{cy}) rect={rect}")
-    # Diagnostic dumps so a CI failure carries enough state to pick the
-    # next hypothesis without another blind iteration. Cheap and stays in
-    # for the long haul — they help local-vs-CI bisects too.
+    print(f"  label_natural_center=({cx},{cy}) rect={rect}")
+    # Clamp the click target to the intersection of the label's natural
+    # rect and the main window's client rect. UIA reports the QLabel's
+    # natural geometry (which can extend past the QScrollArea viewport
+    # when the splitter is tree-dominant — verified on the CI runner at
+    # 1024x768 even after enlarging the window). Without this clamp the
+    # click lands on whatever Z-ordered widget owns the screen point
+    # outside the window (typically: nothing), Qt sees no press, and
+    # the WM_LBUTTONDBLCLK that follows fires on dead air.
     SM_CXSCREEN, SM_CYSCREEN = 0, 1
     screen_w = _user32.GetSystemMetrics(SM_CXSCREEN)
     screen_h = _user32.GetSystemMetrics(SM_CYSCREEN)
     win_rect = win.rectangle()
     print(f"  screen_dims=({screen_w}x{screen_h}) main_window_rect={win_rect}")
+    isect_left = max(rect.left, win_rect.left)
+    isect_top = max(rect.top, win_rect.top)
+    isect_right = min(rect.right, win_rect.right)
+    isect_bottom = min(rect.bottom, win_rect.bottom)
+    isect_w = isect_right - isect_left
+    isect_h = isect_bottom - isect_top
+    if isect_w <= 0 or isect_h <= 0:
+        print(
+            f"FAIL: label visible region is empty — "
+            f"label_rect={rect} window_rect={win_rect} — the splitter or "
+            f"window size is leaving the preview pane entirely off-screen; "
+            f"enlarging the window further (or moving the splitter) is the "
+            f"only recourse"
+        )
+        return 1
+    cx = (isect_left + isect_right) // 2
+    cy = (isect_top + isect_bottom) // 2
     in_screen = 0 <= cx < screen_w and 0 <= cy < screen_h
     in_window = (
         win_rect.left <= cx < win_rect.right
         and win_rect.top <= cy < win_rect.bottom
     )
-    print(f"  click_in_screen={in_screen} click_in_main_window={in_window}")
+    print(
+        f"  clamped_click=({cx},{cy}) visible_region=({isect_w}x{isect_h}) "
+        f"click_in_screen={in_screen} click_in_main_window={in_window}"
+    )
     # Bring the main window to the foreground so the seed click is
     # delivered to it rather than dispatched to whichever window happens
     # to be active. Windows refuses ``SetForegroundWindow`` from

--- a/qa/scenarios/s68_full_res_viewer_double_click.py
+++ b/qa/scenarios/s68_full_res_viewer_double_click.py
@@ -1,0 +1,232 @@
+"""Scenario 68 — double-click on preview tile opens the full-res viewer (#622 Phase 1).
+
+Required source: qa/sandbox/near-duplicates (5 JPEGs, one near-dup group).
+
+What this exercises (the production wiring that layer-1 unit tests can't reach):
+
+  1. ``PreviewPane.show_single`` (image branch) renders the single-view label
+     and submits the async ``_ResolutionTask`` — no UI-thread block on the
+     read-resolution probe (#622 ticket item 6).
+  2. The ``_single_label`` QLabel carries ``objectName="preview_single_label"``
+     and is discoverable via UIA aid-suffix matching.
+  3. A double-click on the label fires ``mouseDoubleClickEvent`` →
+     ``_on_single_label_double_click`` → ``requestFullRes.emit(path)``.
+  4. ``MainWindow.on_open_full_res_viewer`` constructs ``FullResViewerDialog``
+     with ``service=self._img`` (DI) and calls ``show()`` — the dialog
+     appears as a real top-level window with the filename in its title.
+  5. Pressing Escape on the dialog closes it (WA_DeleteOnClose semantics),
+     and the main window remains responsive afterward.
+
+Why this is L3 and not L2 unit-only: the signal emit + slot dispatch is
+already pinned at L1 (tests/test_preview_pane.py +
+tests/test_main_window.py::test_on_open_full_res_viewer_constructs_dialog…).
+What only a live run can prove is that the Qt event delivered from a real
+mouse double-click on the actual label widget makes it to the same code
+path — and that the dialog Qt creates is a usable top-level window
+discoverable by the OS window manager. Both are easy to silently break
+with an objectName drop, a parent reorder, or a setModal/show() change.
+
+PRE: PHOTO_MANAGER_HOME=qa QT_ACCESSIBILITY=1 .venv/Scripts/python.exe main.py
+"""
+from __future__ import annotations
+
+import ctypes
+import ctypes.wintypes
+import sys
+import time
+from pathlib import Path
+
+import pywinauto.mouse
+from pywinauto.keyboard import send_keys
+
+from qa.scenarios import _uia
+
+_user32 = ctypes.windll.user32
+
+# Object name set in app/views/preview_pane.py for the single-view label.
+# UIA reports it as the trailing segment of the automation_id path.
+SINGLE_LABEL_AID_SUFFIX = ".preview_single_label"
+
+# Title-substring used to recognise the FullResViewerDialog among the
+# process's top-level windows. Set by app/views/dialogs/full_res_viewer.py
+# in ``__init__`` (just the filename) and updated to "<filename>  [W×H]"
+# in ``_load_image`` after the QImage is decoded. The q95 variant is the
+# highest-quality of the 5 near-dups and the deterministic first row in
+# the default sort (file size desc); pick it as the unambiguous target.
+EXPECTED_FILE_NAME = "neardup_00_q95.jpg"
+
+
+def _post_double_click_at(win_hwnd: int, cx: int, cy: int) -> None:
+    """Send a real ``WM_LBUTTONDBLCLK`` to `win_hwnd` at screen (cx, cy).
+
+    ``UIAWrapper.click_input(double=True)`` synthesizes two SendInput pairs
+    that Qt processes as two singles rather than one double — same trap
+    s40's ``double_click_tree_row`` documents (Qt's mouse event filter
+    needs the OS-level WM_LBUTTONDBLCLK to fire ``mouseDoubleClickEvent``).
+    ScreenToClient converts the screen point to the main window's client
+    coordinates; Qt's QWidget routing then dispatches the event to whichever
+    child widget lies at that point.
+    """
+    pt = ctypes.wintypes.POINT(cx, cy)
+    _user32.ScreenToClient(win_hwnd, ctypes.byref(pt))
+    lparam = (pt.y & 0xFFFF) << 16 | (pt.x & 0xFFFF)
+    WM_LBUTTONDBLCLK = 0x0203
+    WM_LBUTTONUP = 0x0202
+    MK_LBUTTON = 0x0001
+    _user32.PostMessageW(win_hwnd, WM_LBUTTONDBLCLK, MK_LBUTTON, lparam)
+    _user32.PostMessageW(win_hwnd, WM_LBUTTONUP, 0, lparam)
+
+
+def _find_dialog_by_title_substr(
+    pid: int, exclude_hwnd: int, name_substr: str, timeout: float = 5.0
+) -> int | None:
+    """Find a top-level window of `pid` whose title contains `name_substr`,
+    excluding `exclude_hwnd` (the main window). Returns the new hwnd or None.
+
+    The full-res viewer is a non-modal QDialog so it gets its own top-level
+    HWND. ``_uia.wait_for_dialog`` is exact-match on title, but our title
+    contains the auto-appended ``[W×H]`` suffix once the image loads — so
+    we substring-match on the filename instead.
+    """
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        for hwnd, _cls, title in _uia.list_process_windows(pid):
+            if hwnd == exclude_hwnd:
+                continue
+            if name_substr in title:
+                return hwnd
+        time.sleep(0.2)
+    return None
+
+
+def main() -> int:
+    print("scenario: s68_full_res_viewer_double_click")
+    app, win = _uia.connect_main()
+    main_hwnd = win.handle
+    pid = win.process_id()
+    print(f"connected: pid={pid} title={win.window_text()!r}")
+
+    print("step: open_scan_dialog")
+    dlg, _ = _uia.open_scan_dialog(win)
+    print(f"  configured_sources={_uia.read_configured_sources(dlg)!r}")
+
+    print("step: run_scan")
+    log, elapsed = _uia.run_scan_and_wait(dlg, timeout=60)
+    print(f"  scan_elapsed_s={elapsed:.2f}")
+    if "Done." not in log:
+        print("FAIL: scan did not finish cleanly")
+        for line in _uia.extract_summary(log):
+            if line:
+                print(f"  log: {line}")
+        return 1
+
+    print("step: close_and_load")
+    _uia.close_and_load_manifest(dlg)
+    _, win = _uia.connect_main()
+
+    print("step: select_image_row")
+    # Give the tree-populate a beat — close_and_load only sleeps 1 s and
+    # the tree's expandAll() pass after load races the next UIA query on
+    # the first scan after a cold launch.
+    time.sleep(1.5)
+    # ``left_click_tree_row`` resolves the File-Name cell's screen coords
+    # from the tree's row geometry, focuses the window, then issues a
+    # left-click — the same path s14/s32/s67 use to seed selection.
+    _uia.left_click_tree_row(win, EXPECTED_FILE_NAME)
+    target_name = EXPECTED_FILE_NAME
+    print(f"  target_row={target_name!r}")
+    # Let show_single complete + the async _ResolutionTask kick off.
+    time.sleep(1.0)
+
+    print("step: find_preview_single_label")
+    # The label is a QLabel; UIA reports a QLabel-with-pixmap as "Image" and
+    # an empty/text QLabel as "Text". Try both, falling back to Pane just in
+    # case the platform decides to wrap it.
+    label = None
+    for control_type in ("Image", "Text", "Pane"):
+        label = _uia._find_descendant_by_aid_suffix(
+            win, control_type, SINGLE_LABEL_AID_SUFFIX
+        )
+        if label is not None:
+            print(f"  found_label control_type={control_type!r}")
+            break
+    if label is None:
+        print(
+            f"FAIL: preview_single_label (aid suffix {SINGLE_LABEL_AID_SUFFIX!r}) "
+            f"not found — the objectName set in PreviewPane.__init__ is the "
+            f"only handle UIA scenarios have on this widget"
+        )
+        return 1
+
+    print("step: double_click_preview_label")
+    rect = label.rectangle()
+    cx = (rect.left + rect.right) // 2
+    cy = (rect.top + rect.bottom) // 2
+    print(f"  label_screen_center=({cx},{cy}) rect={rect}")
+    # Seed click — registers Qt's input-tracking state on the target widget
+    # so the subsequent WM_LBUTTONDBLCLK is unambiguously a "second click".
+    pywinauto.mouse.click(button="left", coords=(cx, cy))
+    time.sleep(0.15)
+    _post_double_click_at(main_hwnd, cx, cy)
+    # Give the slot + dialog construction + first paint a moment.
+    time.sleep(1.5)
+
+    print("step: assert_full_res_dialog_opened")
+    new_hwnd = _find_dialog_by_title_substr(
+        pid, exclude_hwnd=main_hwnd, name_substr=EXPECTED_FILE_NAME, timeout=5
+    )
+    if new_hwnd is None:
+        print(
+            f"FAIL: full-res viewer not opened — no top-level window with "
+            f"title containing {EXPECTED_FILE_NAME!r} appeared within 5s "
+            f"(probe_status: full_res_viewer_opened=False)"
+        )
+        return 1
+    new_dlg = _uia.connect_by_handle(new_hwnd)
+    new_title = new_dlg.window_text() or ""
+    print(f"  full_res_dialog_title={new_title!r}")
+    # Soft-probe for the LLM agent: the load-bearing signal.
+    print(f"probe_status: full_res_viewer_opened=True")
+
+    # Spot-check: title should also include the [W×H] suffix after the image
+    # decodes. The bare filename was set in __init__; the post-load update in
+    # _load_image appends "  [W×H]". Lack of the suffix would mean the
+    # synchronous decode raised silently — a regression in the dialog's
+    # error handling.
+    has_resolution_suffix = "×" in new_title or "x" in new_title.split("]")[0]
+    print(f"  title_has_resolution_suffix={has_resolution_suffix}")
+    if not has_resolution_suffix:
+        # Don't fail — this is a soft probe; the image may legitimately fail
+        # to decode in headless / low-resource CI. Just print for review.
+        print(
+            f"  note: title {new_title!r} lacks the [W×H] suffix; the "
+            f"post-load setWindowTitle in _load_image may have raised, or "
+            f"the image decode failed on this rig"
+        )
+
+    print("step: close_full_res_dialog")
+    try:
+        new_dlg.set_focus()
+        time.sleep(0.2)
+    except Exception:
+        pass
+    send_keys("{ESC}")
+    time.sleep(0.6)
+
+    print("step: verify_main_window_responsive")
+    _, win = _uia.connect_main()
+    rows = _uia.read_result_rows(win)
+    print(f"  total_rows_after_close={len(rows)}")
+    if len(rows) == 0:
+        print(
+            "FAIL: main window appears unresponsive after closing the "
+            "full-res viewer — no rows readable via UIA"
+        )
+        return 1
+
+    print("scenario: s68_full_res_viewer_double_click DONE")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/qa/scenarios/s68_full_res_viewer_double_click.py
+++ b/qa/scenarios/s68_full_res_viewer_double_click.py
@@ -66,6 +66,13 @@ def _post_double_click_at(win_hwnd: int, cx: int, cy: int) -> None:
     ScreenToClient converts the screen point to the main window's client
     coordinates; Qt's QWidget routing then dispatches the event to whichever
     child widget lies at that point.
+
+    A seed click via :func:`pywinauto.mouse.click` MUST be sent immediately
+    before calling this — that's what arms Qt's double-click detector by
+    registering the QLabel's prior press. Verified locally (passing) and
+    in s40's tree-row helper (passing in CI). Without the seed, Qt treats
+    the bare ``WM_LBUTTONDBLCLK`` as a single click and the override never
+    fires.
     """
     pt = ctypes.wintypes.POINT(cx, cy)
     _user32.ScreenToClient(win_hwnd, ctypes.byref(pt))
@@ -163,6 +170,16 @@ def main() -> int:
     cx = (rect.left + rect.right) // 2
     cy = (rect.top + rect.bottom) // 2
     print(f"  label_screen_center=({cx},{cy}) rect={rect}")
+    # Bring the main window to the foreground so the seed click is
+    # delivered to it rather than dispatched to whichever window happens
+    # to be active. Windows refuses ``SetForegroundWindow`` from
+    # non-foreground processes unless either the target process owns the
+    # current foreground or alt-tab semantics allow it; ``_focus`` packages
+    # both attempts (``_focus`` lives in ``qa/scenarios/_uia.py``). Without
+    # this the CI runner's "no active window" state silently routes the
+    # SendInput click into the void.
+    _uia._focus(win)
+    time.sleep(0.2)
     # Seed click — registers Qt's input-tracking state on the target widget
     # so the subsequent WM_LBUTTONDBLCLK is unambiguously a "second click".
     pywinauto.mouse.click(button="left", coords=(cx, cy))

--- a/tests/test_dialogs/test_full_res_viewer.py
+++ b/tests/test_dialogs/test_full_res_viewer.py
@@ -281,3 +281,61 @@ class TestPanDrag:
         v_arg = mock_vbar.setValue.call_args[0][0]
         assert h_arg == 200, f"hbar.setValue should be 200, got {h_arg}"
         assert v_arg == 200, f"vbar.setValue should be 200, got {v_arg}"
+
+
+# ── DI service injection (#622 Phase 1) ──────────────────────────────────
+
+
+class TestServiceInjection:
+    """The dialog accepts an optional ``service=`` keyword in its
+    constructor so MainWindow can inject the app-level ImageService
+    instance. Without DI the dialog used to construct a bare
+    ``ImageService()`` on every open, re-running ``_migrate_legacy_disk_cache``
+    each time and bypassing the shared byte-budget LRU.
+    """
+
+    def test_injected_service_is_used_instead_of_constructing_bare(self, qapp_m):
+        """When ``service=mock`` is passed, ``mock.get_preview`` is called
+        and ``ImageService.__init__`` is NEVER invoked at the module level.
+
+        Failure mode: a refactor that ignored the kwarg would silently
+        regress to building a bare ImageService every open — spurious
+        disk-cache migration scans and zero reuse of the warm in-memory
+        cache from the main preview pane.
+        """
+        injected = MagicMock()
+        injected.get_preview.return_value = _make_qimage(100, 100)
+
+        with patch("infrastructure.image_service.ImageService") as MockSvc:
+            dlg = FullResViewerDialog(
+                "/fake/photo.jpg", parent=None, service=injected
+            )
+            try:
+                injected.get_preview.assert_called_once_with("/fake/photo.jpg", 0)
+                # The bare ImageService class must NOT be instantiated by the dialog
+                # when a service was injected.
+                MockSvc.assert_not_called()
+            finally:
+                dlg.deleteLater()
+
+    def test_fallback_to_bare_service_when_no_kwarg(self, qapp_m):
+        """When ``service`` is omitted, the dialog constructs a bare
+        ``ImageService()`` (backward compatibility for callers that don't DI).
+
+        Failure mode: dropping the fallback breaks every existing test that
+        patches ``infrastructure.image_service.ImageService`` and relies on
+        the bare-construction path. That patching pattern is widespread, so
+        this guarantee is load-bearing for the existing test suite.
+        """
+        fake_img = _make_qimage(100, 100)
+        with patch("infrastructure.image_service.ImageService") as MockSvc:
+            instance = MockSvc.return_value
+            instance.get_preview.return_value = fake_img
+
+            dlg = FullResViewerDialog("/fake/photo.jpg", parent=None)
+            try:
+                # Bare-class was constructed (no DI), and its get_preview ran.
+                MockSvc.assert_called_once_with()
+                instance.get_preview.assert_called_once_with("/fake/photo.jpg", 0)
+            finally:
+                dlg.deleteLater()

--- a/tests/test_image_service.py
+++ b/tests/test_image_service.py
@@ -428,6 +428,7 @@ class TestPreviewRecipeVersion:
 
         svc = ImageService.__new__(ImageService)
         svc._status_reporter = None
+        svc._pending_status_msg = None
         svc._disk_path = tmp_path
         svc._migrate_legacy_disk_cache()
 
@@ -442,3 +443,168 @@ class TestPreviewRecipeVersion:
         changing it without bumping the constant causes stale-cache misses.
         """
         assert PREVIEW_RECIPE_VERSION == "1"
+
+
+# ── status_reporter wiring (#622 Phase 1) ────────────────────────────────
+
+
+class TestStatusReporterWiring:
+    """The migration-notice plumbing — ``main.py`` builds ImageService
+    BEFORE MainWindow's status reporter exists, so the legacy-cache wipe
+    message has to be queueable for later delivery. These tests pin both
+    paths (synchronous reporter present + deferred reporter-attached-later).
+    """
+
+    def test_status_reporter_called_when_reporter_is_set_at_migration_time(
+        self, tmp_path
+    ):
+        """Sync path: a reporter set at construction (or before migration runs)
+        is called with the rebuilding-cache message when legacy files exist.
+
+        Failure mode: the original code path that omitted the reporter call
+        for the migration notice would leave the user staring at a slower-than-
+        normal first launch with no idea that the cache is rebuilding.
+        """
+        legacy = tmp_path / "old.jpg"
+        legacy.write_bytes(b"legacy-thumb")
+
+        reporter = MagicMock()
+        svc = ImageService.__new__(ImageService)
+        svc._status_reporter = reporter
+        svc._pending_status_msg = None
+        svc._disk_path = tmp_path
+
+        svc._migrate_legacy_disk_cache()
+
+        reporter.assert_called_once()
+        msg_arg = reporter.call_args.args[0]
+        assert "cache" in msg_arg.lower(), (
+            f"Reporter call must include 'cache' in the message, got: {msg_arg!r}"
+        )
+        assert svc._pending_status_msg is None, (
+            "Pending msg must not be set when reporter consumed it synchronously"
+        )
+
+    def test_pending_message_queued_when_no_reporter_at_migration_time(
+        self, tmp_path
+    ):
+        """Deferred path: when reporter is None at migration time, the message
+        is queued onto ``_pending_status_msg`` so ``set_status_reporter`` can
+        flush it later.
+
+        Failure mode: without the queue, main.py's pre-MainWindow ImageService
+        construction silently drops the notice — the user sees no status
+        indication of the one-time rebuild.
+        """
+        legacy = tmp_path / "old.jpg"
+        legacy.write_bytes(b"legacy-thumb")
+
+        svc = ImageService.__new__(ImageService)
+        svc._status_reporter = None
+        svc._pending_status_msg = None
+        svc._disk_path = tmp_path
+
+        svc._migrate_legacy_disk_cache()
+
+        assert svc._pending_status_msg is not None, (
+            "Migration must queue a pending message when reporter is None"
+        )
+        assert "cache" in svc._pending_status_msg.lower()
+
+    def test_set_status_reporter_flushes_pending_message(self, tmp_path):
+        """``set_status_reporter`` synchronously delivers any queued message.
+
+        Failure mode: a setter that overrode the reporter but failed to
+        flush the queue would leave the user without the notice for the
+        rest of the session (the migration only fires once).
+        """
+        svc = ImageService.__new__(ImageService)
+        svc._status_reporter = None
+        svc._pending_status_msg = "Rebuilding thumbnail cache (version 1)…"
+
+        reporter = MagicMock()
+        svc.set_status_reporter(reporter)
+
+        reporter.assert_called_once_with("Rebuilding thumbnail cache (version 1)…")
+        assert svc._pending_status_msg is None, (
+            "Pending msg must be cleared after flush so a second "
+            "set_status_reporter call doesn't re-deliver it"
+        )
+
+    def test_set_status_reporter_no_pending_no_call(self, tmp_path):
+        """``set_status_reporter`` without a queued message does NOT call the
+        reporter — first-install or already-migrated launches must stay quiet.
+
+        Failure mode: an unconditional call would spam the status bar with
+        an empty message on every fresh-install launch (no legacy thumbs to
+        wipe → no pending msg → reporter should not be called).
+        """
+        svc = ImageService.__new__(ImageService)
+        svc._status_reporter = None
+        svc._pending_status_msg = None
+
+        reporter = MagicMock()
+        svc.set_status_reporter(reporter)
+
+        reporter.assert_not_called()
+        assert svc._status_reporter is reporter, (
+            "Reporter must still be attached even when no pending msg existed"
+        )
+
+    def test_set_status_reporter_swallows_reporter_exception(self, tmp_path):
+        """A reporter that raises during flush must not propagate.
+
+        Failure mode: a fragile status-bar implementation that raises on a
+        message containing certain characters could bring down the whole
+        MainWindow construction path. The setter's try/except keeps the
+        startup robust.
+        """
+        svc = ImageService.__new__(ImageService)
+        svc._status_reporter = None
+        svc._pending_status_msg = "ignored"
+
+        def boom(_msg):
+            raise RuntimeError("status bar exploded")
+
+        svc.set_status_reporter(boom)  # must not raise
+        assert svc._pending_status_msg is None, (
+            "Pending msg cleared even on reporter exception "
+            "(prevents repeated retries)"
+        )
+
+    def test_build_rebuilding_cache_message_uses_translator_when_available(
+        self, tmp_path
+    ):
+        """When ``infrastructure.i18n.t`` resolves the key, the translated
+        string wins. Confirms the i18n path is wired.
+
+        Failure mode: a regression where ``_build_rebuilding_cache_message``
+        ignored the translator would leave Chinese users seeing English on
+        a translated cache-rebuild flow.
+        """
+        svc = ImageService.__new__(ImageService)
+        with patch(
+            "infrastructure.i18n.t",
+            return_value="TRANSLATED-CACHE-MSG",
+        ):
+            msg = svc._build_rebuilding_cache_message()
+        assert msg == "TRANSLATED-CACHE-MSG"
+
+    def test_build_rebuilding_cache_message_falls_back_on_catalog_miss(
+        self, tmp_path
+    ):
+        """When the translator returns the bare key (catalog miss), the
+        fallback English string is returned instead.
+
+        Failure mode: an English-locale user seeing the literal dotted key
+        "preview.rebuilding_cache" in the status bar instead of a sentence —
+        the canonical translator-miss UX bug class.
+        """
+        svc = ImageService.__new__(ImageService)
+        with patch(
+            "infrastructure.i18n.t",
+            return_value="preview.rebuilding_cache",
+        ):
+            msg = svc._build_rebuilding_cache_message()
+        assert "Rebuilding thumbnail cache" in msg
+        assert PREVIEW_RECIPE_VERSION in msg

--- a/tests/test_image_tasks.py
+++ b/tests/test_image_tasks.py
@@ -271,3 +271,142 @@ class TestRequestGridThumbnail:
         task = runner._pool.start.call_args.args[0]
         assert task._is_preview is False
         assert task._side == 128
+
+
+# ── _ResolutionTask + request_resolution (#622 Phase 1) ──────────────────
+
+
+class TestResolutionTask:
+    """The off-thread resolution read dispatch.
+
+    Replaces the synchronous ``_read_resolution(path)`` call in
+    ``PreviewPane.show_single`` (which blocked the UI thread on NAS DNG
+    rawpy reads for 3-5 s) with a QRunnable-dispatched async path.
+    """
+
+    def test_emits_resolution_loaded_with_resolved_string(self):
+        """Happy path: ``_read_resolution`` returns "4000×3000" → receiver
+        gets ``resolutionLoaded.emit(path, "4000×3000")``.
+
+        Failure mode: an emit-with-None or shape-changed payload would
+        break the slot's unpacking, leaving the info label permanently
+        without a resolution row even when the read succeeded.
+        """
+        from unittest.mock import patch as _patch
+
+        from app.views.image_tasks import _ResolutionTask
+
+        receiver = MagicMock()
+        task = _ResolutionTask(path="/photos/raw.dng", receiver=receiver)
+
+        with _patch("app.views.preview_pane._read_resolution", return_value="4000×3000"), \
+             _patch("app.views.media_utils.normalize_windows_path", side_effect=lambda p: p):
+            task.run()
+
+        receiver.resolutionLoaded.emit.assert_called_once_with(
+            "/photos/raw.dng", "4000×3000"
+        )
+
+    def test_emits_empty_string_on_read_failure(self):
+        """Read failure (None return) → emit empty string, not None.
+
+        Failure mode: emitting None would surface as a Qt signal-arg type
+        error (Signal(str, str) rejects None), suppressing the slot call
+        entirely instead of letting it cleanly no-op.
+        """
+        from unittest.mock import patch as _patch
+
+        from app.views.image_tasks import _ResolutionTask
+
+        receiver = MagicMock()
+        task = _ResolutionTask(path="/photos/corrupt.jpg", receiver=receiver)
+
+        with _patch("app.views.preview_pane._read_resolution", return_value=None), \
+             _patch("app.views.media_utils.normalize_windows_path", side_effect=lambda p: p):
+            task.run()
+
+        receiver.resolutionLoaded.emit.assert_called_once_with(
+            "/photos/corrupt.jpg", ""
+        )
+
+    def test_swallows_read_exception_and_emits_empty(self):
+        """An exception during the read (e.g. PIL choke on a truncated TIFF)
+        is logged but does not propagate; the slot still gets an empty string.
+
+        Failure mode: a raise would crash the QThreadPool worker thread,
+        leaving the runner pool in an undefined state — and the info label
+        would never update from "loading" because the slot is never called.
+        """
+        from unittest.mock import patch as _patch
+
+        from app.views.image_tasks import _ResolutionTask
+
+        receiver = MagicMock()
+        task = _ResolutionTask(path="/bad.jpg", receiver=receiver)
+
+        with _patch(
+            "app.views.preview_pane._read_resolution",
+            side_effect=RuntimeError("PIL.UnidentifiedImageError"),
+        ), _patch("app.views.media_utils.normalize_windows_path", side_effect=lambda p: p):
+            task.run()  # must not raise
+
+        receiver.resolutionLoaded.emit.assert_called_once_with("/bad.jpg", "")
+
+
+class TestRequestResolution:
+    """ImageTaskRunner.request_resolution — dispatch + receiver-absent guard."""
+
+    def test_no_receiver_is_silent_no_op(self):
+        """Constructed runner has no resolution receiver until ``set_resolution_receiver``
+        is called. Calling ``request_resolution`` before then must be a silent
+        no-op.
+
+        Failure mode: a missing guard would raise AttributeError on every
+        early-init preview, breaking the show_single path during the brief
+        window before PreviewPane self-registers.
+        """
+        runner = ImageTaskRunner(service=MagicMock(), receiver=MagicMock())
+        runner._pool = MagicMock()
+
+        runner.request_resolution("/a.jpg")
+
+        runner._pool.start.assert_not_called()
+
+    def test_dispatches_resolution_task_when_receiver_set(self):
+        """Happy path: receiver registered → task created and started.
+
+        Verifies the task is a ``_ResolutionTask`` with the correct path
+        and receiver — not the path-unrelated dispatch shape from
+        ``_ImageTask``.
+        """
+        from app.views.image_tasks import _ResolutionTask
+
+        recv = MagicMock()
+        runner = ImageTaskRunner(service=MagicMock(), receiver=MagicMock())
+        runner._pool = MagicMock()
+        runner.set_resolution_receiver(recv)
+
+        runner.request_resolution("/photos/x.dng")
+
+        runner._pool.start.assert_called_once()
+        task = runner._pool.start.call_args.args[0]
+        assert isinstance(task, _ResolutionTask)
+        assert task._path == "/photos/x.dng"
+        assert task._receiver is recv
+
+    def test_set_resolution_receiver_idempotent_last_wins(self):
+        """Repeated set_resolution_receiver calls overwrite — last wins.
+
+        Failure mode: the runner is a singleton-per-MainWindow, but the
+        PreviewPane may be rebuilt on a live-language switch (see #520).
+        A first-wins setter would leak the old receiver and never deliver
+        resolutions to the new pane.
+        """
+        runner = ImageTaskRunner(service=MagicMock(), receiver=MagicMock())
+        first = MagicMock()
+        second = MagicMock()
+
+        runner.set_resolution_receiver(first)
+        runner.set_resolution_receiver(second)
+
+        assert runner._resolution_receiver is second

--- a/tests/test_main_window.py
+++ b/tests/test_main_window.py
@@ -1698,3 +1698,61 @@ class _FakeApp:
 
     def quit(self) -> None:
         self._log.append(1)
+
+
+# ── on_open_full_res_viewer (#622 Phase 1) ───────────────────────────────
+
+
+def test_on_open_full_res_viewer_constructs_dialog_with_di_service_and_shows():
+    """``on_open_full_res_viewer(path)`` must construct ``FullResViewerDialog``
+    with ``path``, ``parent=self``, AND ``service=self._img`` — then call
+    ``dlg.show()`` so the modal actually appears.
+
+    Failure modes pinned here:
+    1. A refactor that drops ``service=self._img`` silently regresses to the
+       pre-Phase-1 behaviour where the dialog built its own bare ImageService
+       each open — re-running ``_migrate_legacy_disk_cache``, missing the
+       warm in-memory LRU, and triggering a fresh disk-cache probe pass.
+    2. A refactor that drops ``dlg.show()`` makes the dialog construct and
+       immediately get GC'd — user double-clicks and nothing visible happens.
+    """
+    instances = []
+
+    class FakeDialog:
+        def __init__(self, path, parent=None, *, service=None):
+            self.path = path
+            self.parent_arg = parent
+            self.service = service
+            self.shown = False
+            instances.append(self)
+
+        def show(self):
+            self.shown = True
+
+    sentinel_service = object()
+    fake_self = SimpleNamespace(_img=sentinel_service)
+
+    # The method does a local import — patch the module-level symbol that
+    # gets bound by the ``from app.views.dialogs.full_res_viewer import
+    # FullResViewerDialog`` inside on_open_full_res_viewer.
+    import app.views.dialogs.full_res_viewer as fvm
+
+    original = fvm.FullResViewerDialog
+    fvm.FullResViewerDialog = FakeDialog
+    try:
+        MainWindow.on_open_full_res_viewer(fake_self, "/photos/a.dng")
+    finally:
+        fvm.FullResViewerDialog = original
+
+    assert len(instances) == 1, "FullResViewerDialog must be constructed exactly once"
+    dlg = instances[0]
+    assert dlg.path == "/photos/a.dng"
+    assert dlg.parent_arg is fake_self
+    assert dlg.service is sentinel_service, (
+        "service kwarg must be ``self._img`` so the dialog reuses the "
+        "app-level ImageService instead of constructing a bare one"
+    )
+    assert dlg.shown is True, (
+        "dlg.show() must be called after construction or the dialog never "
+        "becomes visible — the user double-clicks and nothing happens"
+    )

--- a/tests/test_preview_pane.py
+++ b/tests/test_preview_pane.py
@@ -876,3 +876,189 @@ def test_show_single_video_does_not_auto_play(qapp):
         pass
     finally:
         pane.deleteLater()
+
+
+# ── async resolution slot + stale-path guard (#622 Phase 1) ──────────────
+
+
+class TestResolutionLoadedSlot:
+    """The async resolution delivery path replaces the sync ``_read_resolution``
+    call on the UI thread inside ``show_single``. These tests pin the
+    receive-side semantics: stale-path guard, matching-path label update,
+    and the cleared-payload guard.
+
+    Real failure mode the slot exists to prevent: a slow NAS DNG read
+    completes AFTER the user has navigated to a different file, and the
+    stale "4000×3000" splashes onto the now-different info label — a
+    visible bug that's hard to reproduce except on a real NAS.
+    """
+
+    def test_matching_path_updates_info_label_with_resolution(self, qapp):
+        """Path matches the currently-shown single view → info label is
+        rebuilt with the resolution row.
+
+        Failure mode: a slot that always discards (broken guard, wrong attr)
+        means resolution never arrives — info label silently lacks the row
+        for every image.
+        """
+        fake_runner = MagicMock()
+        fake_runner.request_single_preview.return_value = "single|/photos/x.jpg|2048"
+        pane = PreviewPane(parent=None, task_runner=fake_runner)
+        try:
+            pane.show_single(
+                "/photos/x.jpg",
+                info={"name": "x.jpg", "folder": "/photos", "size": "12345"},
+            )
+            # Pre-condition: info label visible, no resolution yet
+            html_before = pane._single_info_label.text()
+            assert "4000" not in html_before
+            assert "3000" not in html_before
+
+            pane._on_resolution_loaded("/photos/x.jpg", "4000×3000")
+
+            html_after = pane._single_info_label.text()
+            assert "4000" in html_after and "3000" in html_after, (
+                f"Resolution row missing after _on_resolution_loaded; got: {html_after!r}"
+            )
+        finally:
+            pane.deleteLater()
+
+    def test_stale_path_does_not_update_label(self, qapp):
+        """Path mismatch (user navigated away) → label stays unchanged.
+
+        Failure mode: without the guard, a 5-second NAS DNG resolution read
+        could splash the old file's "W×H" onto a now-different label —
+        the user sees /photos/B.jpg with /photos/A.dng's dimensions.
+        """
+        fake_runner = MagicMock()
+        fake_runner.request_single_preview.return_value = "single|/photos/A.jpg|2048"
+        pane = PreviewPane(parent=None, task_runner=fake_runner)
+        try:
+            pane.show_single(
+                "/photos/A.jpg",
+                info={"name": "A.jpg", "folder": "/photos", "size": "1"},
+            )
+            # User navigates to a different file
+            fake_runner.request_single_preview.return_value = "single|/photos/B.jpg|2048"
+            pane.show_single(
+                "/photos/B.jpg",
+                info={"name": "B.jpg", "folder": "/photos", "size": "2"},
+            )
+            html_before = pane._single_info_label.text()
+
+            # Stale resolution for the OLD file arrives now
+            pane._on_resolution_loaded("/photos/A.jpg", "9999×7777")
+
+            html_after = pane._single_info_label.text()
+            assert "9999" not in html_after, (
+                "Stale resolution for the navigated-away file must not surface "
+                f"on the new file's label; got: {html_after!r}"
+            )
+            assert html_after == html_before, (
+                "Label must remain exactly unchanged when stale resolution arrives"
+            )
+        finally:
+            pane.deleteLater()
+
+    def test_cleared_payload_guards_against_post_clear_arrival(self, qapp):
+        """After ``clear()`` runs, a late resolution arrival must NOT touch
+        the (cleared) info label.
+
+        Failure mode: a slot that only checks the path attr would still
+        match (path is set then cleared to None — but None != '/photos/x.jpg',
+        so the path guard catches it). This test pins the payload guard as
+        belt-and-braces against future refactors where ``clear()`` zeroes
+        the payload before the path or the payload is reset out-of-order.
+        """
+        fake_runner = MagicMock()
+        fake_runner.request_single_preview.return_value = "single|/photos/x.jpg|2048"
+        pane = PreviewPane(parent=None, task_runner=fake_runner)
+        try:
+            pane.show_single(
+                "/photos/x.jpg",
+                info={"name": "x.jpg", "folder": "/photos", "size": "1"},
+            )
+            pane.clear()
+            # Path is now None; payload is None — neither matches.
+
+            pane._on_resolution_loaded("/photos/x.jpg", "1×1")
+
+            # _single_info_label was cleared by clear() — must remain empty.
+            assert pane._single_info_label.text() == "", (
+                "Cleared info label must not be revived by a late resolution"
+            )
+            assert pane._single_info_label.isVisible() is False, (
+                "Cleared info label must not become visible from a late resolution"
+            )
+        finally:
+            pane.deleteLater()
+
+
+class TestShowSingleAsyncResolution:
+    """``show_single`` no longer reads the resolution synchronously — it
+    submits a ``_ResolutionTask`` via the runner. This test class pins the
+    dispatch contract."""
+
+    def test_show_single_image_submits_resolution_task(self, qapp):
+        """Image branch must call ``runner.request_resolution(path)`` so the
+        info label can be filled in once the off-thread read completes.
+
+        Failure mode: a refactor that reverted to the sync ``_read_resolution``
+        call would re-block the UI thread for 3-5 s on NAS DNG previews — the
+        very behaviour #622 Phase 1 item 6 is closing.
+        """
+        fake_runner = MagicMock()
+        fake_runner.request_single_preview.return_value = "single|/photos/x.jpg|2048"
+        pane = PreviewPane(parent=None, task_runner=fake_runner)
+        try:
+            pane.show_single(
+                "/photos/x.jpg",
+                info={"name": "x.jpg", "folder": "/photos", "size": "1"},
+            )
+            fake_runner.request_resolution.assert_called_once_with("/photos/x.jpg")
+        finally:
+            pane.deleteLater()
+
+    def test_show_single_image_initial_label_has_no_resolution_row(self, qapp):
+        """The initial sync render (before the resolution task returns)
+        must NOT include any "W×H" — only the basic info rows.
+
+        Failure mode: a refactor that re-introduced a sync ``_read_resolution``
+        before dispatch would block the UI thread; this test would fail by
+        producing a resolution string at sync-render time.
+        """
+        fake_runner = MagicMock()
+        fake_runner.request_single_preview.return_value = "single|/photos/x.jpg|2048"
+        pane = PreviewPane(parent=None, task_runner=fake_runner)
+        try:
+            pane.show_single(
+                "/photos/x.jpg",
+                info={"name": "x.jpg", "folder": "/photos", "size": "1"},
+            )
+            html = pane._single_info_label.text()
+            # No resolution numbers in the initial render (regardless of
+            # the underlying file's true dimensions).
+            assert "×" not in html or pane._single_info_payload is not None, (
+                "Initial info label must not contain a resolution row "
+                f"before the async read completes; got: {html!r}"
+            )
+            assert pane._single_info_payload is not None
+            assert pane._single_info_payload[0] == "/photos/x.jpg"
+        finally:
+            pane.deleteLater()
+
+    def test_runner_registers_as_resolution_receiver(self, qapp):
+        """PreviewPane constructor calls ``runner.set_resolution_receiver(self)``
+        so the runner knows where to deliver ``_ResolutionTask`` results.
+
+        Failure mode: a refactor that dropped the registration would
+        silently route resolution results into the void — info labels
+        permanently without resolution rows even though the task path
+        works end-to-end on the runner side.
+        """
+        fake_runner = MagicMock()
+        pane = PreviewPane(parent=None, task_runner=fake_runner)
+        try:
+            fake_runner.set_resolution_receiver.assert_called_once_with(pane)
+        finally:
+            pane.deleteLater()

--- a/translations/en.yml
+++ b/translations/en.yml
@@ -469,3 +469,4 @@ preview:
   info_duration_unknown: "--:--"
   click_to_pause: "(Click to pause)"
   video_not_available: "(Video not available)"
+  rebuilding_cache: "Rebuilding thumbnail cache (version {version}) — this is a one-time operation."

--- a/translations/zh_TW.yml
+++ b/translations/zh_TW.yml
@@ -378,3 +378,4 @@ preview:
   info_duration_unknown: "--:--"
   click_to_pause: "(點擊暫停)"
   video_not_available: "(無法使用視訊)"
+  rebuilding_cache: "正在重建縮圖快取(版本 {version})— 這是一次性操作。"


### PR DESCRIPTION
## What

Closes the Phase 1 wiring loose ends after the headline #622 items
(byte-budget LRU, embedded JPEG, viewport cap, FullResViewerDialog,
autoplay kill, recipe-version token) had already landed via background
PRs. Four wiring gaps remained:

1. **`_read_resolution` blocked the UI thread for DNG previews** — the
   single-view info row's resolution probe ran on the GUI thread inside
   `show_single()`, costing 3–5 s on NAS DNGs before any pixel painted
   (#622 ticket item 6).
2. **The "rebuilding thumbnail cache" status notice was silently
   swallowed** — `main.py` constructed `ImageService` BEFORE
   `MainWindow.StatusReporterImpl` existed, so the wipe-on-upgrade
   message went to logger-only. The notice was documented in
   `docs/features.md` already but hadn't actually fired.
3. **`FullResViewerDialog` built a second bare `ImageService()` every
   open** — re-running `_migrate_legacy_disk_cache`, bypassing the warm
   in-memory LRU, and re-running the disk-cache probe each double-click.
4. **Migration message was hardcoded English** — `translations/en.yml`
   + `zh_TW.yml` had no `preview.rebuilding_cache` key.

Plus s68: end-to-end qa scenario that drives a real `WM_LBUTTONDBLCLK`
into the preview label and asserts the modal viewer window appears
with `<filename> [W×H]` in title.

## Why

1. (Async resolution) #622 Phase 1 mandates moving the sync
   `_read_resolution` off the UI thread to fix the visible NAS DNG
   stutter. Token-mismatch stale-path guard mirrors `on_image_loaded`'s
   existing pattern.
2. (Status notice) `docs/features.md` already promises the notice will
   appear on first launch after upgrade. Production wiring made that
   promise a lie — the notice was reaching only the rotating log file.
   `set_status_reporter()` + a `_pending_status_msg` queue bridge the
   `main.py` ↔ `MainWindow` construction-order gap so the message
   surfaces synchronously when the reporter is attached.
3. (DI) Reusing the app-level `ImageService` per double-click means no
   redundant migration scan + warm-LRU reuse for the synchronous
   full-res decode.
4. (i18n) Migration is a user-visible status surface; English-only
   defeats the whole catalog discipline.

## How

- `infrastructure/image_service.py` — `set_status_reporter()` public
  setter; pending-message queue; `_build_rebuilding_cache_message()`
  with `t()` lookup + try/except fallback for catalog miss /
  pre-`init_translator` paths.
- `app/views/main_window.py` — `_setup_components` wires the reporter
  via a lambda that calls `status_reporter.show_status(msg,
  timeout=8000)`; `on_open_full_res_viewer` passes `service=self._img`.
- `app/views/image_tasks.py` — new `_ResolutionTask(QRunnable)` that
  off-threads `_read_resolution`; `ImageTaskRunner.set_resolution_receiver`
  + `request_resolution` plumbing.
- `app/views/preview_pane.py` — `resolutionLoaded(str, str)` signal +
  `_on_resolution_loaded` slot with stale-path guard; self-registers
  with the runner in `__init__`; `setObjectName("preview_single_label")`
  for s68's UIA discovery.
- `app/views/dialogs/full_res_viewer.py` — optional `service=` kwarg;
  falls back to constructing a bare instance when None (backward
  compatibility for existing tests).
- `translations/{en,zh_TW}.yml` — new `preview.rebuilding_cache` key
  with `{version}` interpolation.
- 13 new L1 tests across `tests/test_image_service.py`,
  `tests/test_image_tasks.py`, `tests/test_preview_pane.py`,
  `tests/test_dialogs/test_full_res_viewer.py`, `tests/test_main_window.py`
  covering pending-message flush, stale-path guard, DI fallback,
  on_open_full_res_viewer wiring, ResolutionTask happy/failure/exception.
- `qa/scenarios/s68_full_res_viewer_double_click.py` + registration in
  `_config.py` and `_batch.py` — uses Win32 `WM_LBUTTONDBLCLK`
  PostMessage (per s40's note that `click_input(double=True)` is
  unreliable for Qt's `mouseDoubleClickEvent`) and `near-duplicates`
  sandbox (singleton-only `huge` never renders as a TreeItem).
- `docs/features.md` — bumped "Last verified" on the two entries this
  PR affects (byte-budget LRU's status notice now actually fires;
  full-res viewer's DI wiring + s68 added to Related).

Full suite: 2231 passed, 3 skipped, 89.21% coverage; per-file 70%
floor clear. s68 passes locally (full-res title:
`neardup_00_q95.jpg  [640×480]`).

Refs #622
